### PR TITLE
Handle double click on the NX session rows to activate the default response

### DIFF
--- a/remmina-plugins/nx/nx_plugin.h
+++ b/remmina-plugins/nx/nx_plugin.h
@@ -71,6 +71,7 @@ typedef struct _RemminaPluginNxData
 	guint session_manager_start_handler;
 	gboolean attach_session;
 	GtkTreeIter iter;
+	gint default_response;
 } RemminaPluginNxData;
 
 extern RemminaPluginService *remmina_plugin_nx_service;


### PR DESCRIPTION
Fixes issue #16 make sessions in the NX session dialog double-clickable