### PR TITLE
rename context_size to ContextSize to match changes in FreeRDP

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -826,7 +826,7 @@ static void remmina_rdp_init(RemminaProtocolWidget* gp)
 	instance->VerifyChangedCertificate = remmina_rdp_verify_changed_certificate;
 	instance->ReceiveChannelData = remmina_rdp_receive_channel_data;
 
-	instance->context_size = sizeof(rfContext);
+	instance->ContextSize = sizeof(rfContext);
 	freerdp_context_new(instance);
 	rfi = (rfContext*) instance->context;
 


### PR DESCRIPTION
FreeRDP commit 208c9f844ad9d84333be474debc2a5282e9c4ad5 renames context_size to ContextSize in include/freerdp/freerdp.h, this breaks the build of the remmina rdp plugin at:

remmina-plugins/rdp/rdp_plugin.c:829:10: error: 'freerdp' has no member named 'context_size'

Downstream bug report with full build log and patch here:
https://bugs.gentoo.org/show_bug.cgi?id=476950
