### PR TITLE
Remove call to rfx_context_set_cpu_opt, which was removed from FreeRDP

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -237,7 +237,6 @@ static BOOL remmina_rdp_pre_connect(freerdp* instance)
 		settings->PerformanceFlags = PERF_FLAG_NONE;
 
 		rfi->rfx_context = rfx_context_new();
-		rfx_context_set_cpu_opt(rfi->rfx_context, CPU_SSE2);
 	}
 
 	freerdp_channels_pre_connect(rfi->channels, instance);


### PR DESCRIPTION
I don't fully understand the code here, but based on the commits in FreeRDP, I think this call can simply be removed.

In any case, something needs to change because the function is no longer defined in the FreeRDP source.
