### PR TITLE
Fix for scrolling in Remmina

### DIFF
--- a/remmina-plugins/rdp/rdp_event.c
+++ b/remmina-plugins/rdp/rdp_event.c
@@ -377,6 +377,15 @@ static gboolean remmina_rdp_event_on_scroll(GtkWidget* widget, GdkEventScroll* e
 		case GDK_SCROLL_DOWN:
 			flag = PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0088;
 			break;
+		
+		case GDK_SCROLL_SMOOTH:
+			if (event->delta_y < 0)
+				flag = PTR_FLAGS_WHEEL | 0x0078;
+			if (event->delta_y > 0)
+				flag = PTR_FLAGS_WHEEL | PTR_FLAGS_WHEEL_NEGATIVE | 0x0088;
+			if (!flag)
+				return FALSE;
+			break;
 
 		default:
 			return FALSE;

--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -1426,6 +1426,18 @@ static gboolean remmina_plugin_vnc_on_scroll(GtkWidget *widget, GdkEventScroll *
 		case GDK_SCROLL_RIGHT:
 			mask = (1 << 6);
 			break;
+		case GDK_SCROLL_SMOOTH:
+			if (event->delta_y < 0)
+				mask = (1 << 3);
+			if (event->delta_y > 0)
+				mask = (1 << 4);
+			if (event->delta_x < 0)
+				mask = (1 << 5);
+			if (event->delta_x > 0)
+				mask = (1 << 6);
+			if (!mask)
+				return FALSE;
+			break;
 		default:
 			return FALSE;
 	}

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1477,6 +1477,20 @@ static gboolean remmina_connection_holder_toolbar_scroll(GtkWidget* widget, GdkE
 				return TRUE;
 			}
 			break;
+		case GDK_SCROLL_SMOOTH:
+			if (event->delta_y < 0 && opacity > 0)
+                        {
+                                remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity - 1);
+                                remmina_connection_holder_update_toolbar_opacity(cnnhld);
+                                return TRUE;
+                        }
+			if (event->delta_y > 0 && opacity < TOOLBAR_OPACITY_LEVEL)
+                        {
+                                remmina_file_set_int(cnnobj->remmina_file, "toolbar_opacity", opacity + 1);
+                                remmina_connection_holder_update_toolbar_opacity(cnnhld);
+                                return TRUE;
+                        }
+                        break;
 		default:
 			break;
 	}


### PR DESCRIPTION
Fixes scrolling in Remmina. Caused by GDK_SCROLL_SMOOTH that is not implemented yet.
