### PR TITLE
libssh fixes - SSH_OPTIONS_LOG_VERBOSITY

### DIFF
--- a/remmina/include/remmina/plugin.h
+++ b/remmina/include/remmina/plugin.h
@@ -15,7 +15,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  *
  *  In addition, as a special exception, the copyright holders give
@@ -210,6 +210,7 @@ typedef struct _RemminaPluginService
     gchar*       (* pref_get_value)                       (const gchar *key);
     gint         (* pref_get_scale_quality)               (void);
     gint         (* pref_get_sshtunnel_port)              (void);
+    gint         (* pref_get_ssh_loglevel)                (void);
     guint        (* pref_keymap_get_keyval)               (const gchar *keymap, guint keyval);
 
     void         (* log_print)                            (const gchar *text);
@@ -218,7 +219,7 @@ typedef struct _RemminaPluginService
     void         (* ui_register)                          (GtkWidget *widget);
 
     GtkWidget*   (* open_connection)                      (RemminaFile *remminafile, GCallback disconnect_cb, gpointer data, guint *handler);
-    void         (* get_server_port)                      (const gchar *server, gint defaultport, gchar **host, gint *port);  
+    void         (* get_server_port)                      (const gchar *server, gint defaultport, gchar **host, gint *port);
     gboolean     (* is_main_thread)                       (void);
 
 } RemminaPluginService;

--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -140,6 +140,7 @@ RemminaPluginService remmina_plugin_manager_service =
 		remmina_pref_get_value,
 		remmina_pref_get_scale_quality,
 		remmina_pref_get_sshtunnel_port,
+		remmina_pref_get_ssh_loglevel,
 		remmina_pref_keymap_get_keyval,
 
 		remmina_log_print,

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -302,6 +302,11 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.toolbar_pin_down = FALSE;
 
+	if (g_key_file_has_key(gkeyfile, "remmina_pref", "ssh_loglevel", NULL))
+		remmina_pref.ssh_loglevel = g_key_file_get_integer(gkeyfile, "remmina_pref", "ssh_loglevel", NULL);
+	else
+		remmina_pref.ssh_loglevel = DEFAULT_SSH_LOGLEVEL;
+
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "sshtunnel_port", NULL))
 		remmina_pref.sshtunnel_port = g_key_file_get_integer(gkeyfile, "remmina_pref", "sshtunnel_port", NULL);
 	else
@@ -502,6 +507,7 @@ void remmina_pref_save(void)
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_connection_toolbar", remmina_pref.hide_connection_toolbar);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "default_action", remmina_pref.default_action);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "scale_quality", remmina_pref.scale_quality);
+	g_key_file_set_integer(gkeyfile, "remmina_pref", "ssh_loglevel", remmina_pref.ssh_loglevel);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_toolbar", remmina_pref.hide_toolbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_statusbar", remmina_pref.hide_statusbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "show_quick_search", remmina_pref.show_quick_search);
@@ -699,6 +705,12 @@ gint remmina_pref_get_scale_quality(void)
 		remmina_pref.scale_quality = 0;
 	}
 	return remmina_pref.scale_quality;
+}
+
+gint remmina_pref_get_ssh_loglevel(void)
+{
+	TRACE_CALL("remmina_pref_get_ssh_loglevel");
+	return remmina_pref.ssh_loglevel;
 }
 
 gint remmina_pref_get_sshtunnel_port(void)

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -83,6 +83,7 @@ typedef struct _RemminaPref
 	gboolean save_when_connect;
 	gint default_action;
 	gint scale_quality;
+	gint ssh_loglevel;
 	gint sshtunnel_port;
 	gint auto_scroll_step;
 	gint recent_maximum;
@@ -145,6 +146,7 @@ typedef struct _RemminaPref
 
 #define DEFAULT_SSHTUNNEL_PORT 4732
 #define DEFAULT_SSH_PORT 22
+#define DEFAULT_SSH_LOGLEVEL 1
 
 extern const gchar *default_resolutions;
 extern gchar *remmina_pref_file;
@@ -161,6 +163,7 @@ guint remmina_pref_keymap_get_keyval(const gchar *keymap, guint keyval);
 gchar** remmina_pref_keymap_groups(void);
 
 gint remmina_pref_get_scale_quality(void);
+gint remmina_pref_get_ssh_loglevel(void);
 gint remmina_pref_get_sshtunnel_port(void);
 
 void remmina_pref_set_value(const gchar *key, const gchar *value);

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -131,6 +131,7 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.show_buttons_icons = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons);
 	remmina_pref.show_menu_icons = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_show_menu_icons);
 	remmina_pref.scale_quality = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_options_scale_quality);
+	remmina_pref.ssh_loglevel = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_options_ssh_loglevel);
 
 	remmina_pref.sshtunnel_port = atoi(gtk_entry_get_text(remmina_pref_dialog->entry_options_ssh_port));
 	if (remmina_pref.sshtunnel_port <= 0)
@@ -336,6 +337,7 @@ static void remmina_pref_dialog_init(void)
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons, remmina_pref.show_buttons_icons);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_show_menu_icons, remmina_pref.show_menu_icons);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_options_scale_quality, remmina_pref.scale_quality);
+	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_options_ssh_loglevel, remmina_pref.ssh_loglevel);
 
 	gtk_button_set_label(remmina_pref_dialog->button_keyboard_copy, remmina_key_chooser_get_value(remmina_pref.vte_shortcutkey_copy, 0));
 	gtk_button_set_label(remmina_pref_dialog->button_keyboard_paste, remmina_key_chooser_get_value(remmina_pref.vte_shortcutkey_paste, 0));
@@ -371,6 +373,7 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_show_buttons_icons"));
 	remmina_pref_dialog->comboboxtext_appearance_show_menu_icons = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_show_menu_icons"));
 	remmina_pref_dialog->comboboxtext_options_scale_quality = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_options_scale_quality"));
+	remmina_pref_dialog->comboboxtext_options_ssh_loglevel = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_options_ssh_loglevel"));
 	remmina_pref_dialog->entry_options_ssh_port = GTK_ENTRY(GET_OBJECT("entry_options_ssh_port"));
 	remmina_pref_dialog->entry_options_scroll = GTK_ENTRY(GET_OBJECT("entry_options_scroll"));
 	remmina_pref_dialog->entry_options_recent_items = GTK_ENTRY(GET_OBJECT("entry_options_recent_items"));

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -61,6 +61,7 @@ typedef struct _RemminaPrefDialog
 	GtkComboBox *comboboxtext_appearance_show_buttons_icons;
 	GtkComboBox *comboboxtext_appearance_show_menu_icons;
 	GtkComboBox *comboboxtext_options_scale_quality;
+	GtkComboBox *comboboxtext_options_ssh_loglevel;
 	GtkEntry *entry_options_ssh_port;
 	GtkEntry *entry_options_scroll;
 	GtkEntry *entry_options_recent_items;

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -72,6 +72,7 @@
 #include "remmina_public.h"
 #include "remmina_log.h"
 #include "remmina_ssh.h"
+#include "remmina_pref.h"
 #include "remmina/remmina_trace_calls.h"
 
 /*************************** SSH Base *********************************/
@@ -374,6 +375,7 @@ remmina_ssh_init_session (RemminaSSH *ssh)
 {
 	TRACE_CALL("remmina_ssh_init_session");
 	gint verbosity;
+	//gchar* verbosity;
 
 	ssh->callback = g_new0 (struct ssh_callbacks_struct, 1);
 	ssh->callback->userdata = ssh;
@@ -385,7 +387,7 @@ remmina_ssh_init_session (RemminaSSH *ssh)
 	ssh_options_set (ssh->session, SSH_OPTIONS_USER, ssh->user);
 	if (remmina_log_running ())
 	{
-		verbosity = SSH_LOG_RARE;
+		verbosity = remmina_pref.ssh_loglevel;
 		ssh_options_set (ssh->session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
 		ssh->callback->log_function = remmina_ssh_log_callback;
 	}
@@ -416,6 +418,7 @@ remmina_ssh_init_from_file (RemminaSSH *ssh, RemminaFile *remminafile)
 	const gchar *ssh_username;
 	const gchar *ssh_privatekey;
 	const gchar *server;
+	gint verbosity;
 	gchar *s;
 
 	ssh->session = NULL;

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -100,8 +100,8 @@
                       <object class="GtkLabel" id="label_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Double-click action</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -128,8 +128,8 @@
                       <object class="GtkLabel" id="label_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Scale quality</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -158,8 +158,8 @@
                       <object class="GtkLabel" id="label_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">SSH tunnel local port</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -182,12 +182,12 @@
                       <object class="GtkLabel" id="label_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Auto scroll step size</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -198,7 +198,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -206,12 +206,12 @@
                       <object class="GtkLabel" id="label_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Maximum recent items</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -223,7 +223,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -236,19 +236,19 @@
                       </object>
                       <packing>
                         <property name="left_attach">2</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_options_resolutions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Resolutions</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -261,7 +261,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -269,12 +269,12 @@
                       <object class="GtkLabel" id="label_options_keystrokes">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Keystrokes</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -287,8 +287,39 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                         <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkComboBoxText" id="comboboxtext_options_ssh_loglevel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="hexpand">True</property>
+                        <items>
+                          <item id="0" translatable="yes">SSH_LOG_NOLOG</item>
+                          <item id="1" translatable="yes">SSH_LOG_RARE</item>
+                          <item id="2" translatable="yes">SSH_LOG_ENTRY</item>
+                          <item id="3" translatable="yes">SSH_LOG_PACKET</item>
+                          <item id="4" translatable="yes">SSH_LOG_FUNCTIONS</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">5</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_options_ssh_loglevel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">SSH log level</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                   </object>
@@ -368,8 +399,8 @@
                       <object class="GtkLabel" id="label_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Default view mode</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -398,8 +429,8 @@
                       <object class="GtkLabel" id="label_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Tab interface</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -428,8 +459,8 @@
                       <object class="GtkLabel" id="label_appearance_show_buttons_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Show buttons icons</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -458,8 +489,8 @@
                       <object class="GtkLabel" id="label_appearance_show_menu_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Show menu icons</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -618,8 +649,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Host key</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -646,8 +677,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Toggle fullscreen mode</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -674,8 +705,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Auto-fit window</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -702,8 +733,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Switch tab pages</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -743,8 +774,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Toggle scaled mode</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -771,8 +802,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Grab keyboard</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -799,8 +830,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Minimize window</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -827,8 +858,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Disconnect</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -855,8 +886,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Show / hide toolbar</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -915,8 +946,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Font</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -928,8 +959,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Colors</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -941,8 +972,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Foreground color</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -954,8 +985,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Background color</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -967,8 +998,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Scrollback lines</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -980,8 +1011,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Keyboard</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1130,8 +1161,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Copy</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1169,8 +1200,8 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Paste</property>
+                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>


### PR DESCRIPTION
This merge add a new option in remmina preferences to set the ssh log level.

This feature is useful to investigate #176 #331 #539 

@giox069 minor enhancements, it has been tested on fedora f21, f22, Arch Linux