### PR TITLE
remmina: Actually install its headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,5 +127,3 @@ if(GTK_FOUND)
 endif()
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_SOURCE_DIR}/config.h)
-
-install(DIRECTORY include/remmina DESTINATION include/remmina FILES_MATCHING PATTERN "*.h")

--- a/remmina/CMakeLists.txt
+++ b/remmina/CMakeLists.txt
@@ -176,7 +176,7 @@ add_subdirectory(desktop)
 add_subdirectory(external_tools)
 
 install(TARGETS remmina DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(DIRECTORY include/remmina/ DESTINATION include/remmina FILES_MATCHING PATTERN "*.h")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/remmina.pc.in ${CMAKE_CURRENT_BINARY_DIR}/remmina.pc @ONLY)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/remmina.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
-


### PR DESCRIPTION
The installation of the headers in `remmina/include/remmina` has been
broken ever since Remmina moved away from autotools, as the path
specified in the call to `install()` did not exist.

Move the `install()` call to remmina/ so that it works, and add a trailing
/ to the path so that we do not end up with `$CMAKE_INSTALL_PREFIX/include/remmina/remmina`.