### PR TITLE
Check for permit store password

### DIFF
--- a/remmina-plugins/nx/nx_plugin.c
+++ b/remmina-plugins/nx/nx_plugin.c
@@ -278,7 +278,7 @@ static gboolean remmina_plugin_nx_start_session(RemminaProtocolWidget *gp)
 		g_free(s1);
 		g_free(s2);
 
-		THREADS_ENTER ret = remmina_plugin_nx_service->protocol_plugin_init_authuserpwd(gp, FALSE);
+		THREADS_ENTER ret = remmina_plugin_nx_service->protocol_plugin_init_authuserpwd(gp, FALSE, TRUE);
 		THREADS_LEAVE
 
 		if (ret != GTK_RESPONSE_OK)

--- a/remmina-plugins/nx/nx_plugin.c
+++ b/remmina-plugins/nx/nx_plugin.c
@@ -278,7 +278,7 @@ static gboolean remmina_plugin_nx_start_session(RemminaProtocolWidget *gp)
 		g_free(s1);
 		g_free(s2);
 
-		THREADS_ENTER ret = remmina_plugin_nx_service->protocol_plugin_init_authuserpwd(gp, FALSE, TRUE);
+		THREADS_ENTER ret = remmina_plugin_nx_service->protocol_plugin_init_authuserpwd(gp, FALSE, FALSE);
 		THREADS_LEAVE
 
 		if (ret != GTK_RESPONSE_OK)

--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -1107,7 +1107,7 @@ static const RemminaProtocolSetting remmina_rdp_advanced_settings[] =
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "sharesmartcard", N_("Share smartcard"), TRUE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableclipboard", N_("Disable clipboard sync"), FALSE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "console", N_("Attach to console (Windows 2003 / 2003 R2)"), FALSE, NULL, NULL },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "storepassword", N_("Permit store password"), FALSE, NULL, NULL },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "storepassword", N_("Disable password storing"), FALSE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_END, NULL, NULL, FALSE, NULL, NULL }
 };
 

--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -356,14 +356,15 @@ static BOOL remmina_rdp_authenticate(freerdp* instance, char** username, char** 
 	rfContext* rfi;
 	RemminaProtocolWidget* gp;
 	gboolean save;
+	gboolean s_storepassword;
 	RemminaFile* remminafile;
 
 	rfi = (rfContext*) instance->context;
 	gp = rfi->protocol_widget;
 	remminafile = remmina_plugin_service->protocol_plugin_get_file(gp);
-
+	s_storepassword = remmina_plugin_service->file_get_int(remminafile, "storepassword", FALSE);
 	THREADS_ENTER
-	ret = remmina_plugin_service->protocol_plugin_init_authuserpwd(gp, TRUE);
+	ret = remmina_plugin_service->protocol_plugin_init_authuserpwd(gp, TRUE, s_storepassword);
 	THREADS_LEAVE
 
 	if (ret == GTK_RESPONSE_OK)
@@ -1106,6 +1107,7 @@ static const RemminaProtocolSetting remmina_rdp_advanced_settings[] =
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "sharesmartcard", N_("Share smartcard"), TRUE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableclipboard", N_("Disable clipboard sync"), FALSE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "console", N_("Attach to console (Windows 2003 / 2003 R2)"), FALSE, NULL, NULL },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "storepassword", N_("Permit store password"), FALSE, NULL, NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_END, NULL, NULL, FALSE, NULL, NULL }
 };
 

--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -881,7 +881,7 @@ remmina_plugin_vnc_rfb_credential (rfbClient *cl, int credentialType)
 			g_free(s2);
 
 			THREADS_ENTER
-			ret = remmina_plugin_service->protocol_plugin_init_authuserpwd (gp, FALSE, TRUE);
+			ret = remmina_plugin_service->protocol_plugin_init_authuserpwd (gp, FALSE, FALSE);
 			THREADS_LEAVE
 
 			if (ret == GTK_RESPONSE_OK)

--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -881,7 +881,7 @@ remmina_plugin_vnc_rfb_credential (rfbClient *cl, int credentialType)
 			g_free(s2);
 
 			THREADS_ENTER
-			ret = remmina_plugin_service->protocol_plugin_init_authuserpwd (gp, FALSE);
+			ret = remmina_plugin_service->protocol_plugin_init_authuserpwd (gp, FALSE, TRUE);
 			THREADS_LEAVE
 
 			if (ret == GTK_RESPONSE_OK)

--- a/remmina/include/remmina/plugin.h
+++ b/remmina/include/remmina/plugin.h
@@ -169,7 +169,7 @@ typedef struct _RemminaPluginService
     void         (* protocol_plugin_set_display)          (RemminaProtocolWidget *gp, gint display);
     gboolean     (* protocol_plugin_close_connection)     (RemminaProtocolWidget *gp);
     gint         (* protocol_plugin_init_authpwd)         (RemminaProtocolWidget *gp, RemminaAuthpwdType authpwd_type);
-    gint         (* protocol_plugin_init_authuserpwd)     (RemminaProtocolWidget *gp, gboolean want_domain);
+    gint         (* protocol_plugin_init_authuserpwd)     (RemminaProtocolWidget *gp, gboolean want_domain, gboolean storepassword);
     gint         (* protocol_plugin_init_certificate)     (RemminaProtocolWidget *gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint);
     gint         (* protocol_plugin_changed_certificate)  (RemminaProtocolWidget *gp, const gchar* subject, const gchar* issuer, const gchar* new_fingerprint, const gchar* old_fingerprint);
     gchar*       (* protocol_plugin_init_get_username)    (RemminaProtocolWidget *gp);

--- a/remmina/po/en_AU.po
+++ b/remmina/po/en_AU.po
@@ -1381,8 +1381,8 @@ msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Attach to console (Windows 2003 / 2003 R2)"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1136
-msgid "Permit store password"
-msgstr "Permit store password"
+msgid "Disable password storing"
+msgstr "Disable password storing"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"

--- a/remmina/po/en_AU.po
+++ b/remmina/po/en_AU.po
@@ -1380,6 +1380,10 @@ msgstr ""
 msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Attach to console (Windows 2003 / 2003 R2)"
 
+#: remmina-plugins/rdp/rdp_plugin.c:1136
+msgid "Permit store password"
+msgstr "Permit store password"
+
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"
 msgstr "RDP - Remote Desktop Protocol"

--- a/remmina/po/en_GB.po
+++ b/remmina/po/en_GB.po
@@ -1381,8 +1381,8 @@ msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Attach to console (Windows 2003 / 2003 R2)"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1136
-msgid "Permit store password"
-msgstr "Permit store password"
+msgid "Disable password storing"
+msgstr "Disable password storing"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"

--- a/remmina/po/en_GB.po
+++ b/remmina/po/en_GB.po
@@ -1380,6 +1380,10 @@ msgstr ""
 msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Attach to console (Windows 2003 / 2003 R2)"
 
+#: remmina-plugins/rdp/rdp_plugin.c:1136
+msgid "Permit store password"
+msgstr "Permit store password"
+
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"
 msgstr "RDP - Remote Desktop Protocol"

--- a/remmina/po/es.po
+++ b/remmina/po/es.po
@@ -1389,8 +1389,8 @@ msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Anexar a consola (Windows 2003 / 2003 R2)"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1136
-msgid "Permit store password"
-msgstr "Permitir guardar contraseña"
+msgid "Disable password storing"
+msgstr "Deshabilitar guardar contraseña"
 
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"

--- a/remmina/po/es.po
+++ b/remmina/po/es.po
@@ -1388,6 +1388,10 @@ msgstr ""
 msgid "Attach to console (Windows 2003 / 2003 R2)"
 msgstr "Anexar a consola (Windows 2003 / 2003 R2)"
 
+#: remmina-plugins/rdp/rdp_plugin.c:1136
+msgid "Permit store password"
+msgstr "Permitir guardar contraseña"
+
 #: remmina-plugins/rdp/rdp_plugin.c:1151
 msgid "RDP - Remote Desktop Protocol"
 msgstr "RDP - Protocolo de escritorio remoto (Remote Desktop Protocol)"

--- a/remmina/src/remmina_init_dialog.c
+++ b/remmina/src/remmina_init_dialog.c
@@ -220,10 +220,10 @@ gint remmina_init_dialog_authpwd(RemminaInitDialog *dialog, const gchar *label, 
 	s = g_strdup_printf(_("Save %s"), label);
 	save_password_check = gtk_check_button_new_with_label(s);
 	g_free(s);
-	gtk_widget_show(save_password_check);
-	gtk_grid_attach(GTK_GRID(table), save_password_check, 0, 1, 2, 1);
 	if (allow_save)
 	{
+		gtk_widget_show(save_password_check);
+		gtk_grid_attach(GTK_GRID(table), save_password_check, 0, 1, 2, 1);
 		if (dialog->save_password)
 			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(save_password_check), TRUE);
 	}
@@ -326,10 +326,11 @@ gint remmina_init_dialog_authuserpwd(RemminaInitDialog *dialog, gboolean want_do
 	}
 
 	save_password_check = gtk_check_button_new_with_label(_("Save password"));
-	gtk_widget_show(save_password_check);
-	gtk_grid_attach(GTK_GRID(table), save_password_check, 0, 4, 2, 3);
+	
 	if (allow_save)
 	{
+		gtk_widget_show(save_password_check);
+		gtk_grid_attach(GTK_GRID(table), save_password_check, 0, 4, 2, 3);
 		if (dialog->save_password)
 			gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(save_password_check), TRUE);
 	}

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -835,7 +835,7 @@ gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolea
 	
 	return remmina_init_dialog_authuserpwd(REMMINA_INIT_DIALOG(gp->priv->init_dialog), want_domain,
 			remmina_file_get_string(remminafile, "username"),
-			want_domain ? remmina_file_get_string(remminafile, "domain") : NULL, (remmina_file_get_filename(remminafile) != NULL) && storepassword);
+			want_domain ? remmina_file_get_string(remminafile, "domain") : NULL, (remmina_file_get_filename(remminafile) != NULL) && (storepassword == FALSE));
 }
 
 gint remmina_protocol_widget_init_certificate(RemminaProtocolWidget* gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint)

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -829,14 +829,13 @@ gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget* gp, RemminaAuth
 	return ret;
 }
 
-gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolean want_domain)
+gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolean want_domain, gboolean storepassword)
 {
 	RemminaFile* remminafile = gp->priv->remmina_file;
 	
 	return remmina_init_dialog_authuserpwd(REMMINA_INIT_DIALOG(gp->priv->init_dialog), want_domain,
 			remmina_file_get_string(remminafile, "username"),
-			want_domain ? remmina_file_get_string(remminafile, "domain") : NULL,
-			(remmina_file_get_filename(remminafile) != NULL));
+			want_domain ? remmina_file_get_string(remminafile, "domain") : NULL, (remmina_file_get_filename(remminafile) != NULL) && storepassword);
 }
 
 gint remmina_protocol_widget_init_certificate(RemminaProtocolWidget* gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint)

--- a/remmina/src/remmina_protocol_widget.h
+++ b/remmina/src/remmina_protocol_widget.h
@@ -120,7 +120,7 @@ gboolean remmina_protocol_widget_start_xport_tunnel(RemminaProtocolWidget *gp, R
 void remmina_protocol_widget_set_display(RemminaProtocolWidget *gp, gint display);
 
 gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget *gp, RemminaAuthpwdType authpwd_type);
-gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget *gp, gboolean want_domain);
+gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget *gp, gboolean want_domain, gboolean storepassword);
 gint remmina_protocol_widget_init_certificate(RemminaProtocolWidget* gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint);
 gint remmina_protocol_widget_changed_certificate(RemminaProtocolWidget *gp, const gchar* subject, const gchar* issuer, const gchar* new_fingerprint, const gchar* old_fingerprint);
 gchar* remmina_protocol_widget_init_get_username(RemminaProtocolWidget *gp);


### PR DESCRIPTION
In some thin client environments is necessary that you can not store the password, because another user could access that account.
It happens because all users use the same filesystem.