### PR TITLE
make gettext behave correctly

### DIFF
--- a/cmake/GETTEXT.cmake
+++ b/cmake/GETTEXT.cmake
@@ -20,14 +20,19 @@
 find_suggested_package(Gettext)
 
 function(gettext po_dir package_name)
+	# check if LINGUAS env var is unset
+	execute_process(COMMAND sh -c "echo -n \${LINGUAS+x}"
+		OUTPUT_VARIABLE UNSETLINGUAS)
 	set(mo_files)
 	file(GLOB po_files ${po_dir}/*.po)
 	foreach(po_file ${po_files})
 		get_filename_component(lang ${po_file} NAME_WE)
-		set(mo_file ${CMAKE_CURRENT_BINARY_DIR}/${lang}.mo)
-		add_custom_command(OUTPUT ${mo_file} COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${mo_file} ${po_file} DEPENDS ${po_file})
-		install(FILES ${mo_file} DESTINATION share/locale/${lang}/LC_MESSAGES RENAME ${package_name}.mo)
-		set(mo_files ${mo_files} ${mo_file})
+		if($ENV{LINGUAS} MATCHES "^.*${lang}.*$" OR "${UNSETLINGUAS}" STREQUAL "")
+			set(mo_file ${CMAKE_CURRENT_BINARY_DIR}/${lang}.mo)
+			add_custom_command(OUTPUT ${mo_file} COMMAND ${GETTEXT_MSGFMT_EXECUTABLE} -o ${mo_file} ${po_file} DEPENDS ${po_file})
+			install(FILES ${mo_file} DESTINATION share/locale/${lang}/LC_MESSAGES RENAME ${package_name}.mo)
+			set(mo_files ${mo_files} ${mo_file})
+		endif()
 	endforeach()
 	set(translations-target "${package_name}-translations")
 	add_custom_target(${translations-target} ALL DEPENDS ${mo_files})


### PR DESCRIPTION
desired behavior is:
LINGUAS unset => install all
LINGUAS="" => install none
LINGUAS="en de" => install en and de

I can't find a cmake internal way to check for unset (_not_ empty) variables, so I use the shell. I tested all usecases.