### PR TITLE
Fix app indicator when using custom install prefix

### DIFF
--- a/remmina/src/remmina_icon.c
+++ b/remmina/src/remmina_icon.c
@@ -394,6 +394,7 @@ void remmina_icon_init(void)
 	{
 #ifdef HAVE_LIBAPPINDICATOR
 		remmina_icon.icon = app_indicator_new ("remmina-icon", "remmina", APP_INDICATOR_CATEGORY_OTHER);
+		app_indicator_set_icon_theme_path (remmina_icon.icon, REMMINA_DATADIR G_DIR_SEPARATOR_S "icons");
 
 		app_indicator_set_status (remmina_icon.icon, APP_INDICATOR_STATUS_ACTIVE);
 		remmina_icon_populate_menu ();


### PR DESCRIPTION
I'm not sure what the preferred method is for sending a patch to Remmina (in this case a 1 line patch), so let me know if there is another preferred method besides a pull request (e.g. emailing a patch).

When Remmina is installed to a custom location (e.g. when using
'cmake -DCMAKE_INSTALL_PREFIX=/opt/remmina') the app indicator applet in Unity doesn't display because it tries to load the icon from one of the standard icon theme locations (e.g. /usr/share/icons, etc). When it
doesn't find the Remmina icon, the app indicator is not displayed in the notification panel. With this commit, the app indicator is configured to look in the correct location for the icon. As a result, the app indicator properly loads into the notification panel.
