### PR TITLE
DWORD is the replacement for RDP_SCANCODE

### DIFF
--- a/remmina-plugins/rdp/rdp_event.c
+++ b/remmina-plugins/rdp/rdp_event.c
@@ -431,7 +431,7 @@ static gboolean remmina_rdp_event_on_key(GtkWidget* widget, GdkEventKey* event, 
 	guint16 cooked_keycode;
 	rfContext* rfi;
 	RemminaPluginRdpEvent rdp_event;
-	RDP_SCANCODE scancode;
+	DWORD scancode;
 
 	rfi = GET_DATA(gp);
 	rdp_event.type = REMMINA_RDP_EVENT_TYPE_SCANCODE;


### PR DESCRIPTION
As seen in [75f80d01](https://github.com/FreeRDP/FreeRDP/commit/75f80d019892fdef224ef530055c2ba52c99e58b), RDP_SCANCODE has been replaced by DWORD.
