### PR TITLE
Fix for scrolling in Remmina

### DIFF
--- a/remmina-plugins/rdp/rdp_event.c
+++ b/remmina-plugins/rdp/rdp_event.c
@@ -369,18 +369,18 @@ static gboolean remmina_rdp_event_on_scroll(GtkWidget* widget, GdkEventScroll* e
 	rdp_event.type = REMMINA_RDP_EVENT_TYPE_MOUSE;
 
 	switch (event->direction)
+	if (event->direction == GDK_SCROLL_UP || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y < 0))
 	{
-		case GDK_SCROLL_UP:
-			flag = PTR_FLAGS_WHEEL | 0x0078;
-			break;
-
-		case GDK_SCROLL_DOWN:
-			flag = PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0088;
-			break;
-
-		default:
-			return FALSE;
+		flag = PTR_FLAGS_WHEEL | 0x0078;
 	}
+	if (event->direction == GDK_SCROLL_DOWN || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y > 0))
+	{
+		flag = PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0088;
+	}
+	if (!flags)
+	{
+		return FALSE;
+	}	
 
 	rdp_event.mouse_event.flags = flag;
 	remmina_rdp_event_translate_pos(gp, event->x, event->y, &rdp_event.mouse_event.x, &rdp_event.mouse_event.y);

--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -1426,6 +1426,16 @@ static gboolean remmina_plugin_vnc_on_scroll(GtkWidget *widget, GdkEventScroll *
 		case GDK_SCROLL_RIGHT:
 			mask = (1 << 6);
 			break;
+		case GDK_SCROLL_SMOOTH:
+			if (event->delta_y < 0)
+				mask = (1 << 3);
+			if (event->delta_y > 0)
+				mask = (1 << 4);
+			if (event->delta_x < 0)
+				mask = (1 << 5);
+			if (event->delta_x > 0)
+				mask = (1 << 6);
+			break;
 		default:
 			return FALSE;
 	}

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1459,26 +1459,23 @@ static gboolean remmina_connection_holder_toolbar_scroll(GtkWidget* widget, GdkE
 	int opacity;
 
 	opacity = remmina_file_get_int(cnnobj->remmina_file, "toolbar_opacity", 0);
-	switch (event->direction)
+	if (event->direction == GDK_SCROLL_UP || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y < 0))
 	{
-		case GDK_SCROLL_UP:
-			if (opacity > 0)
-			{
-				remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity - 1);
-				remmina_connection_holder_update_toolbar_opacity(cnnhld);
-				return TRUE;
-			}
-			break;
-		case GDK_SCROLL_DOWN:
-			if (opacity < TOOLBAR_OPACITY_LEVEL)
-			{
-				remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity + 1);
-				remmina_connection_holder_update_toolbar_opacity(cnnhld);
-				return TRUE;
-			}
-			break;
-		default:
-			break;
+		if (opacity > 0)
+		{
+			remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity - 1);
+			remmina_connection_holder_update_toolbar_opacity(cnnhld);
+	    		return TRUE;
+		}
+	}
+	if (event->direction == GDK_SCROLL_DOWN || (event->direction == GDK_SCROLL_SMOOTH && event->delta_y > 0))
+	{
+		if (opacity < TOOLBAR_OPACITY_LEVEL)
+		{
+			remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity + 1);
+			remmina_connection_holder_update_toolbar_opacity(cnnhld);
+			return TRUE;
+		}
 	}
 	return FALSE;
 }


### PR DESCRIPTION
GDK_SCROLL_SMOOTH got added in GDK.
This needs to be handled also to re-enable the scrolling in Remmina.
