### PR TITLE
remmina.desktop: Use full path to execute remmina

### DIFF
--- a/remmina/desktop/CMakeLists.txt
+++ b/remmina/desktop/CMakeLists.txt
@@ -53,5 +53,6 @@ install(FILES ${ICON32_DATA} DESTINATION ${ICON32_DIR})
 install(FILES ${ICON48_DATA} DESTINATION ${ICON48_DIR})
 install(FILES ${ICONSVG_DATA} DESTINATION ${ICONSVG_DIR})
 
-install(FILES remmina.desktop DESTINATION "${REMMINA_DATADIR}/applications")
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/remmina.desktop.in ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop DESTINATION "${REMMINA_DATADIR}/applications")
 install(FILES remmina.appdata.xml DESTINATION "${REMMINA_DATADIR}/appdata")

--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -65,9 +65,9 @@ Comment[th]=เชื่อมต่อไปยังพื้นโต๊ะ�
 Comment[tr]=Uzak masaüstlerine bağlan
 Comment[uk]=Приєднатися до віддаленого комп’ютера
 Comment[zh_CN]=连接到远程桌面
-TryExec=remmina
-Exec=remmina
-Icon=remmina
+TryExec=@bindir@/remmina
+Exec=@bindir@/remmina
+Icon=@bindir@/remmina
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
@@ -94,7 +94,7 @@ Name[sv]=Skapa en ny anslutningsprofil
 Name[tr]=Yeni Bir Bağlantı Profili Oluştur
 Name[uk]=Створити новий профіль з’єднання
 Name[zh_CN]=新建连接配置
-Exec=remmina --new
+Exec=@bindir@/remmina --new
 
 [Desktop Action Tray]
 Name=Start Remmina Minimized
@@ -117,4 +117,4 @@ Name[sv]=Starta Remmina minimerat
 Name[tr]=Remmina'yı Küçültülmüş Başlat
 Name[uk]=Запустити Rammina у системному лотку
 Name[zh_CN]=启动后自动最小化
-Exec=remmina --icon
+Exec=@bindir@/remmina --icon


### PR DESCRIPTION
Another try to fix #607:

I believe the cause of this is this line:

    install(FILES remmina.desktop DESTINATION "${REMMINA_DATADIR}/applications")

CMake was looking in the source directory for remmina.desktop but would not find it, because the `remmina.desktop` is now being build from `remmina.desktop.in` and saved to ${CMAKE_CURRENT_BINARY_DIR}, so we need to change it to this:

    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop DESTINATION "${REMMINA_DATADIR}/applications")

Unfortunately as I wrote in issue #607 I cannot build Remmina at the moment because I have not all dependencies on my system. But looking into `remmina/CMakeList.txt` we can see that the install directive to `remmina.pc` works in a similar way:

    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/remmina.pc.in ${CMAKE_CURRENT_BINARY_DIR}/remmina.pc @ONLY)
    install(FILES ${CMAKE_CURRENT_BINARY_DIR}/remmina.pc DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

so I am confident this change will fix the problem.