### PR TITLE
Help GNOME SHELL to not hide the floating toolbar

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1759,7 +1759,7 @@ static void remmina_connection_holder_create_floating_toolbar(RemminaConnectionH
 	priv->floating_toolbar_label = widget;
 
 	/* The position will be moved in configure event instead during maximizing. Just make it invisible here */
-	gtk_window_move(GTK_WINDOW(window), 0, -200);
+	gtk_window_move(GTK_WINDOW(window), 0, 6000);
 	gtk_window_set_accept_focus(GTK_WINDOW(window), FALSE);
 
 	priv->floating_toolbar = window;


### PR DESCRIPTION
Remmina creates the floating toolbar (a popup window) at position y=-200
to have it hidden. But Gnome Shell sometimes is unable to show it.
Creating it at position y=6000 seems to help a little bit
gnome shell not to hide it.
