### PR TITLE
remmina.desktop: Use full path to execute remmina

### DIFF
--- a/remmina/desktop/CMakeLists.txt
+++ b/remmina/desktop/CMakeLists.txt
@@ -53,5 +53,6 @@ install(FILES ${ICON32_DATA} DESTINATION ${ICON32_DIR})
 install(FILES ${ICON48_DATA} DESTINATION ${ICON48_DIR})
 install(FILES ${ICONSVG_DATA} DESTINATION ${ICONSVG_DIR})
 
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/remmina.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop @ONLY)
 install(FILES remmina.desktop DESTINATION "${REMMINA_DATADIR}/applications")
 install(FILES remmina.appdata.xml DESTINATION "${REMMINA_DATADIR}/appdata")

--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -65,9 +65,9 @@ Comment[th]=เชื่อมต่อไปยังพื้นโต๊ะ�
 Comment[tr]=Uzak masaüstlerine bağlan
 Comment[uk]=Приєднатися до віддаленого комп’ютера
 Comment[zh_CN]=连接到远程桌面
-TryExec=remmina
-Exec=remmina
-Icon=remmina
+TryExec=@bindir@/remmina
+Exec=@bindir@/remmina
+Icon=@bindir@/remmina
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
@@ -94,7 +94,7 @@ Name[sv]=Skapa en ny anslutningsprofil
 Name[tr]=Yeni Bir Bağlantı Profili Oluştur
 Name[uk]=Створити новий профіль з’єднання
 Name[zh_CN]=新建连接配置
-Exec=remmina --new
+Exec=@bindir@/remmina --new
 
 [Desktop Action Tray]
 Name=Start Remmina Minimized
@@ -117,4 +117,4 @@ Name[sv]=Starta Remmina minimerat
 Name[tr]=Remmina'yı Küçültülmüş Başlat
 Name[uk]=Запустити Rammina у системному лотку
 Name[zh_CN]=启动后自动最小化
-Exec=remmina --icon
+Exec=@bindir@/remmina --icon


### PR DESCRIPTION
This patch makes sure that when remmina is started via the desktop
file it always starts the binary shipped with the distribution
and not another remmina binary that my have higher precedence
in the search path, such as in /usr/local/bin/.

Without this patch, if there is a remmina binary in /usr/local/bin, for example because the user previously compiled remmina, and then decided to go back to the distribution version, but the binary was not correctly cleaned up, then the .desktop file installed by the distribution will try to execute the binary in /usr/local/bin instead of /usr/bin, which can be a very annoying cause of errors.

With this patch, if the user installs both Remmina from the distribution and compiles a newer version by himself, then he will end up with to .desktop files, one in /usr/share/applications/remmina.desktop and another one in /usr/local/share/applications/desktop/.

I am currently not able to compile Remmina on my machine so please test this patch before you merge it.