### PR TITLE
Fix debian bug 764142

### DIFF
--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -149,7 +149,7 @@ static void remmina_plugin_manager_load_plugin(const gchar *name)
 	GModule *module;
 	RemminaPluginEntryFunc entry;
 
-	module = g_module_open(name, G_MODULE_BIND_LAZY | G_MODULE_BIND_LOCAL);
+	module = g_module_open(name, G_MODULE_BIND_LAZY);
 
 	if (!module)
 	{


### PR DESCRIPTION
When FreeRDP is compiled with -DSTATIC_CHANNELS=off and
RDP local sound is enable in Remmina, Remmina will crash
upon RDP connection with the error
/usr/lib/x86_64-linux-gnu/freerdp/rdpsnd-client-pulse.so: undefined symbol:
freerdp_dsp_context_new
This is the fix.
