### PR TITLE
Support for ~/.ssh/config closes #235 , libssh does not support most of the ssh options

### DIFF
--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  *
  *  In addition, as a special exception, the copyright holders give
@@ -392,6 +392,8 @@ remmina_ssh_init_session (RemminaSSH *ssh)
 	ssh_callbacks_init (ssh->callback);
 	ssh_set_callbacks(ssh->session, ssh->callback);
 
+	/* As the latest parse the ~/.ssh/config file */
+	ssh_options_parse_config(ssh->session, NULL);
 	if (ssh_connect (ssh->session))
 	{
 		remmina_ssh_set_error (ssh, _("Failed to startup SSH session: %s"));


### PR DESCRIPTION
I've added the support for ~/.ssh/config, but keep in mind that most of the ssh options are not supported by libssh , so I'm not sure it will works as you like, please test it.

I'm going to merge this in 'next'
