### PR TITLE
Update for changes in FreeRDP master's rfx_context_new()

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -236,7 +236,7 @@ static BOOL remmina_rdp_pre_connect(freerdp* instance)
 		settings->LargePointerFlag = True;
 		settings->PerformanceFlags = PERF_FLAG_NONE;
 
-		rfi->rfx_context = rfx_context_new();
+		rfi->rfx_context = rfx_context_new(FALSE);
 	}
 
 	freerdp_channels_pre_connect(rfi->channels, instance);


### PR DESCRIPTION
FreeRDP's rfx_context_new now takes an argument, update Remmina's
rdp_plugin.c for this change.

Without this fix, Remmina fails to build against FreeRDP master with the following error:

remmina-plugins/rdp/rdp_plugin.c: In function 'remmina_rdp_pre_connect':
remmina-plugins/rdp/rdp_plugin.c:239:3: error: too few arguments to function 'rfx_context_new'
