### PR TITLE
libssh - deprecations warnings

### DIFF
--- a/remmina-plugins/nx/nx_session.c
+++ b/remmina-plugins/nx/nx_session.c
@@ -50,12 +50,10 @@ static gboolean remmina_get_keytype(const gchar *private_key_file, gint *keytype
 	FILE *fp;
 	gchar buf1[100], buf2[100];
 
-	if ((fp = g_fopen(private_key_file, "r")) == NULL)
-	{
+	if ((fp = g_fopen(private_key_file, "r")) == NULL) {
 		return FALSE;
 	}
-	if (!fgets(buf1, sizeof(buf1), fp) || !fgets(buf2, sizeof(buf2), fp))
-	{
+	if (!fgets(buf1, sizeof(buf1), fp) || !fgets(buf2, sizeof(buf2), fp)) {
 		fclose(fp);
 		return FALSE;
 	}
@@ -63,11 +61,10 @@ static gboolean remmina_get_keytype(const gchar *private_key_file, gint *keytype
 
 	if (strstr(buf1, "BEGIN RSA"))
 		*keytype = REMMINA_SSH_TYPE_RSA;
+	else if (strstr(buf1, "BEGIN DSA"))
+		*keytype = REMMINA_SSH_TYPE_DSS;
 	else
-		if (strstr(buf1, "BEGIN DSA"))
-			*keytype = REMMINA_SSH_TYPE_DSS;
-		else
-			return FALSE;
+		return FALSE;
 
 	*encrypted = (strstr(buf2, "ENCRYPTED") ? TRUE : FALSE);
 
@@ -91,8 +88,7 @@ static const gchar nx_default_private_key[] = "-----BEGIN DSA PRIVATE KEY-----\n
 
 static const gchar nx_hello_server_msg[] = "hello nxserver - version ";
 
-struct _RemminaNXSession
-{
+struct _RemminaNXSession {
 	/* Common SSH members */
 	ssh_session session;
 	ssh_channel channel;
@@ -149,32 +145,27 @@ void remmina_nx_session_free(RemminaNXSession *nx)
 	TRACE_CALL("remmina_nx_session_free");
 	pthread_t thread;
 
-	if (nx->proxy_watch_source)
-	{
+	if (nx->proxy_watch_source) {
 		g_source_remove(nx->proxy_watch_source);
 		nx->proxy_watch_source = 0;
 	}
-	if (nx->proxy_pid)
-	{
+	if (nx->proxy_pid) {
 		kill(nx->proxy_pid, SIGTERM);
 		g_spawn_close_pid(nx->proxy_pid);
 		nx->proxy_pid = 0;
 	}
 	thread = nx->thread;
-	if (thread)
-	{
+	if (thread) {
 		nx->running = FALSE;
 		pthread_cancel(thread);
 		pthread_join(thread, NULL);
 		nx->thread = 0;
 	}
-	if (nx->channel)
-	{
+	if (nx->channel) {
 		ssh_channel_close(nx->channel);
 		ssh_channel_free(nx->channel);
 	}
-	if (nx->server_sock >= 0)
-	{
+	if (nx->server_sock >= 0) {
 		close(nx->server_sock);
 		nx->server_sock = -1;
 	}
@@ -187,13 +178,11 @@ void remmina_nx_session_free(RemminaNXSession *nx)
 	g_free(nx->session_id);
 	g_free(nx->proxy_cookie);
 
-	if (nx->session_list)
-	{
+	if (nx->session_list) {
 		g_object_unref(nx->session_list);
 		nx->session_list = NULL;
 	}
-	if (nx->session)
-	{
+	if (nx->session) {
 		ssh_free(nx->session);
 		nx->session = NULL;
 	}
@@ -238,8 +227,7 @@ remmina_nx_session_get_error(RemminaNXSession *nx)
 void remmina_nx_session_clear_error(RemminaNXSession *nx)
 {
 	TRACE_CALL("remmina_nx_session_clear_error");
-	if (nx->error)
-	{
+	if (nx->error) {
 		g_free(nx->error);
 		nx->error = NULL;
 	}
@@ -279,11 +267,9 @@ static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 	ssh_channel_select(ch, NULL, NULL, &timeout);
 
 	is_stderr = 0;
-	while (is_stderr <= 1)
-	{
+	while (is_stderr <= 1) {
 		len = ssh_channel_poll(nx->channel, is_stderr);
-		if (len == SSH_ERROR)
-		{
+		if (len == SSH_ERROR) {
 			remmina_nx_session_set_error(nx, "Error reading channel: %s");
 			return FALSE;
 		}
@@ -296,13 +282,11 @@ static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 
 	buffer = buffer_new();
 	len = ssh_channel_read_buffer(nx->channel, buffer, len, is_stderr);
-	if (len <= 0)
-	{
+	if (len <= 0) {
 		remmina_nx_session_set_application_error(nx, "Channel closed.");
 		return FALSE;
 	}
-	if (len > 0)
-	{
+	if (len > 0) {
 		g_string_append_len(nx->response, (const gchar*) buffer_get(buffer), len);
 	}
 
@@ -327,28 +311,26 @@ static void remmina_nx_session_parse_session_list_line(RemminaNXSession *nx, con
 	gtk_list_store_append(nx->session_list, &iter);
 
 	p1 = (char*) line;
-	for (i = 0; i < 7; i++)
-	{
+	for (i = 0; i < 7; i++) {
 		p2 = strchr(p1, ' ');
 		if (!p2)
 			return;
 		val = g_strndup(p1, (gint)(p2 - p1));
-		switch (i)
-		{
-			case 0:
-				gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_DISPLAY, val, -1);
-				break;
-			case 1:
-				gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_TYPE, val, -1);
-				break;
-			case 2:
-				gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_ID, val, -1);
-				break;
-			case 6:
-				gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_STATUS, val, -1);
-				break;
-			default:
-				break;
+		switch (i) {
+		case 0:
+			gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_DISPLAY, val, -1);
+			break;
+		case 1:
+			gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_TYPE, val, -1);
+			break;
+		case 2:
+			gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_ID, val, -1);
+			break;
+		case 6:
+			gtk_list_store_set(nx->session_list, &iter, REMMINA_NX_SESSION_COLUMN_STATUS, val, -1);
+			break;
+		default:
+			break;
 		}
 		g_free(val);
 
@@ -378,17 +360,13 @@ static gint remmina_nx_session_parse_line(RemminaNXSession *nx, const gchar *lin
 	*valueptr = NULL;
 
 	/* Get the server version from the initial line */
-	if (!nx->version)
-	{
+	if (!nx->version) {
 		s = g_ascii_strdown(line, -1);
 		ptr = strstr(s, nx_hello_server_msg);
-		if (!ptr)
-		{
+		if (!ptr) {
 			/* Try to use a default version */
 			nx->version = g_strdup("3.3.0");
-		}
-		else
-		{
+		} else {
 			nx->version = g_strdup(ptr + strlen(nx_hello_server_msg));
 			ptr = strchr(nx->version, ' ');
 			if (ptr)
@@ -402,19 +380,13 @@ static gint remmina_nx_session_parse_line(RemminaNXSession *nx, const gchar *lin
 		return nx->status;
 	}
 
-	if (sscanf(line, "NX> %i ", &status) < 1)
-	{
-		if (nx->session_list_state && nx->session_list)
-		{
-			if (nx->session_list_state == 1 && strncmp(line, "----", 4) == 0)
-			{
+	if (sscanf(line, "NX> %i ", &status) < 1) {
+		if (nx->session_list_state && nx->session_list) {
+			if (nx->session_list_state == 1 && strncmp(line, "----", 4) == 0) {
 				nx->session_list_state = 2;
+			} else if (nx->session_list_state == 2) {
+				remmina_nx_session_parse_session_list_line(nx, line);
 			}
-			else
-				if (nx->session_list_state == 2)
-				{
-					remmina_nx_session_parse_session_list_line(nx, line);
-				}
 			return -1;
 		}
 		return nx->status;
@@ -449,8 +421,7 @@ remmina_nx_session_get_line(RemminaNXSession *nx)
 	line = g_strndup(pos, len - 1);
 
 	l = strlen(line);
-	if (l > 0 && line[l - 1] == '\r')
-	{
+	if (l > 0 && line[l - 1] == '\r') {
 		line[l - 1] = '\0';
 	}
 
@@ -469,55 +440,44 @@ static gint remmina_nx_session_parse_response(RemminaNXSession *nx)
 	if (nx->response_pos >= nx->response->len)
 		return -1;
 
-	while ((line = remmina_nx_session_get_line(nx)) != NULL)
-	{
+	while ((line = remmina_nx_session_get_line(nx)) != NULL) {
 		if (nx->log_callback)
 			nx->log_callback("[NX] %s\n", line);
 
 		status = remmina_nx_session_parse_line(nx, line, &p);
-		if (status == 500)
-		{
+		if (status == 500) {
 			/* 500: Last operation failed. Should be ignored. */
+		} else if (status >= 400 && status <= 599) {
+			remmina_nx_session_set_application_error(nx, "%s", line);
+		} else {
+			switch (status) {
+			case 127: /* Session list */
+				nx->session_list_state = 1;
+				break;
+			case 148: /* Server capacity not reached for user xxx */
+				nx->session_list_state = 0;
+				nx->allow_start = TRUE;
+				break;
+			case 700:
+				nx->session_id = g_strdup(p);
+				break;
+			case 705:
+				nx->session_display = atoi(p);
+				break;
+			case 701:
+				nx->proxy_cookie = g_strdup(p);
+				break;
+			}
 		}
-		else
-			if (status >= 400 && status <= 599)
-			{
-				remmina_nx_session_set_application_error(nx, "%s", line);
-			}
-			else
-			{
-				switch (status)
-				{
-					case 127: /* Session list */
-						nx->session_list_state = 1;
-						break;
-					case 148: /* Server capacity not reached for user xxx */
-						nx->session_list_state = 0;
-						nx->allow_start = TRUE;
-						break;
-					case 700:
-						nx->session_id = g_strdup(p);
-						break;
-					case 705:
-						nx->session_display = atoi(p);
-						break;
-					case 701:
-						nx->proxy_cookie = g_strdup(p);
-						break;
-				}
-			}
 		g_free(line);
 
 		nx->status = status;
 	}
 
 	pos = nx->response->str + nx->response_pos;
-	if (sscanf(pos, "NX> %i ", &status) < 1)
-	{
+	if (sscanf(pos, "NX> %i ", &status) < 1) {
 		status = nx->status;
-	}
-	else
-	{
+	} else {
 		if (nx->log_callback)
 			nx->log_callback("[NX] %s\n", pos);
 		nx->response_pos += 8;
@@ -531,8 +491,7 @@ static gint remmina_nx_session_expect_status2(RemminaNXSession *nx, gint status,
 	TRACE_CALL("remmina_nx_session_expect_status2");
 	gint response;
 
-	while ((response = remmina_nx_session_parse_response(nx)) != status && response != status2)
-	{
+	while ((response = remmina_nx_session_parse_response(nx)) != status && response != status2) {
 		if (response == 999)
 			break;
 		if (!remmina_nx_session_get_response(nx))
@@ -567,7 +526,7 @@ static void remmina_nx_session_send_command(RemminaNXSession *nx, const gchar *c
 }
 
 gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guint port, const gchar *private_key_file,
-		RemminaNXPassphraseCallback passphrase_func, gpointer userdata)
+								 RemminaNXPassphraseCallback passphrase_func, gpointer userdata)
 {
 	TRACE_CALL("remmina_nx_session_open");
 	gint ret;
@@ -581,15 +540,12 @@ gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guin
 	ssh_options_set(nx->session, SSH_OPTIONS_PORT, &port);
 	ssh_options_set(nx->session, SSH_OPTIONS_USER, "nx");
 
-	if (private_key_file && private_key_file[0])
-	{
-		if (!remmina_get_keytype(private_key_file, &keytype, &encrypted))
-		{
+	if (private_key_file && private_key_file[0]) {
+		if (!remmina_get_keytype(private_key_file, &keytype, &encrypted)) {
 			remmina_nx_session_set_application_error(nx, "Invalid private key file.");
 			return FALSE;
 		}
-		if (encrypted && !passphrase_func(&passphrase, userdata))
-		{
+		if (encrypted && !passphrase_func(&passphrase, userdata)) {
 			return FALSE;
 		}
 		if ( ssh_pki_import_privkey_file(private_key_file, (passphrase ? passphrase : ""), NULL, NULL, &priv_key) != SSH_OK ) {
@@ -598,9 +554,7 @@ gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guin
 			return FALSE;
 		}
 		g_free(passphrase);
-	}
-	else
-	{
+	} else {
 		/* Use NoMachine's default nx private key */
 		if ( ssh_pki_import_privkey_base64(nx_default_private_key, NULL, NULL, NULL, &priv_key) != SSH_OK ) {
 			remmina_nx_session_set_application_error(nx, "Failed to import NX default private key.");
@@ -608,8 +562,7 @@ gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guin
 		}
 	}
 
-	if (ssh_connect(nx->session))
-	{
+	if (ssh_connect(nx->session)) {
 		ssh_key_free(priv_key);
 		remmina_nx_session_set_error(nx, "Failed to startup SSH session: %s");
 		return FALSE;
@@ -619,19 +572,16 @@ gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guin
 
 	ssh_key_free(priv_key);
 
-	if (ret != SSH_AUTH_SUCCESS)
-	{
+	if (ret != SSH_AUTH_SUCCESS) {
 		remmina_nx_session_set_error(nx, "NX SSH authentication failed: %s");
 		return FALSE;
 	}
 
-	if ((nx->channel = ssh_channel_new(nx->session)) == NULL || ssh_channel_open_session(nx->channel) != SSH_OK)
-	{
+	if ((nx->channel = ssh_channel_new(nx->session)) == NULL || ssh_channel_open_session(nx->channel) != SSH_OK) {
 		return FALSE;
 	}
 
-	if (ssh_channel_request_shell(nx->channel) != SSH_OK)
-	{
+	if (ssh_channel_request_shell(nx->channel) != SSH_OK) {
 		return FALSE;
 	}
 
@@ -669,17 +619,13 @@ gboolean remmina_nx_session_login(RemminaNXSession *nx, const gchar *username, c
 	remmina_nx_session_send_command(nx, username);
 	/* NoMachine Testdrive does not prompt for password, in which case 105 response is received without 102 */
 	response = remmina_nx_session_expect_status2(nx, 102, 105);
-	if (response == 102)
-	{
+	if (response == 102) {
 		remmina_nx_session_send_command(nx, password);
 		if (!remmina_nx_session_expect_status(nx, 105))
 			return FALSE;
+	} else if (response != 105) {
+		return FALSE;
 	}
-	else
-		if (response != 105)
-		{
-			return FALSE;
-		}
 
 	return TRUE;
 }
@@ -705,8 +651,7 @@ static gboolean remmina_nx_session_send_session_command(RemminaNXSession *nx, co
 
 	cmd = g_string_new(cmd_type);
 	g_hash_table_iter_init(&iter, nx->session_parameters);
-	while (g_hash_table_iter_next(&iter, (gpointer*) &key, (gpointer*) &value))
-	{
+	while (g_hash_table_iter_next(&iter, (gpointer*) &key, (gpointer*) &value)) {
 		g_string_append_printf(cmd, " --%s=\"%s\"", key, value);
 	}
 
@@ -723,13 +668,10 @@ gboolean remmina_nx_session_list(RemminaNXSession *nx)
 	TRACE_CALL("remmina_nx_session_list");
 	gboolean ret;
 
-	if (nx->session_list == NULL)
-	{
+	if (nx->session_list == NULL) {
 		nx->session_list = gtk_list_store_new(REMMINA_NX_SESSION_N_COLUMNS, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING,
-				G_TYPE_STRING, G_TYPE_STRING);
-	}
-	else
-	{
+											  G_TYPE_STRING, G_TYPE_STRING);
+	} else {
 		gtk_list_store_clear(nx->session_list);
 	}
 	ret = remmina_nx_session_send_session_command(nx, "listsession", 105);
@@ -849,8 +791,7 @@ static gpointer remmina_nx_session_tunnel_main_thread(gpointer data)
 
 	/* Accept a local connection */
 	sock = accept(nx->server_sock, NULL, NULL);
-	if (sock < 0)
-	{
+	if (sock < 0) {
 		remmina_nx_session_set_application_error(nx, "Failed to accept local socket");
 		nx->thread = 0;
 		return NULL;
@@ -862,8 +803,7 @@ static gpointer remmina_nx_session_tunnel_main_thread(gpointer data)
 	channels[1] = NULL;
 
 	/* Start the tunnel data transmittion */
-	while (nx->running)
-	{
+	while (nx->running) {
 		timeout.tv_sec = 1;
 		timeout.tv_usec = 0;
 
@@ -878,65 +818,49 @@ static gpointer remmina_nx_session_tunnel_main_thread(gpointer data)
 		if (ret == -1)
 			break;
 
-		if (FD_ISSET(sock, &set))
-		{
+		if (FD_ISSET(sock, &set)) {
 			len = read(sock, buffer, sizeof(buffer));
 			if (len == 0)
 				nx->running = FALSE;
-			else
-				if (len > 0)
-				{
-					for (ptr = buffer, lenw = 0; len > 0; len -= lenw, ptr += lenw)
-					{
-						ssh_set_fd_towrite(nx->session);
-						lenw = channel_write(channels[0], (char*) ptr, len);
-						if (lenw <= 0)
-						{
-							nx->running = FALSE;
-							break;
-						}
+			else if (len > 0) {
+				for (ptr = buffer, lenw = 0; len > 0; len -= lenw, ptr += lenw) {
+					ssh_set_fd_towrite(nx->session);
+					lenw = channel_write(channels[0], (char*) ptr, len);
+					if (lenw <= 0) {
+						nx->running = FALSE;
+						break;
 					}
 				}
+			}
 		}
 
 		if (!nx->running)
 			break;
 
-		if (channels_out[0] && socketbuffer_len <= 0)
-		{
+		if (channels_out[0] && socketbuffer_len <= 0) {
 			len = channel_read_nonblocking(channels_out[0], socketbuffer, sizeof(socketbuffer), 0);
-			if (len == SSH_ERROR || len == SSH_EOF)
-			{
+			if (len == SSH_ERROR || len == SSH_EOF) {
 				nx->running = FALSE;
 				break;
+			} else if (len > 0) {
+				socketbuffer_ptr = socketbuffer;
+				socketbuffer_len = len;
+			} else {
+				/* Clean up the stderr buffer in case FreeNX send something there */
+				len = channel_read_nonblocking(channels_out[0], buffer, sizeof(buffer), 1);
 			}
-			else
-				if (len > 0)
-				{
-					socketbuffer_ptr = socketbuffer;
-					socketbuffer_len = len;
-				}
-				else
-				{
-					/* Clean up the stderr buffer in case FreeNX send something there */
-					len = channel_read_nonblocking(channels_out[0], buffer, sizeof(buffer), 1);
-				}
 		}
 
-		if (nx->running && socketbuffer_len > 0)
-		{
-			for (lenw = 0; socketbuffer_len > 0; socketbuffer_len -= lenw, socketbuffer_ptr += lenw)
-			{
+		if (nx->running && socketbuffer_len > 0) {
+			for (lenw = 0; socketbuffer_len > 0; socketbuffer_len -= lenw, socketbuffer_ptr += lenw) {
 				lenw = write(sock, socketbuffer_ptr, socketbuffer_len);
-				if (lenw == -1 && errno == EAGAIN && nx->running)
-				{
+				if (lenw == -1 && errno == EAGAIN && nx->running) {
 					/* Sometimes we cannot write to a socket (always EAGAIN), probably because it's internal
 					 * buffer is full. We need read the pending bytes from the socket first. so here we simply
 					 * break, leave the buffer there, and continue with other data */
 					break;
 				}
-				if (lenw <= 0)
-				{
+				if (lenw <= 0) {
 					nx->running = FALSE;
 					break;
 				}
@@ -961,8 +885,7 @@ gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 		return TRUE;
 
 	remmina_nx_session_send_command(nx, "bye");
-	if (!remmina_nx_session_expect_status(nx, 999))
-	{
+	if (!remmina_nx_session_expect_status(nx, 999)) {
 		/* Shoud not happen, just in case */
 		remmina_nx_session_set_application_error(nx, "Server won't say bye to us?");
 		return FALSE;
@@ -972,8 +895,7 @@ gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 
 	/* Create the server socket that listens on the local port */
 	sock = socket(AF_INET, SOCK_STREAM, 0);
-	if (sock < 0)
-	{
+	if (sock < 0) {
 		remmina_nx_session_set_application_error(nx, "Failed to create socket.");
 		return FALSE;
 	}
@@ -983,15 +905,13 @@ gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 	sin.sin_port = htons(port);
 	sin.sin_addr.s_addr = inet_addr("127.0.0.1");
 
-	if (bind(sock, (struct sockaddr *) &sin, sizeof(sin)))
-	{
+	if (bind(sock, (struct sockaddr *) &sin, sizeof(sin))) {
 		remmina_nx_session_set_application_error(nx, "Failed to bind on local port.");
 		close(sock);
 		return FALSE;
 	}
 
-	if (listen(sock, 1))
-	{
+	if (listen(sock, 1)) {
 		remmina_nx_session_set_application_error(nx, "Failed to listen on local port.");
 		close(sock);
 		return FALSE;
@@ -1000,8 +920,7 @@ gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 	nx->server_sock = sock;
 	nx->running = TRUE;
 
-	if (pthread_create(&nx->thread, NULL, remmina_nx_session_tunnel_main_thread, nx))
-	{
+	if (pthread_create(&nx->thread, NULL, remmina_nx_session_tunnel_main_thread, nx)) {
 		remmina_nx_session_set_application_error(nx, "Failed to initialize pthread.");
 		nx->thread = 0;
 		return FALSE;
@@ -1013,17 +932,14 @@ static gchar*
 remmina_nx_session_get_proxy_option(RemminaNXSession *nx)
 {
 	TRACE_CALL("remmina_nx_session_get_proxy_option");
-	if (nx->encryption)
-	{
+	if (nx->encryption) {
 		return g_strdup_printf("nx,session=%s,cookie=%s,id=%s,shmem=1,shpix=1,connect=127.0.0.1:%i",
-				(gchar*) g_hash_table_lookup(nx->session_parameters, "session"), nx->proxy_cookie,
-				nx->session_id, (nx->localport ? nx->localport : nx->session_display));
-	}
-	else
-	{
+							   (gchar*) g_hash_table_lookup(nx->session_parameters, "session"), nx->proxy_cookie,
+							   nx->session_id, (nx->localport ? nx->localport : nx->session_display));
+	} else {
 		return g_strdup_printf("nx,session=%s,cookie=%s,id=%s,shmem=1,shpix=1,connect=%s:%i",
-				(gchar*) g_hash_table_lookup(nx->session_parameters, "session"), nx->proxy_cookie,
-				nx->session_id, nx->server, nx->session_display);
+							   (gchar*) g_hash_table_lookup(nx->session_parameters, "session"), nx->proxy_cookie,
+							   nx->session_id, nx->server, nx->session_display);
 	}
 }
 
@@ -1039,25 +955,18 @@ gboolean remmina_nx_session_invoke_proxy(RemminaNXSession *nx, gint display, GCh
 	gint i;
 
 	/* Copy all current environment variable, but change DISPLAY. Assume we should always have DISPLAY... */
-	if (display >= 0)
-	{
+	if (display >= 0) {
 		envp = g_listenv();
-		for (i = 0; envp[i]; i++)
-		{
-			if (g_strcmp0(envp[i], "DISPLAY") == 0)
-			{
+		for (i = 0; envp[i]; i++) {
+			if (g_strcmp0(envp[i], "DISPLAY") == 0) {
 				s = g_strdup_printf("DISPLAY=:%i", display);
-			}
-			else
-			{
+			} else {
 				s = g_strdup_printf("%s=%s", envp[i], g_getenv(envp[i]));
 			}
 			g_free(envp[i]);
 			envp[i] = s;
 		}
-	}
-	else
-	{
+	} else {
 		envp = NULL;
 	}
 
@@ -1068,19 +977,17 @@ gboolean remmina_nx_session_invoke_proxy(RemminaNXSession *nx, gint display, GCh
 	argv[argc++] = NULL;
 
 	ret = g_spawn_async(NULL, argv, envp, G_SPAWN_SEARCH_PATH | G_SPAWN_DO_NOT_REAP_CHILD, NULL, NULL, &nx->proxy_pid,
-			&error);
+						&error);
 	g_strfreev(envp);
 	for (i = 0; i < argc; i++)
 		g_free(argv[i]);
 
-	if (!ret)
-	{
+	if (!ret) {
 		remmina_nx_session_set_application_error(nx, "%s", error->message);
 		return FALSE;
 	}
 
-	if (exit_func)
-	{
+	if (exit_func) {
 		nx->proxy_watch_source = g_child_watch_add(nx->proxy_pid, exit_func, user_data);
 	}
 

--- a/remmina-plugins/nx/nx_session.c
+++ b/remmina-plugins/nx/nx_session.c
@@ -276,12 +276,12 @@ static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 	timeout.tv_usec = 0;
 	ch[0] = nx->channel;
 	ch[1] = NULL;
-	channel_select(ch, NULL, NULL, &timeout);
+	ssh_channel_select(ch, NULL, NULL, &timeout);
 
 	is_stderr = 0;
 	while (is_stderr <= 1)
 	{
-		len = channel_poll(nx->channel, is_stderr);
+		len = ssh_channel_poll(nx->channel, is_stderr);
 		if (len == SSH_ERROR)
 		{
 			remmina_nx_session_set_error(nx, "Error reading channel: %s");
@@ -295,7 +295,7 @@ static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 		return FALSE;
 
 	buffer = buffer_new();
-	len = channel_read_buffer(nx->channel, buffer, len, is_stderr);
+	len = ssh_channel_read_buffer(nx->channel, buffer, len, is_stderr);
 	if (len <= 0)
 	{
 		remmina_nx_session_set_application_error(nx, "Channel closed.");

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -1405,4 +1405,3 @@ GtkWidget* remmina_file_editor_new_from_filename(const gchar* filename)
 		return NULL;
 	}
 }
-// vim:noet:ci:pi:sts=0:sw=4:ts=4

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -50,8 +50,7 @@
 #include "remmina_masterthread_exec.h"
 #include "remmina/remmina_trace_calls.h"
 
-struct _RemminaProtocolWidgetPriv
-{
+struct _RemminaProtocolWidgetPriv {
 	GtkWidget* init_dialog;
 
 	RemminaFile* remmina_file;
@@ -78,8 +77,7 @@ struct _RemminaProtocolWidgetPriv
 
 G_DEFINE_TYPE(RemminaProtocolWidget, remmina_protocol_widget, GTK_TYPE_EVENT_BOX)
 
-enum
-{
+enum {
 	CONNECT_SIGNAL,
 	DISCONNECT_SIGNAL,
 	DESKTOP_RESIZE_SIGNAL,
@@ -87,8 +85,7 @@ enum
 	LAST_SIGNAL
 };
 
-typedef struct _RemminaProtocolWidgetSignalData
-{
+typedef struct _RemminaProtocolWidgetSignalData {
 	RemminaProtocolWidget* gp;
 	const gchar* signal_name;
 } RemminaProtocolWidgetSignalData;
@@ -117,8 +114,7 @@ static void remmina_protocol_widget_init_cancel(RemminaInitDialog *dialog, gint 
 {
 	TRACE_CALL("remmina_protocol_widget_init_cancel");
 	if ((response_id == GTK_RESPONSE_CANCEL || response_id == GTK_RESPONSE_DELETE_EVENT)
-			&& dialog->mode == REMMINA_INIT_MODE_CONNECTING)
-	{
+			&& dialog->mode == REMMINA_INIT_MODE_CONNECTING) {
 		remmina_protocol_widget_close_connection(gp);
 	}
 }
@@ -126,8 +122,7 @@ static void remmina_protocol_widget_init_cancel(RemminaInitDialog *dialog, gint 
 static void remmina_protocol_widget_show_init_dialog(RemminaProtocolWidget* gp, const gchar *name)
 {
 	TRACE_CALL("remmina_protocol_widget_show_init_dialog");
-	if (gp->priv->init_dialog)
-	{
+	if (gp->priv->init_dialog) {
 		gtk_widget_destroy(gp->priv->init_dialog);
 	}
 	gp->priv->init_dialog = remmina_init_dialog_new(_("Connecting to '%s'..."), (name ? name : "*"));
@@ -157,8 +152,7 @@ static void remmina_protocol_widget_connect(RemminaProtocolWidget* gp, gpointer 
 {
 	TRACE_CALL("remmina_protocol_widget_connect");
 #ifdef HAVE_LIBSSH
-	if (gp->priv->ssh_tunnel)
-	{
+	if (gp->priv->ssh_tunnel) {
 		remmina_ssh_tunnel_cancel_accept (gp->priv->ssh_tunnel);
 	}
 #endif
@@ -178,8 +172,7 @@ void remmina_protocol_widget_grab_focus(RemminaProtocolWidget* gp)
 
 	child = gtk_bin_get_child(GTK_BIN(gp));
 
-	if (child)
-	{
+	if (child) {
 		gtk_widget_set_can_focus(child, TRUE);
 		gtk_widget_grab_focus(child);
 	}
@@ -210,12 +203,11 @@ void remmina_protocol_widget_open_connection_real(gpointer data)
 
 	/* Locate the protocol plugin */
 	plugin = (RemminaProtocolPlugin*) remmina_plugin_manager_get_plugin(REMMINA_PLUGIN_TYPE_PROTOCOL,
-			remmina_file_get_string(remminafile, "protocol"));
+			 remmina_file_get_string(remminafile, "protocol"));
 
-	if (!plugin || !plugin->init || !plugin->open_connection)
-	{
+	if (!plugin || !plugin->init || !plugin->open_connection) {
 		remmina_protocol_widget_set_error(gp, _("Protocol plugin %s is not installed."),
-				remmina_file_get_string(remminafile, "protocol"));
+										  remmina_file_get_string(remminafile, "protocol"));
 		remmina_protocol_widget_close_connection(gp);
 		return;
 	}
@@ -224,33 +216,26 @@ void remmina_protocol_widget_open_connection_real(gpointer data)
 
 	gp->priv->plugin = plugin;
 
-	for (num_plugin = 0, feature = (RemminaProtocolFeature*) plugin->features; feature && feature->type; num_plugin++, feature++)
-	{
+	for (num_plugin = 0, feature = (RemminaProtocolFeature*) plugin->features; feature && feature->type; num_plugin++, feature++) {
 	}
 
 	num_ssh = 0;
 #ifdef HAVE_LIBSSH
-	if (remmina_file_get_int(gp->priv->remmina_file, "ssh_enabled", FALSE))
-	{
+	if (remmina_file_get_int(gp->priv->remmina_file, "ssh_enabled", FALSE)) {
 		num_ssh += 2;
 	}
 #endif
-	if (num_plugin + num_ssh == 0)
-	{
+	if (num_plugin + num_ssh == 0) {
 		gp->priv->features = NULL;
-	}
-	else
-	{
+	} else {
 		gp->priv->features = g_new0(RemminaProtocolFeature, num_plugin + num_ssh + 1);
 		feature = gp->priv->features;
-		if (plugin->features)
-		{
+		if (plugin->features) {
 			memcpy(feature, plugin->features, sizeof(RemminaProtocolFeature) * num_plugin);
 			feature += num_plugin;
 		}
 #ifdef HAVE_LIBSSH
-		if (num_ssh)
-		{
+		if (num_ssh) {
 			feature->type = REMMINA_PROTOCOL_FEATURE_TYPE_TOOL;
 			feature->id = REMMINA_PROTOCOL_FEATURE_TOOL_SSH;
 			feature->opt1 = _("Open Secure Shell in New Terminal...");
@@ -267,8 +252,7 @@ void remmina_protocol_widget_open_connection_real(gpointer data)
 #endif
 	}
 
-	if (!plugin->open_connection(gp))
-	{
+	if (!plugin->open_connection(gp)) {
 		remmina_protocol_widget_close_connection(gp);
 	}
 }
@@ -301,32 +285,28 @@ gboolean remmina_protocol_widget_close_connection(RemminaProtocolWidget* gp)
 	display = gtk_widget_get_display(GTK_WIDGET(gp));
 	manager = gdk_display_get_device_manager(display);
 	device = gdk_device_manager_get_client_pointer(manager);
-	if (device != NULL)
-	{
+	if (device != NULL) {
 		gdk_device_ungrab(device, GDK_CURRENT_TIME);
 	}
 
-	if (gp->priv->chat_window)
-	{
+	if (gp->priv->chat_window) {
 		gtk_widget_destroy(gp->priv->chat_window);
 		gp->priv->chat_window = NULL;
 	}
 
-	if (!gp->priv->plugin || !gp->priv->plugin->close_connection)
-	{
+	if (!gp->priv->plugin || !gp->priv->plugin->close_connection) {
 		remmina_protocol_widget_emit_signal(gp, "disconnect");
 		return FALSE;
 	}
 
 	retval = gp->priv->plugin->close_connection(gp);
 
-	#ifdef HAVE_LIBSSH
-	if (gp->priv->ssh_tunnel)
-	{
+#ifdef HAVE_LIBSSH
+	if (gp->priv->ssh_tunnel) {
 		remmina_ssh_tunnel_free(gp->priv->ssh_tunnel);
 		gp->priv->ssh_tunnel = NULL;
 	}
-	#endif
+#endif
 
 	return retval;
 }
@@ -366,14 +346,12 @@ void remmina_protocol_widget_send_keystrokes(RemminaProtocolWidget* gp, GtkMenuI
 		{ NULL, NULL, 0 }
 	};
 	/* Keystrokes can be sent only to plugins that accepts them */
-	if (remmina_protocol_widget_plugin_receives_keystrokes(gp))
-	{
+	if (remmina_protocol_widget_plugin_receives_keystrokes(gp)) {
 		/* Replace special characters */
-		for (i = 0; keystrokes_replaces[i].replace; i++)
-		{
+		for (i = 0; keystrokes_replaces[i].replace; i++) {
 			remmina_public_str_replace_in_place(keystrokes,
-				keystrokes_replaces[i].search,
-				keystrokes_replaces[i].replace);
+												keystrokes_replaces[i].search,
+												keystrokes_replaces[i].replace);
 		}
 		keyvals = (guint *) g_malloc(strlen(keystrokes));
 		while(TRUE) {
@@ -383,10 +361,8 @@ void remmina_protocol_widget_send_keystrokes(RemminaProtocolWidget* gp, GtkMenuI
 				break;
 			keyval = gdk_unicode_to_keyval(character);
 			/* Replace all the special character with its keyval */
-			for (i = 0; keystrokes_replaces[i].replace; i++)
-			{
-				if (character == keystrokes_replaces[i].replace[0])
-				{
+			for (i = 0; keystrokes_replaces[i].replace; i++) {
+				if (character == keystrokes_replaces[i].replace[0]) {
 					keys = g_new0(GdkKeymapKey, 1);
 					keyval = keystrokes_replaces[i].keyval;
 					/* A special character was generated, no keyval lookup needed */
@@ -395,8 +371,7 @@ void remmina_protocol_widget_send_keystrokes(RemminaProtocolWidget* gp, GtkMenuI
 				}
 			}
 			/* Decode character if it's not a special character */
-			if (character)
-			{
+			if (character) {
 				/* get keyval without modifications */
 				if (!gdk_keymap_get_entries_for_keyval(keymap, keyval, &keys, &n_keys)) {
 					g_warning("keyval 0x%04x has no keycode!", keyval);
@@ -461,13 +436,11 @@ gboolean remmina_protocol_widget_query_feature_by_type(RemminaProtocolWidget* gp
 
 #ifdef HAVE_LIBSSH
 	if (type == REMMINA_PROTOCOL_FEATURE_TYPE_TOOL &&
-			remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE))
-	{
+			remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE)) {
 		return TRUE;
 	}
 #endif
-	for (feature = gp->priv->plugin->features; feature && feature->type; feature++)
-	{
+	for (feature = gp->priv->plugin->features; feature && feature->type; feature++) {
 		if (feature->type == type)
 			return TRUE;
 	}
@@ -485,10 +458,8 @@ void remmina_protocol_widget_call_feature_by_type(RemminaProtocolWidget* gp, Rem
 	TRACE_CALL("remmina_protocol_widget_call_feature_by_type");
 	const RemminaProtocolFeature *feature;
 
-	for (feature = gp->priv->plugin->features; feature && feature->type; feature++)
-	{
-		if (feature->type == type && (id == 0 || feature->id == id))
-		{
+	for (feature = gp->priv->plugin->features; feature && feature->type; feature++) {
+		if (feature->type == type && (id == 0 || feature->id == id)) {
 			remmina_protocol_widget_call_feature_by_ref(gp, feature);
 			break;
 		}
@@ -498,29 +469,26 @@ void remmina_protocol_widget_call_feature_by_type(RemminaProtocolWidget* gp, Rem
 void remmina_protocol_widget_call_feature_by_ref(RemminaProtocolWidget* gp, const RemminaProtocolFeature *feature)
 {
 	TRACE_CALL("remmina_protocol_widget_call_feature_by_ref");
-	switch (feature->id)
-	{
+	switch (feature->id) {
 #ifdef HAVE_LIBSSH
-		case REMMINA_PROTOCOL_FEATURE_TOOL_SSH:
-		if (gp->priv->ssh_tunnel)
-		{
+	case REMMINA_PROTOCOL_FEATURE_TOOL_SSH:
+		if (gp->priv->ssh_tunnel) {
 			remmina_connection_window_open_from_file_full (
-					remmina_file_dup_temp_protocol (gp->priv->remmina_file, "SSH"), NULL, gp->priv->ssh_tunnel, NULL);
+				remmina_file_dup_temp_protocol (gp->priv->remmina_file, "SSH"), NULL, gp->priv->ssh_tunnel, NULL);
 			return;
 		}
 		break;
 
-		case REMMINA_PROTOCOL_FEATURE_TOOL_SFTP:
-		if (gp->priv->ssh_tunnel)
-		{
+	case REMMINA_PROTOCOL_FEATURE_TOOL_SFTP:
+		if (gp->priv->ssh_tunnel) {
 			remmina_connection_window_open_from_file_full (
-					remmina_file_dup_temp_protocol (gp->priv->remmina_file, "SFTP"), NULL, gp->priv->ssh_tunnel, NULL);
+				remmina_file_dup_temp_protocol (gp->priv->remmina_file, "SFTP"), NULL, gp->priv->ssh_tunnel, NULL);
 			return;
 		}
 		break;
 #endif
-		default:
-			break;
+	default:
+		break;
 	}
 	gp->priv->plugin->call_feature(gp, feature);
 }
@@ -528,8 +496,7 @@ void remmina_protocol_widget_call_feature_by_ref(RemminaProtocolWidget* gp, cons
 static gboolean remmina_protocol_widget_on_key_press(GtkWidget *widget, GdkEventKey *event, RemminaProtocolWidget* gp)
 {
 	TRACE_CALL("remmina_protocol_widget_on_key_press");
-	if (gp->priv->hostkey_func)
-	{
+	if (gp->priv->hostkey_func) {
 		return gp->priv->hostkey_func(gp, event->keyval, FALSE, gp->priv->hostkey_func_data);
 	}
 	return FALSE;
@@ -538,8 +505,7 @@ static gboolean remmina_protocol_widget_on_key_press(GtkWidget *widget, GdkEvent
 static gboolean remmina_protocol_widget_on_key_release(GtkWidget *widget, GdkEventKey *event, RemminaProtocolWidget* gp)
 {
 	TRACE_CALL("remmina_protocol_widget_on_key_release");
-	if (gp->priv->hostkey_func)
-	{
+	if (gp->priv->hostkey_func) {
 		return gp->priv->hostkey_func(gp, event->keyval, TRUE, gp->priv->hostkey_func_data);
 	}
 	return FALSE;
@@ -567,25 +533,21 @@ static gboolean remmina_protocol_widget_init_tunnel (RemminaProtocolWidget* gp)
 	gint ret;
 
 	/* Reuse existing SSH connection if it's reconnecting to destination */
-	if (gp->priv->ssh_tunnel == NULL)
-	{
+	if (gp->priv->ssh_tunnel == NULL) {
 		tunnel = remmina_ssh_tunnel_new_from_file (gp->priv->remmina_file);
 
 		remmina_init_dialog_set_status (REMMINA_INIT_DIALOG (gp->priv->init_dialog),
-				_("Connecting to SSH server %s..."), REMMINA_SSH (tunnel)->server);
+										_("Connecting to SSH server %s..."), REMMINA_SSH (tunnel)->server);
 
-		if (!remmina_ssh_init_session (REMMINA_SSH (tunnel)))
-		{
+		if (!remmina_ssh_init_session (REMMINA_SSH (tunnel))) {
 			remmina_protocol_widget_set_error (gp, REMMINA_SSH (tunnel)->error);
 			remmina_ssh_tunnel_free (tunnel);
 			return FALSE;
 		}
 
 		ret = remmina_ssh_auth_gui (REMMINA_SSH (tunnel), REMMINA_INIT_DIALOG (gp->priv->init_dialog));
-		if (ret <= 0)
-		{
-			if (ret == 0)
-			{
+		if (ret <= 0) {
+			if (ret == 0) {
 				remmina_protocol_widget_set_error (gp, REMMINA_SSH (tunnel)->error);
 			}
 			remmina_ssh_tunnel_free (tunnel);
@@ -608,44 +570,38 @@ gchar* remmina_protocol_widget_start_direct_tunnel(RemminaProtocolWidget* gp, gi
 
 	server = remmina_file_get_string(gp->priv->remmina_file, "server");
 
-	if (!server)
-	{
+	if (!server) {
 		return g_strdup("");
 	}
 
 	remmina_public_get_server_port(server, default_port, &host, &port);
 
-	if (port_plus && port < 100)
-	{
+	if (port_plus && port < 100) {
 		/* Protocols like VNC supports using instance number :0, :1, etc as port number. */
 		port += default_port;
 	}
 
 #ifdef HAVE_LIBSSH
-	if (!remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE))
-	{
+	if (!remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE)) {
 		dest = g_strdup_printf("[%s]:%i", host, port);
 		g_free(host);
 		return dest;
 	}
 
-	if (!remmina_protocol_widget_init_tunnel (gp))
-	{
+	if (!remmina_protocol_widget_init_tunnel (gp)) {
 		g_free(host);
 		return NULL;
 	}
 
 	remmina_init_dialog_set_status (REMMINA_INIT_DIALOG (gp->priv->init_dialog),
-			_("Connecting to %s through SSH tunnel..."), server);
+									_("Connecting to %s through SSH tunnel..."), server);
 
-	if (remmina_file_get_int (gp->priv->remmina_file, "ssh_loopback", FALSE))
-	{
+	if (remmina_file_get_int (gp->priv->remmina_file, "ssh_loopback", FALSE)) {
 		g_free(host);
 		host = g_strdup ("127.0.0.1");
 	}
 
-	if (!remmina_ssh_tunnel_open (gp->priv->ssh_tunnel, host, port, remmina_pref.sshtunnel_port))
-	{
+	if (!remmina_ssh_tunnel_open (gp->priv->ssh_tunnel, host, port, remmina_pref.sshtunnel_port)) {
 		g_free(host);
 		remmina_protocol_widget_set_error (gp, REMMINA_SSH (gp->priv->ssh_tunnel)->error);
 		return NULL;
@@ -667,21 +623,18 @@ gboolean remmina_protocol_widget_start_reverse_tunnel(RemminaProtocolWidget* gp,
 {
 	TRACE_CALL("remmina_protocol_widget_start_reverse_tunnel");
 #ifdef HAVE_LIBSSH
-	if (!remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE))
-	{
+	if (!remmina_file_get_int (gp->priv->remmina_file, "ssh_enabled", FALSE)) {
 		return TRUE;
 	}
 
-	if (!remmina_protocol_widget_init_tunnel (gp))
-	{
+	if (!remmina_protocol_widget_init_tunnel (gp)) {
 		return FALSE;
 	}
 
 	remmina_init_dialog_set_status (REMMINA_INIT_DIALOG (gp->priv->init_dialog),
-			_("Waiting for an incoming SSH tunnel at port %i..."), remmina_file_get_int (gp->priv->remmina_file, "listenport", 0));
+									_("Waiting for an incoming SSH tunnel at port %i..."), remmina_file_get_int (gp->priv->remmina_file, "listenport", 0));
 
-	if (!remmina_ssh_tunnel_reverse (gp->priv->ssh_tunnel, remmina_file_get_int (gp->priv->remmina_file, "listenport", 0), local_port))
-	{
+	if (!remmina_ssh_tunnel_reverse (gp->priv->ssh_tunnel, remmina_file_get_int (gp->priv->remmina_file, "listenport", 0), local_port)) {
 		remmina_protocol_widget_set_error (gp, REMMINA_SSH (gp->priv->ssh_tunnel)->error);
 		return FALSE;
 	}
@@ -694,64 +647,56 @@ gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wa
 {
 	TRACE_CALL("remmina_protocol_widget_ssh_exec");
 #ifdef HAVE_LIBSSH
-		RemminaSSHTunnel *tunnel = gp->priv->ssh_tunnel;
-		ssh_channel channel;
-		gint status;
-		gboolean ret = FALSE;
-		gchar *cmd, *ptr;
-		va_list args;
+	RemminaSSHTunnel *tunnel = gp->priv->ssh_tunnel;
+	ssh_channel channel;
+	gint status;
+	gboolean ret = FALSE;
+	gchar *cmd, *ptr;
+	va_list args;
 
-		if ((channel = ssh_channel_new (REMMINA_SSH (tunnel)->session)) == NULL)
-		{
-			return FALSE;
-		}
+	if ((channel = ssh_channel_new (REMMINA_SSH (tunnel)->session)) == NULL) {
+		return FALSE;
+	}
 
-		va_start (args, fmt);
-		cmd = g_strdup_vprintf (fmt, args);
-		va_end (args);
+	va_start (args, fmt);
+	cmd = g_strdup_vprintf (fmt, args);
+	va_end (args);
 
-		if (ssh_channel_open_session (channel) == SSH_OK &&
-				ssh_channel_request_exec (channel, cmd) == SSH_OK)
-		{
-			if (wait)
-			{
-				ssh_channel_send_eof (channel);
-				status = ssh_channel_get_exit_status (channel);
-				ptr = strchr (cmd, ' ');
-				if (ptr) *ptr = '\0';
-				switch (status)
-				{
-					case 0:
-						ret = TRUE;
-						break;
-					case 127:
-						remmina_ssh_set_application_error (REMMINA_SSH (tunnel),
-								_("Command %s not found on SSH server"), cmd);
-						break;
-					default:
-						remmina_ssh_set_application_error (REMMINA_SSH (tunnel),
-								_("Command %s failed on SSH server (status = %i)."), cmd,status);
-						break;
-				}
-			}
-			else
-			{
+	if (ssh_channel_open_session (channel) == SSH_OK &&
+			ssh_channel_request_exec (channel, cmd) == SSH_OK) {
+		if (wait) {
+			ssh_channel_send_eof (channel);
+			status = ssh_channel_get_exit_status (channel);
+			ptr = strchr (cmd, ' ');
+			if (ptr) *ptr = '\0';
+			switch (status) {
+			case 0:
 				ret = TRUE;
+				break;
+			case 127:
+				remmina_ssh_set_application_error (REMMINA_SSH (tunnel),
+												   _("Command %s not found on SSH server"), cmd);
+				break;
+			default:
+				remmina_ssh_set_application_error (REMMINA_SSH (tunnel),
+												   _("Command %s failed on SSH server (status = %i)."), cmd,status);
+				break;
 			}
+		} else {
+			ret = TRUE;
 		}
-		else
-		{
-			remmina_ssh_set_error (REMMINA_SSH (tunnel), _("Failed to execute command: %s"));
-		}
-		g_free(cmd);
-		if (wait)
-			ssh_channel_close (channel);
-		ssh_channel_free (channel);
-		return ret;
+	} else {
+		remmina_ssh_set_error (REMMINA_SSH (tunnel), _("Failed to execute command: %s"));
+	}
+	g_free(cmd);
+	if (wait)
+		ssh_channel_close (channel);
+	ssh_channel_free (channel);
+	return ret;
 
 #else
 
-		return FALSE;
+	return FALSE;
 
 #endif
 }
@@ -784,8 +729,7 @@ static gboolean remmina_protocol_widget_tunnel_disconnect_callback(RemminaSSHTun
 	TRACE_CALL("remmina_protocol_widget_tunnel_disconnect_callback");
 	RemminaProtocolWidget* gp = REMMINA_PROTOCOL_WIDGET (data);
 
-	if (REMMINA_SSH (tunnel)->error)
-	{
+	if (REMMINA_SSH (tunnel)->error) {
 		remmina_protocol_widget_set_error (gp, "%s", REMMINA_SSH (tunnel)->error);
 	}
 
@@ -804,7 +748,7 @@ gboolean remmina_protocol_widget_start_xport_tunnel(RemminaProtocolWidget* gp, R
 	if (!remmina_protocol_widget_init_tunnel (gp)) return FALSE;
 
 	remmina_init_dialog_set_status (REMMINA_INIT_DIALOG (gp->priv->init_dialog),
-			_("Connecting to %s through SSH tunnel..."), remmina_file_get_string (gp->priv->remmina_file, "server"));
+									_("Connecting to %s through SSH tunnel..."), remmina_file_get_string (gp->priv->remmina_file, "server"));
 
 	gp->priv->init_func = init_func;
 	gp->priv->ssh_tunnel->init_func = remmina_protocol_widget_tunnel_init_callback;
@@ -816,10 +760,9 @@ gboolean remmina_protocol_widget_start_xport_tunnel(RemminaProtocolWidget* gp, R
 	bindlocalhost = (g_strcmp0(REMMINA_SSH (gp->priv->ssh_tunnel)->server, server) == 0);
 	g_free(server);
 
-	if (!remmina_ssh_tunnel_xport (gp->priv->ssh_tunnel, bindlocalhost))
-	{
+	if (!remmina_ssh_tunnel_xport (gp->priv->ssh_tunnel, bindlocalhost)) {
 		remmina_protocol_widget_set_error (gp, "Failed to open channel : %s",
-				ssh_get_error (REMMINA_SSH (gp->priv->ssh_tunnel)->session));
+										   ssh_get_error (REMMINA_SSH (gp->priv->ssh_tunnel)->session));
 		return FALSE;
 	}
 
@@ -939,28 +882,27 @@ gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget* gp, RemminaAuth
 	gchar* s;
 	gint ret;
 
-	switch (authpwd_type)
-	{
-		case REMMINA_AUTHPWD_TYPE_PROTOCOL:
-			s = g_strdup_printf(_("%s password"), remmina_file_get_string(remminafile, "protocol"));
-			break;
-		case REMMINA_AUTHPWD_TYPE_SSH_PWD:
-			s = g_strdup(_("SSH password"));
-			break;
-		case REMMINA_AUTHPWD_TYPE_SSH_PRIVKEY:
-			s = g_strdup(_("SSH private key passphrase"));
-			break;
-		default:
-			s = g_strdup(_("Password"));
-			break;
+	switch (authpwd_type) {
+	case REMMINA_AUTHPWD_TYPE_PROTOCOL:
+		s = g_strdup_printf(_("%s password"), remmina_file_get_string(remminafile, "protocol"));
+		break;
+	case REMMINA_AUTHPWD_TYPE_SSH_PWD:
+		s = g_strdup(_("SSH password"));
+		break;
+	case REMMINA_AUTHPWD_TYPE_SSH_PRIVKEY:
+		s = g_strdup(_("SSH private key passphrase"));
+		break;
+	default:
+		s = g_strdup(_("Password"));
+		break;
 	}
 	ret = remmina_init_dialog_authpwd(
-			REMMINA_INIT_DIALOG(gp->priv->init_dialog),
-			s,
-			remmina_file_get_filename(remminafile) != NULL &&
-				allow_password_saving &&
-				authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PWD &&
-				authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PRIVKEY);
+			  REMMINA_INIT_DIALOG(gp->priv->init_dialog),
+			  s,
+			  remmina_file_get_filename(remminafile) != NULL &&
+			  allow_password_saving &&
+			  authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PWD &&
+			  authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PRIVKEY);
 	g_free(s);
 
 	return ret;
@@ -972,11 +914,11 @@ gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolea
 	RemminaFile* remminafile = gp->priv->remmina_file;
 
 	return remmina_init_dialog_authuserpwd(
-		REMMINA_INIT_DIALOG(gp->priv->init_dialog),
-		want_domain,
-		remmina_file_get_string(remminafile, "username"),
-		want_domain ? remmina_file_get_string(remminafile, "domain") : NULL,
-		(remmina_file_get_filename(remminafile) != NULL) && allow_password_saving);
+			   REMMINA_INIT_DIALOG(gp->priv->init_dialog),
+			   want_domain,
+			   remmina_file_get_string(remminafile, "username"),
+			   want_domain ? remmina_file_get_string(remminafile, "domain") : NULL,
+			   (remmina_file_get_filename(remminafile) != NULL) && allow_password_saving);
 }
 
 gint remmina_protocol_widget_init_certificate(RemminaProtocolWidget* gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint)
@@ -1020,8 +962,8 @@ gint remmina_protocol_widget_init_authx509(RemminaProtocolWidget* gp)
 	RemminaFile* remminafile = gp->priv->remmina_file;
 
 	return remmina_init_dialog_authx509(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
-			remmina_file_get_string(remminafile, "cacert"), remmina_file_get_string(remminafile, "cacrl"),
-			remmina_file_get_string(remminafile, "clientcert"), remmina_file_get_string(remminafile, "clientkey"));
+										remmina_file_get_string(remminafile, "cacert"), remmina_file_get_string(remminafile, "cacrl"),
+										remmina_file_get_string(remminafile, "clientcert"), remmina_file_get_string(remminafile, "clientkey"));
 }
 
 gchar* remmina_protocol_widget_init_get_cacert(RemminaProtocolWidget* gp)
@@ -1081,42 +1023,35 @@ void remmina_protocol_widget_init_save_cred(RemminaProtocolWidget* gp)
 
 	/* Save user name and certificates if any; save the password if it's requested to do so */
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->username;
-	if (s && s[0])
-	{
+	if (s && s[0]) {
 		remmina_file_set_string(remminafile, "username", s);
 		save = TRUE;
 	}
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->cacert;
-	if (s && s[0])
-	{
+	if (s && s[0]) {
 		remmina_file_set_string(remminafile, "cacert", s);
 		save = TRUE;
 	}
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->cacrl;
-	if (s && s[0])
-	{
+	if (s && s[0]) {
 		remmina_file_set_string(remminafile, "cacrl", s);
 		save = TRUE;
 	}
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->clientcert;
-	if (s && s[0])
-	{
+	if (s && s[0]) {
 		remmina_file_set_string(remminafile, "clientcert", s);
 		save = TRUE;
 	}
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->clientkey;
-	if (s && s[0])
-	{
+	if (s && s[0]) {
 		remmina_file_set_string(remminafile, "clientkey", s);
 		save = TRUE;
 	}
-	if (REMMINA_INIT_DIALOG(gp->priv->init_dialog)->save_password)
-	{
+	if (REMMINA_INIT_DIALOG(gp->priv->init_dialog)->save_password) {
 		remmina_file_set_string(remminafile, "password", REMMINA_INIT_DIALOG(gp->priv->init_dialog)->password);
 		save = TRUE;
 	}
-	if (save)
-	{
+	if (save) {
 		remmina_file_save_group(remminafile, REMMINA_SETTING_GROUP_CREDENTIAL);
 	}
 }
@@ -1126,15 +1061,15 @@ void remmina_protocol_widget_init_show_listen(RemminaProtocolWidget* gp, gint po
 {
 	TRACE_CALL("remmina_protocol_widget_init_show_listen");
 	remmina_init_dialog_set_status(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
-			_("Listening on port %i for an incoming %s connection..."), port,
-			remmina_file_get_string(gp->priv->remmina_file, "protocol"));
+								   _("Listening on port %i for an incoming %s connection..."), port,
+								   remmina_file_get_string(gp->priv->remmina_file, "protocol"));
 }
 
 void remmina_protocol_widget_init_show_retry(RemminaProtocolWidget* gp)
 {
 	TRACE_CALL("remmina_protocol_widget_init_show_retry");
 	remmina_init_dialog_set_status_temp(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
-			_("Authentication failed. Trying to reconnect..."));
+										_("Authentication failed. Trying to reconnect..."));
 }
 
 void remmina_protocol_widget_init_show(RemminaProtocolWidget* gp)
@@ -1156,19 +1091,16 @@ static void remmina_protocol_widget_chat_on_destroy(RemminaProtocolWidget* gp)
 }
 
 void remmina_protocol_widget_chat_open(RemminaProtocolWidget* gp, const gchar *name,
-		void(*on_send)(RemminaProtocolWidget* gp, const gchar *text), void(*on_destroy)(RemminaProtocolWidget* gp))
+									   void(*on_send)(RemminaProtocolWidget* gp, const gchar *text), void(*on_destroy)(RemminaProtocolWidget* gp))
 {
 	TRACE_CALL("remmina_protocol_widget_chat_open");
-	if (gp->priv->chat_window)
-	{
+	if (gp->priv->chat_window) {
 		gtk_window_present(GTK_WINDOW(gp->priv->chat_window));
-	}
-	else
-	{
+	} else {
 		gp->priv->chat_window = remmina_chat_window_new(GTK_WINDOW(gtk_widget_get_toplevel(GTK_WIDGET(gp))), name);
 		g_signal_connect_swapped(G_OBJECT(gp->priv->chat_window), "send", G_CALLBACK(on_send), gp);
 		g_signal_connect_swapped(G_OBJECT(gp->priv->chat_window), "destroy",
-				G_CALLBACK(remmina_protocol_widget_chat_on_destroy), gp);
+								 G_CALLBACK(remmina_protocol_widget_chat_on_destroy), gp);
 		g_signal_connect_swapped(G_OBJECT(gp->priv->chat_window), "destroy", G_CALLBACK(on_destroy), gp);
 		gtk_widget_show(gp->priv->chat_window);
 	}
@@ -1177,8 +1109,7 @@ void remmina_protocol_widget_chat_open(RemminaProtocolWidget* gp, const gchar *n
 void remmina_protocol_widget_chat_close(RemminaProtocolWidget* gp)
 {
 	TRACE_CALL("remmina_protocol_widget_chat_close");
-	if (gp->priv->chat_window)
-	{
+	if (gp->priv->chat_window) {
 		gtk_widget_destroy(gp->priv->chat_window);
 	}
 }
@@ -1188,8 +1119,7 @@ void remmina_protocol_widget_chat_receive(RemminaProtocolWidget* gp, const gchar
 	TRACE_CALL("remmina_protocol_widget_chat_receive");
 	/* This function can be called from a non main thread */
 
-	if (gp->priv->chat_window)
-	{
+	if (gp->priv->chat_window) {
 		if ( !remmina_masterthread_exec_is_main_thread() ) {
 			/* Allow the execution of this function from a non main thread */
 			RemminaMTExecData *d;
@@ -1234,8 +1164,7 @@ void remmina_protocol_widget_send_keys_signals(GtkWidget *widget, const guint *k
 	if (action & GDK_KEY_PRESS) {
 		/* Press the requested buttons */
 		event.type = GDK_KEY_PRESS;
-		for (i = 0; i < keyvals_length; i++)
-		{
+		for (i = 0; i < keyvals_length; i++) {
 			event.keyval = keyvals[i];
 			event.hardware_keycode = remmina_public_get_keycode_for_keyval(keymap, event.keyval);
 			event.is_modifier = (int) remmina_public_get_modifier_for_keycode(keymap, event.hardware_keycode);
@@ -1246,8 +1175,7 @@ void remmina_protocol_widget_send_keys_signals(GtkWidget *widget, const guint *k
 	if (action & GDK_KEY_RELEASE) {
 		/* Release the requested buttons in reverse order */
 		event.type = GDK_KEY_RELEASE;
-		for (i = (keyvals_length - 1); i >= 0; i--)
-		{
+		for (i = (keyvals_length - 1); i >= 0; i--) {
 			event.keyval = keyvals[i];
 			event.hardware_keycode = remmina_public_get_keycode_for_keyval(keymap, event.keyval);
 			event.is_modifier = (int) remmina_public_get_modifier_for_keycode(keymap, event.hardware_keycode);

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -701,7 +701,7 @@ gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wa
 		gchar *cmd, *ptr;
 		va_list args;
 
-		if ((channel = channel_new (REMMINA_SSH (tunnel)->session)) == NULL)
+		if ((channel = ssh_channel_new (REMMINA_SSH (tunnel)->session)) == NULL)
 		{
 			return FALSE;
 		}
@@ -710,13 +710,13 @@ gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wa
 		cmd = g_strdup_vprintf (fmt, args);
 		va_end (args);
 
-		if (channel_open_session (channel) == SSH_OK &&
-				channel_request_exec (channel, cmd) == SSH_OK)
+		if (ssh_channel_open_session (channel) == SSH_OK &&
+				ssh_channel_request_exec (channel, cmd) == SSH_OK)
 		{
 			if (wait)
 			{
-				channel_send_eof (channel);
-				status = channel_get_exit_status (channel);
+				ssh_channel_send_eof (channel);
+				status = ssh_channel_get_exit_status (channel);
 				ptr = strchr (cmd, ' ');
 				if (ptr) *ptr = '\0';
 				switch (status)
@@ -745,8 +745,8 @@ gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wa
 		}
 		g_free(cmd);
 		if (wait)
-			channel_close (channel);
-		channel_free (channel);
+			ssh_channel_close (channel);
+		ssh_channel_free (channel);
 		return ret;
 
 #else

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -80,8 +80,7 @@
 #define LOCK_SSH(ssh) pthread_mutex_lock (&REMMINA_SSH (ssh)->ssh_mutex);
 #define UNLOCK_SSH(ssh) pthread_mutex_unlock (&REMMINA_SSH (ssh)->ssh_mutex);
 
-static const gchar *common_identities[] =
-{
+static const gchar *common_identities[] = {
 	".ssh/id_rsa",
 	".ssh/id_dsa",
 	".ssh/identity",
@@ -104,11 +103,9 @@ remmina_ssh_find_identity (void)
 	gchar *path;
 	gint i;
 
-	for (i = 0; common_identities[i]; i++)
-	{
+	for (i = 0; common_identities[i]; i++) {
 		path = remmina_ssh_identity_path (common_identities[i]);
-		if (g_file_test (path, G_FILE_TEST_IS_REGULAR | G_FILE_TEST_EXISTS))
-		{
+		if (g_file_test (path, G_FILE_TEST_IS_REGULAR | G_FILE_TEST_EXISTS)) {
 			return path;
 		}
 		g_free(path);
@@ -151,23 +148,18 @@ remmina_ssh_auth_password (RemminaSSH *ssh)
 	if (ssh->password == NULL) return -1;
 
 	authlist = ssh_userauth_list (ssh->session, NULL);
-	if (authlist & SSH_AUTH_METHOD_INTERACTIVE)
-	{
-		while ((ret = ssh_userauth_kbdint (ssh->session, NULL, NULL)) == SSH_AUTH_INFO)
-		{
+	if (authlist & SSH_AUTH_METHOD_INTERACTIVE) {
+		while ((ret = ssh_userauth_kbdint (ssh->session, NULL, NULL)) == SSH_AUTH_INFO) {
 			n = ssh_userauth_kbdint_getnprompts (ssh->session);
-			for (i = 0; i < n; i++)
-			{
+			for (i = 0; i < n; i++) {
 				ssh_userauth_kbdint_setanswer(ssh->session, i, ssh->password);
 			}
 		}
 	}
-	if (ret != SSH_AUTH_SUCCESS && authlist & SSH_AUTH_METHOD_PASSWORD)
-	{
+	if (ret != SSH_AUTH_SUCCESS && authlist & SSH_AUTH_METHOD_PASSWORD) {
 		ret = ssh_userauth_password (ssh->session, NULL, ssh->password);
 	}
-	if (ret != SSH_AUTH_SUCCESS)
-	{
+	if (ret != SSH_AUTH_SUCCESS) {
 		remmina_ssh_set_error (ssh, _("SSH password authentication failed: %s"));
 		return 0;
 	}
@@ -185,16 +177,14 @@ remmina_ssh_auth_pubkey (RemminaSSH *ssh)
 
 	if (ssh->authenticated) return 1;
 
-	if (ssh->privkeyfile == NULL)
-	{
+	if (ssh->privkeyfile == NULL) {
 		ssh->error = g_strdup_printf(_("SSH public key authentication failed: %s"),
-				_("SSH Key file not yet set."));
+									 _("SSH Key file not yet set."));
 		return 0;
 	}
 
 	if ( ssh_pki_import_privkey_file( ssh->privkeyfile, (ssh->password ? ssh->password : ""),
-		NULL, NULL, &priv_key ) != SSH_OK )
-	{
+									  NULL, NULL, &priv_key ) != SSH_OK ) {
 		if (ssh->password == NULL || ssh->password[0] == '\0') return -1;
 
 		remmina_ssh_set_error (ssh, _("SSH public key authentication failed: %s"));
@@ -204,8 +194,7 @@ remmina_ssh_auth_pubkey (RemminaSSH *ssh)
 	ret = ssh_userauth_publickey (ssh->session, NULL, priv_key);
 	ssh_key_free(priv_key);
 
-	if (ret != SSH_AUTH_SUCCESS)
-	{
+	if (ret != SSH_AUTH_SUCCESS) {
 		remmina_ssh_set_error (ssh, _("SSH public key authentication failed: %s"));
 		return 0;
 	}
@@ -221,8 +210,7 @@ remmina_ssh_auth_auto_pubkey (RemminaSSH* ssh)
 	gint ret;
 	ret = ssh_userauth_autopubkey (ssh->session, "");
 
-	if (ret != SSH_AUTH_SUCCESS)
-	{
+	if (ret != SSH_AUTH_SUCCESS) {
 		remmina_ssh_set_error (ssh, _("SSH automatic public key authentication failed: %s"));
 		return 0;
 	}
@@ -237,31 +225,28 @@ remmina_ssh_auth (RemminaSSH *ssh, const gchar *password)
 	TRACE_CALL("remmina_ssh_auth");
 	/* Check known host again to ensure it's still the original server when user forks
 	 a new session from existing one */
-	if (ssh_is_server_known (ssh->session) != SSH_SERVER_KNOWN_OK)
-	{
+	if (ssh_is_server_known (ssh->session) != SSH_SERVER_KNOWN_OK) {
 		remmina_ssh_set_application_error (ssh, "SSH public key has changed!");
 		return 0;
 	}
 
-	if (password)
-	{
+	if (password) {
 		g_free(ssh->password);
 		ssh->password = g_strdup (password);
 	}
 
-	switch (ssh->auth)
-	{
+	switch (ssh->auth) {
 
-		case SSH_AUTH_PASSWORD:
+	case SSH_AUTH_PASSWORD:
 		return remmina_ssh_auth_password (ssh);
 
-		case SSH_AUTH_PUBLICKEY:
+	case SSH_AUTH_PUBLICKEY:
 		return remmina_ssh_auth_pubkey (ssh);
 
-		case SSH_AUTH_AUTO_PUBLICKEY:
+	case SSH_AUTH_AUTO_PUBLICKEY:
 		return remmina_ssh_auth_auto_pubkey (ssh);
 
-		default:
+	default:
 		return 0;
 	}
 }
@@ -279,46 +264,41 @@ remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog)
 
 	/* Check if the server's public key is known */
 	ret = ssh_is_server_known (ssh->session);
-	switch (ret)
-	{
-		case SSH_SERVER_KNOWN_OK:
-			break;
+	switch (ret) {
+	case SSH_SERVER_KNOWN_OK:
+		break;
 
-		case SSH_SERVER_NOT_KNOWN:
-		case SSH_SERVER_FILE_NOT_FOUND:
-		case SSH_SERVER_KNOWN_CHANGED:
-		case SSH_SERVER_FOUND_OTHER:
-			if ( ssh_get_publickey(ssh->session, &server_pubkey) != SSH_OK )
-			{
-				remmina_ssh_set_error(ssh, "ssh_get_publickey() has failed: %s");
-				return 0;
-			}
-			if ( ssh_get_publickey_hash(server_pubkey, SSH_PUBLICKEY_HASH_MD5, &pubkey, &len) != 0 ) {
-				ssh_key_free(server_pubkey);
-				remmina_ssh_set_error(ssh, "ssh_get_publickey_hash() has failed: %s");
-				return 0;
-			}
+	case SSH_SERVER_NOT_KNOWN:
+	case SSH_SERVER_FILE_NOT_FOUND:
+	case SSH_SERVER_KNOWN_CHANGED:
+	case SSH_SERVER_FOUND_OTHER:
+		if ( ssh_get_publickey(ssh->session, &server_pubkey) != SSH_OK ) {
+			remmina_ssh_set_error(ssh, "ssh_get_publickey() has failed: %s");
+			return 0;
+		}
+		if ( ssh_get_publickey_hash(server_pubkey, SSH_PUBLICKEY_HASH_MD5, &pubkey, &len) != 0 ) {
 			ssh_key_free(server_pubkey);
-			keyname = ssh_get_hexa (pubkey, len);
+			remmina_ssh_set_error(ssh, "ssh_get_publickey_hash() has failed: %s");
+			return 0;
+		}
+		ssh_key_free(server_pubkey);
+		keyname = ssh_get_hexa (pubkey, len);
 
 
-			if (ret == SSH_SERVER_NOT_KNOWN || ret == SSH_SERVER_FILE_NOT_FOUND)
-			{
-				ret = remmina_init_dialog_serverkey_unknown (dialog, keyname);
-			}
-			else
-			{
-				ret = remmina_init_dialog_serverkey_changed (dialog, keyname);
-			}
+		if (ret == SSH_SERVER_NOT_KNOWN || ret == SSH_SERVER_FILE_NOT_FOUND) {
+			ret = remmina_init_dialog_serverkey_unknown (dialog, keyname);
+		} else {
+			ret = remmina_init_dialog_serverkey_changed (dialog, keyname);
+		}
 
-			ssh_string_free_char(keyname);
-			ssh_clean_pubkey_hash (&pubkey);
-			if (ret != GTK_RESPONSE_OK) return -1;
-			ssh_write_knownhost (ssh->session);
-			break;
-		case SSH_SERVER_ERROR:
-		default:
-			remmina_ssh_set_error (ssh, "SSH known host checking failed: %s");
+		ssh_string_free_char(keyname);
+		ssh_clean_pubkey_hash (&pubkey);
+		if (ret != GTK_RESPONSE_OK) return -1;
+		ssh_write_knownhost (ssh->session);
+		break;
+	case SSH_SERVER_ERROR:
+	default:
+		remmina_ssh_set_error (ssh, "SSH known host checking failed: %s");
 		return 0;
 	}
 
@@ -327,26 +307,23 @@ remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog)
 	if (ret > 0) return 1;
 
 	/* Requested for a non-empty password */
-	if (ret < 0)
-	{
+	if (ret < 0) {
 		if (!dialog) return -1;
 
-		switch (ssh->auth)
-		{
-			case SSH_AUTH_PASSWORD:
+		switch (ssh->auth) {
+		case SSH_AUTH_PASSWORD:
 			tips = _("Authenticating %s's password to SSH server %s...");
 			keyname = _("SSH password");
 			break;
-			case SSH_AUTH_PUBLICKEY:
+		case SSH_AUTH_PUBLICKEY:
 			tips = _("Authenticating %s's identity to SSH server %s...");
 			keyname = _("SSH private key passphrase");
 			break;
-			default:
+		default:
 			return FALSE;
 		}
 
-		if (ssh->auth != SSH_AUTH_AUTO_PUBLICKEY)
-		{
+		if (ssh->auth != SSH_AUTH_AUTO_PUBLICKEY) {
 			remmina_init_dialog_set_status (dialog, tips, ssh->user, ssh->server);
 			ret = remmina_init_dialog_authpwd (dialog, keyname, FALSE);
 
@@ -355,8 +332,7 @@ remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog)
 		ret = remmina_ssh_auth (ssh, dialog->password);
 	}
 
-	if (ret <= 0)
-	{
+	if (ret <= 0) {
 		return 0;
 	}
 
@@ -384,8 +360,7 @@ remmina_ssh_init_session (RemminaSSH *ssh)
 	ssh_options_set (ssh->session, SSH_OPTIONS_HOST, ssh->server);
 	ssh_options_set (ssh->session, SSH_OPTIONS_PORT, &ssh->port);
 	ssh_options_set (ssh->session, SSH_OPTIONS_USER, ssh->user);
-	if (remmina_log_running ())
-	{
+	if (remmina_log_running ()) {
 		verbosity = remmina_pref.ssh_loglevel;
 		ssh_options_set (ssh->session, SSH_OPTIONS_LOG_VERBOSITY, &verbosity);
 		ssh->callback->log_function = remmina_ssh_log_callback;
@@ -395,15 +370,13 @@ remmina_ssh_init_session (RemminaSSH *ssh)
 
 	/* As the latest parse the ~/.ssh/config file */
 	ssh_options_parse_config(ssh->session, NULL);
-	if (ssh_connect (ssh->session))
-	{
+	if (ssh_connect (ssh->session)) {
 		remmina_ssh_set_error (ssh, _("Failed to startup SSH session: %s"));
 		return FALSE;
 	}
 
 	/* Try the "none" authentication */
-	if (ssh_userauth_none (ssh->session, NULL) == SSH_AUTH_SUCCESS)
-	{
+	if (ssh_userauth_none (ssh->session, NULL) == SSH_AUTH_SUCCESS) {
 		ssh->authenticated = TRUE;
 	}
 	return TRUE;
@@ -430,22 +403,16 @@ remmina_ssh_init_from_file (RemminaSSH *ssh, RemminaFile *remminafile)
 	ssh_username = remmina_file_get_string (remminafile, "ssh_username");
 	ssh_privatekey = remmina_file_get_string (remminafile, "ssh_privatekey");
 	server = remmina_file_get_string (remminafile, "server");
-	if (ssh_server)
-	{
+	if (ssh_server) {
 		remmina_public_get_server_port (ssh_server, 22, &ssh->server, &ssh->port);
-		if (ssh->server[0] == '\0')
-		{
+		if (ssh->server[0] == '\0') {
 			g_free(ssh->server);
 			remmina_public_get_server_port (server, 0, &ssh->server, NULL);
 		}
-	}
-	else if (server == NULL)
-	{
+	} else if (server == NULL) {
 		ssh->server = g_strdup ("localhost");
 		ssh->port = 22;
-	}
-	else
-	{
+	} else {
 		remmina_public_get_server_port (server, 0, &ssh->server, NULL);
 		ssh->port = 22;
 	}
@@ -457,13 +424,10 @@ remmina_ssh_init_from_file (RemminaSSH *ssh, RemminaFile *remminafile)
 
 	/* Public/Private keys */
 	s = (ssh_privatekey ? g_strdup (ssh_privatekey) : remmina_ssh_find_identity ());
-	if (s)
-	{
+	if (s) {
 		ssh->privkeyfile = remmina_ssh_identity_path (s);
 		g_free(s);
-	}
-	else
-	{
+	} else {
 		ssh->privkeyfile = NULL;
 	}
 
@@ -496,8 +460,7 @@ remmina_ssh_convert (RemminaSSH *ssh, const gchar *from)
 	TRACE_CALL("remmina_ssh_convert");
 	gchar *to = NULL;
 
-	if (ssh->charset && from)
-	{
+	if (ssh->charset && from) {
 		to = g_convert (from, -1, "UTF-8", ssh->charset, NULL, NULL, NULL);
 	}
 	if (!to) to = g_strdup (from);
@@ -510,8 +473,7 @@ remmina_ssh_unconvert (RemminaSSH *ssh, const gchar *from)
 	TRACE_CALL("remmina_ssh_unconvert");
 	gchar *to = NULL;
 
-	if (ssh->charset && from)
-	{
+	if (ssh->charset && from) {
 		to = g_convert (from, -1, ssh->charset, "UTF-8", NULL, NULL, NULL);
 	}
 	if (!to) to = g_strdup (from);
@@ -522,8 +484,7 @@ void
 remmina_ssh_free (RemminaSSH *ssh)
 {
 	TRACE_CALL("remmina_ssh_free");
-	if (ssh->session)
-	{
+	if (ssh->session) {
 		ssh_free (ssh->session);
 		ssh->session = NULL;
 	}
@@ -539,8 +500,7 @@ remmina_ssh_free (RemminaSSH *ssh)
 }
 
 /*************************** SSH Tunnel *********************************/
-struct _RemminaSSHTunnelBuffer
-{
+struct _RemminaSSHTunnelBuffer {
 	gchar *data;
 	gchar *ptr;
 	ssize_t len;
@@ -563,8 +523,7 @@ static void
 remmina_ssh_tunnel_buffer_free (RemminaSSHTunnelBuffer *buffer)
 {
 	TRACE_CALL("remmina_ssh_tunnel_buffer_free");
-	if (buffer)
-	{
+	if (buffer) {
 		g_free(buffer->data);
 		g_free(buffer);
 	}
@@ -611,8 +570,7 @@ remmina_ssh_tunnel_close_all_channels (RemminaSSHTunnel *tunnel)
 	TRACE_CALL("remmina_ssh_tunnel_close_all_channels");
 	int i;
 
-	for (i = 0; i < tunnel->num_channels; i++)
-	{
+	for (i = 0; i < tunnel->num_channels; i++) {
 		close (tunnel->sockets[i]);
 		remmina_ssh_tunnel_buffer_free (tunnel->socketbuffers[i]);
 		ssh_channel_close (tunnel->channels[i]);
@@ -629,8 +587,7 @@ remmina_ssh_tunnel_close_all_channels (RemminaSSHTunnel *tunnel)
 	tunnel->num_channels = 0;
 	tunnel->max_channels = 0;
 
-	if (tunnel->x11_channel)
-	{
+	if (tunnel->x11_channel) {
 		ssh_channel_close (tunnel->x11_channel);
 		ssh_channel_free (tunnel->x11_channel);
 		tunnel->x11_channel = NULL;
@@ -661,19 +618,18 @@ remmina_ssh_tunnel_add_channel (RemminaSSHTunnel *tunnel, ssh_channel channel, g
 	gint i;
 
 	i = tunnel->num_channels++;
-	if (tunnel->num_channels > tunnel->max_channels)
-	{
+	if (tunnel->num_channels > tunnel->max_channels) {
 		/* Allocate an extra NULL pointer in channels for ssh_select */
 		tunnel->channels = (ssh_channel*) g_realloc (tunnel->channels,
-				sizeof (ssh_channel) * (tunnel->num_channels + 1));
+						   sizeof (ssh_channel) * (tunnel->num_channels + 1));
 		tunnel->sockets = (gint*) g_realloc (tunnel->sockets,
-				sizeof (gint) * tunnel->num_channels);
+											 sizeof (gint) * tunnel->num_channels);
 		tunnel->socketbuffers = (RemminaSSHTunnelBuffer**) g_realloc (tunnel->socketbuffers,
-				sizeof (RemminaSSHTunnelBuffer*) * tunnel->num_channels);
+								sizeof (RemminaSSHTunnelBuffer*) * tunnel->num_channels);
 		tunnel->max_channels = tunnel->num_channels;
 
 		tunnel->channels_out = (ssh_channel*) g_realloc (tunnel->channels_out,
-				sizeof (ssh_channel) * (tunnel->num_channels + 1));
+							   sizeof (ssh_channel) * (tunnel->num_channels + 1));
 	}
 	tunnel->channels[i] = channel;
 	tunnel->channels[i + 1] = NULL;
@@ -707,28 +663,24 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 	g_get_current_time (&t1);
 	t2 = t1;
 
-	switch (tunnel->tunnel_type)
-	{
-		case REMMINA_SSH_TUNNEL_OPEN:
+	switch (tunnel->tunnel_type) {
+	case REMMINA_SSH_TUNNEL_OPEN:
 		/* Accept a local connection */
 		sock = accept (tunnel->server_sock, NULL, NULL);
-		if (sock < 0)
-		{
+		if (sock < 0) {
 			REMMINA_SSH (tunnel)->error = g_strdup ("Failed to accept local socket");
 			tunnel->thread = 0;
 			return NULL;
 		}
 
-		if ((channel = ssh_channel_new (tunnel->ssh.session)) == NULL)
-		{
+		if ((channel = ssh_channel_new (tunnel->ssh.session)) == NULL) {
 			close (sock);
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), "Failed to createt channel : %s");
 			tunnel->thread = 0;
 			return NULL;
 		}
 		/* Request the SSH server to connect to the destination */
-		if (ssh_channel_open_forward (channel, tunnel->dest, tunnel->port, "127.0.0.1", 0) != SSH_OK)
-		{
+		if (ssh_channel_open_forward (channel, tunnel->dest, tunnel->port, "127.0.0.1", 0) != SSH_OK) {
 			close (sock);
 			ssh_channel_close (channel);
 			ssh_channel_free (channel);
@@ -739,15 +691,13 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		remmina_ssh_tunnel_add_channel (tunnel, channel, sock);
 		break;
 
-		case REMMINA_SSH_TUNNEL_X11:
-		if ((tunnel->x11_channel = ssh_channel_new (tunnel->ssh.session)) == NULL)
-		{
+	case REMMINA_SSH_TUNNEL_X11:
+		if ((tunnel->x11_channel = ssh_channel_new (tunnel->ssh.session)) == NULL) {
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), "Failed to create channel : %s");
 			tunnel->thread = 0;
 			return NULL;
 		}
-		if (!remmina_public_get_xauth_cookie (tunnel->localdisplay, &ptr))
-		{
+		if (!remmina_public_get_xauth_cookie (tunnel->localdisplay, &ptr)) {
 			remmina_ssh_set_application_error (REMMINA_SSH (tunnel), "%s", ptr);
 			g_free(ptr);
 			tunnel->thread = 0;
@@ -755,16 +705,14 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		}
 		if (ssh_channel_open_session (tunnel->x11_channel) ||
 				ssh_channel_request_x11 (tunnel->x11_channel, TRUE, NULL, ptr,
-						gdk_screen_get_number (gdk_screen_get_default ())))
-		{
+										 gdk_screen_get_number (gdk_screen_get_default ()))) {
 			g_free(ptr);
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), "Failed to open channel : %s");
 			tunnel->thread = 0;
 			return NULL;
 		}
 		g_free(ptr);
-		if (ssh_channel_request_exec (tunnel->x11_channel, tunnel->dest))
-		{
+		if (ssh_channel_request_exec (tunnel->x11_channel, tunnel->dest)) {
 			ptr = g_strdup_printf(_("Failed to execute %s on SSH server : %%s"), tunnel->dest);
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), ptr);
 			g_free(ptr);
@@ -773,10 +721,8 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		}
 
 		if (tunnel->init_func &&
-				! (*tunnel->init_func) (tunnel, tunnel->callback_data))
-		{
-			if (tunnel->disconnect_func)
-			{
+				! (*tunnel->init_func) (tunnel, tunnel->callback_data)) {
+			if (tunnel->disconnect_func) {
 				(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 			}
 			tunnel->thread = 0;
@@ -785,26 +731,20 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 
 		break;
 
-		case REMMINA_SSH_TUNNEL_XPORT:
+	case REMMINA_SSH_TUNNEL_XPORT:
 		/* Detect the next available port starting from 6010 on the server */
-		for (i = 10; i <= MAX_X_DISPLAY_NUMBER; i++)
-		{
+		for (i = 10; i <= MAX_X_DISPLAY_NUMBER; i++) {
 			if (ssh_channel_listen_forward (REMMINA_SSH (tunnel)->session,
-							(tunnel->bindlocalhost ? "localhost" : NULL), 6000 + i, NULL))
-			{
+											(tunnel->bindlocalhost ? "localhost" : NULL), 6000 + i, NULL)) {
 				continue;
-			}
-			else
-			{
+			} else {
 				tunnel->remotedisplay = i;
 				break;
 			}
 		}
-		if (tunnel->remotedisplay < 1)
-		{
+		if (tunnel->remotedisplay < 1) {
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), _("Failed to request port forwarding : %s"));
-			if (tunnel->disconnect_func)
-			{
+			if (tunnel->disconnect_func) {
 				(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 			}
 			tunnel->thread = 0;
@@ -812,10 +752,8 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		}
 
 		if (tunnel->init_func &&
-				! (*tunnel->init_func) (tunnel, tunnel->callback_data))
-		{
-			if (tunnel->disconnect_func)
-			{
+				! (*tunnel->init_func) (tunnel, tunnel->callback_data)) {
+			if (tunnel->disconnect_func) {
 				(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 			}
 			tunnel->thread = 0;
@@ -824,12 +762,10 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 
 		break;
 
-		case REMMINA_SSH_TUNNEL_REVERSE:
-		if (ssh_channel_listen_forward (REMMINA_SSH (tunnel)->session, NULL, tunnel->port, NULL))
-		{
+	case REMMINA_SSH_TUNNEL_REVERSE:
+		if (ssh_channel_listen_forward (REMMINA_SSH (tunnel)->session, NULL, tunnel->port, NULL)) {
 			remmina_ssh_set_error (REMMINA_SSH (tunnel), _("Failed to request port forwarding : %s"));
-			if (tunnel->disconnect_func)
-			{
+			if (tunnel->disconnect_func) {
 				(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 			}
 			tunnel->thread = 0;
@@ -837,10 +773,8 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		}
 
 		if (tunnel->init_func &&
-				! (*tunnel->init_func) (tunnel, tunnel->callback_data))
-		{
-			if (tunnel->disconnect_func)
-			{
+				! (*tunnel->init_func) (tunnel, tunnel->callback_data)) {
+			if (tunnel->disconnect_func) {
 				(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 			}
 			tunnel->thread = 0;
@@ -854,93 +788,68 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 	tunnel->buffer = g_malloc (tunnel->buffer_len);
 
 	/* Start the tunnel data transmittion */
-	while (tunnel->running)
-	{
+	while (tunnel->running) {
 		if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_XPORT ||
 				tunnel->tunnel_type == REMMINA_SSH_TUNNEL_X11 ||
-				tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE)
-		{
-			if (first)
-			{
+				tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE) {
+			if (first) {
 				first = FALSE;
 				/* Wait for a period of time for the first incoming connection */
-				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_X11)
-				{
+				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_X11) {
 					channel = ssh_channel_accept_x11 (tunnel->x11_channel, 15000);
-				}
-				else
-				{
+				} else {
 					channel = ssh_channel_accept_forward (REMMINA_SSH (tunnel)->session, 15000, &tunnel->port);
 				}
-				if (!channel)
-				{
+				if (!channel) {
 					remmina_ssh_set_application_error (REMMINA_SSH (tunnel), _("No response from the server."));
-					if (tunnel->disconnect_func)
-					{
+					if (tunnel->disconnect_func) {
 						(*tunnel->disconnect_func) (tunnel, tunnel->callback_data);
 					}
 					tunnel->thread = 0;
 					return NULL;
 				}
-				if (tunnel->connect_func)
-				{
+				if (tunnel->connect_func) {
 					(*tunnel->connect_func) (tunnel, tunnel->callback_data);
 				}
-				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE)
-				{
+				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE) {
 					/* For reverse tunnel, we only need one connection. */
 					ssh_channel_cancel_forward (REMMINA_SSH (tunnel)->session, NULL, tunnel->port);
 				}
-			}
-			else if (tunnel->tunnel_type != REMMINA_SSH_TUNNEL_REVERSE)
-			{
+			} else if (tunnel->tunnel_type != REMMINA_SSH_TUNNEL_REVERSE) {
 				/* Poll once per some period of time if no incoming connections.
 				 * Don't try to poll continuously as it will significantly slow down the loop */
 				g_get_current_time (&t1);
 				diff = (t1.tv_sec - t2.tv_sec) * 10 + (t1.tv_usec - t2.tv_usec) / 100000;
-				if (diff > 1)
-				{
-					if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_X11)
-					{
+				if (diff > 1) {
+					if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_X11) {
 						channel = ssh_channel_accept_x11 (tunnel->x11_channel, 0);
-					}
-					else
-					{
+					} else {
 						channel = ssh_channel_accept_forward (REMMINA_SSH (tunnel)->session, 0, &tunnel->port);
 					}
-					if (channel == NULL)
-					{
+					if (channel == NULL) {
 						t2 = t1;
 					}
 				}
 			}
 
-			if (channel)
-			{
-				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE)
-				{
+			if (channel) {
+				if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_REVERSE) {
 					sin.sin_family = AF_INET;
 					sin.sin_port = htons (tunnel->localport);
 					sin.sin_addr.s_addr = inet_addr ("127.0.0.1");
 					sock = socket (AF_INET, SOCK_STREAM, 0);
-					if (connect (sock, (struct sockaddr *) &sin, sizeof (sin)) < 0)
-					{
+					if (connect (sock, (struct sockaddr *) &sin, sizeof (sin)) < 0) {
 						remmina_ssh_set_application_error (REMMINA_SSH (tunnel),
-								"Cannot connect to local port %i.", tunnel->localport);
+														   "Cannot connect to local port %i.", tunnel->localport);
 						close (sock);
 						sock = -1;
 					}
-				}
-				else
-				{
+				} else {
 					sock = remmina_public_open_xdisplay (tunnel->localdisplay);
 				}
-				if (sock >= 0)
-				{
+				if (sock >= 0) {
 					remmina_ssh_tunnel_add_channel (tunnel, channel, sock);
-				}
-				else
-				{
+				} else {
 					/* Failed to create unix socket. Will this happen? */
 					ssh_channel_close (channel);
 					ssh_channel_free (channel);
@@ -949,8 +858,7 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 			}
 		}
 
-		if (tunnel->num_channels <= 0)
-		{
+		if (tunnel->num_channels <= 0) {
 			/* No more connections. We should quit */
 			break;
 		}
@@ -960,10 +868,8 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 
 		FD_ZERO (&set);
 		maxfd = 0;
-		for (i = 0; i < tunnel->num_channels; i++)
-		{
-			if (tunnel->sockets[i] > maxfd)
-			{
+		for (i = 0; i < tunnel->num_channels; i++) {
+			if (tunnel->sockets[i] > maxfd) {
 				maxfd = tunnel->sockets[i];
 			}
 			FD_SET (tunnel->sockets[i], &set);
@@ -975,19 +881,14 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		if (ret == -1) break;
 
 		i = 0;
-		while (tunnel->running && i < tunnel->num_channels)
-		{
+		while (tunnel->running && i < tunnel->num_channels) {
 			disconnected = FALSE;
-			if (FD_ISSET (tunnel->sockets[i], &set))
-			{
+			if (FD_ISSET (tunnel->sockets[i], &set)) {
 				while (!disconnected &&
-						(len = read (tunnel->sockets[i], tunnel->buffer, tunnel->buffer_len)) > 0)
-				{
-					for (ptr = tunnel->buffer, lenw = 0; len > 0; len -= lenw, ptr += lenw)
-					{
+						(len = read (tunnel->sockets[i], tunnel->buffer, tunnel->buffer_len)) > 0) {
+					for (ptr = tunnel->buffer, lenw = 0; len > 0; len -= lenw, ptr += lenw) {
 						lenw = ssh_channel_write (tunnel->channels[i], (char*) ptr, len);
-						if (lenw <= 0)
-						{
+						if (lenw <= 0) {
 							disconnected = TRUE;
 							break;
 						}
@@ -995,8 +896,7 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 				}
 				if (len == 0) disconnected = TRUE;
 			}
-			if (disconnected)
-			{
+			if (disconnected) {
 				remmina_ssh_tunnel_remove_channel (tunnel, i);
 				continue;
 			}
@@ -1005,60 +905,46 @@ remmina_ssh_tunnel_main_thread_proc (gpointer data)
 		if (!tunnel->running) break;
 
 		i = 0;
-		while (tunnel->running && i < tunnel->num_channels)
-		{
+		while (tunnel->running && i < tunnel->num_channels) {
 			disconnected = FALSE;
 
-			if (!tunnel->socketbuffers[i])
-			{
+			if (!tunnel->socketbuffers[i]) {
 				len = ssh_channel_poll (tunnel->channels[i], 0);
-				if (len == SSH_ERROR || len == SSH_EOF)
-				{
+				if (len == SSH_ERROR || len == SSH_EOF) {
 					disconnected = TRUE;
-				}
-				else if (len > 0)
-				{
+				} else if (len > 0) {
 					tunnel->socketbuffers[i] = remmina_ssh_tunnel_buffer_new (len);
 					len = ssh_channel_read_nonblocking (tunnel->channels[i], tunnel->socketbuffers[i]->data, len, 0);
-					if (len <= 0)
-					{
+					if (len <= 0) {
 						disconnected = TRUE;
-					}
-					else
-					{
+					} else {
 						tunnel->socketbuffers[i]->len = len;
 					}
 				}
 			}
 
-			if (!disconnected && tunnel->socketbuffers[i])
-			{
+			if (!disconnected && tunnel->socketbuffers[i]) {
 				for (lenw = 0; tunnel->socketbuffers[i]->len > 0;
-						tunnel->socketbuffers[i]->len -= lenw, tunnel->socketbuffers[i]->ptr += lenw)
-				{
+						tunnel->socketbuffers[i]->len -= lenw, tunnel->socketbuffers[i]->ptr += lenw) {
 					lenw = write (tunnel->sockets[i], tunnel->socketbuffers[i]->ptr, tunnel->socketbuffers[i]->len);
-					if (lenw == -1 && errno == EAGAIN && tunnel->running)
-					{
+					if (lenw == -1 && errno == EAGAIN && tunnel->running) {
 						/* Sometimes we cannot write to a socket (always EAGAIN), probably because it's internal
 						 * buffer is full. We need read the pending bytes from the socket first. so here we simply
 						 * break, leave the buffer there, and continue with other data */
 						break;
 					}
-					if (lenw <= 0)
-					{
+					if (lenw <= 0) {
 						disconnected = TRUE;
 						break;
 					}
 				}
-				if (tunnel->socketbuffers[i]->len <= 0)
-				{
+				if (tunnel->socketbuffers[i]->len <= 0) {
 					remmina_ssh_tunnel_buffer_free (tunnel->socketbuffers[i]);
 					tunnel->socketbuffers[i] = NULL;
 				}
 			}
 
-			if (disconnected)
-			{
+			if (disconnected) {
 				remmina_ssh_tunnel_remove_channel (tunnel, i);
 				continue;
 			}
@@ -1079,8 +965,7 @@ remmina_ssh_tunnel_main_thread (gpointer data)
 
 	pthread_setcancelstate (PTHREAD_CANCEL_ENABLE, NULL);
 
-	while (TRUE)
-	{
+	while (TRUE) {
 		remmina_ssh_tunnel_main_thread_proc (data);
 		if (tunnel->server_sock < 0 || tunnel->thread == 0 || !tunnel->running) break;
 	}
@@ -1092,8 +977,7 @@ void
 remmina_ssh_tunnel_cancel_accept (RemminaSSHTunnel *tunnel)
 {
 	TRACE_CALL("remmina_ssh_tunnel_cancel_accept");
-	if (tunnel->server_sock >= 0)
-	{
+	if (tunnel->server_sock >= 0) {
 		close (tunnel->server_sock);
 		tunnel->server_sock = -1;
 	}
@@ -1110,16 +994,14 @@ remmina_ssh_tunnel_open (RemminaSSHTunnel* tunnel, const gchar *host, gint port,
 	tunnel->tunnel_type = REMMINA_SSH_TUNNEL_OPEN;
 	tunnel->dest = g_strdup (host);
 	tunnel->port = port;
-	if (tunnel->port == 0)
-	{
+	if (tunnel->port == 0) {
 		REMMINA_SSH (tunnel)->error = g_strdup ("Destination port has not been assigned");
 		return FALSE;
 	}
 
 	/* Create the server socket that listens on the local port */
 	sock = socket (AF_INET, SOCK_STREAM, 0);
-	if (sock < 0)
-	{
+	if (sock < 0) {
 		REMMINA_SSH (tunnel)->error = g_strdup ("Failed to create socket.");
 		return FALSE;
 	}
@@ -1129,15 +1011,13 @@ remmina_ssh_tunnel_open (RemminaSSHTunnel* tunnel, const gchar *host, gint port,
 	sin.sin_port = htons (local_port);
 	sin.sin_addr.s_addr = inet_addr ("127.0.0.1");
 
-	if (bind (sock, (struct sockaddr *) &sin, sizeof(sin)))
-	{
+	if (bind (sock, (struct sockaddr *) &sin, sizeof(sin))) {
 		REMMINA_SSH (tunnel)->error = g_strdup ("Failed to bind on local port.");
 		close (sock);
 		return FALSE;
 	}
 
-	if (listen (sock, 1))
-	{
+	if (listen (sock, 1)) {
 		REMMINA_SSH (tunnel)->error = g_strdup ("Failed to listen on local port.");
 		close (sock);
 		return FALSE;
@@ -1146,8 +1026,7 @@ remmina_ssh_tunnel_open (RemminaSSHTunnel* tunnel, const gchar *host, gint port,
 	tunnel->server_sock = sock;
 	tunnel->running = TRUE;
 
-	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel))
-	{
+	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel)) {
 		remmina_ssh_set_application_error (REMMINA_SSH (tunnel), "Failed to initialize pthread.");
 		tunnel->thread = 0;
 		return FALSE;
@@ -1163,8 +1042,7 @@ remmina_ssh_tunnel_x11 (RemminaSSHTunnel *tunnel, const gchar *cmd)
 	tunnel->dest = g_strdup (cmd);
 	tunnel->running = TRUE;
 
-	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel))
-	{
+	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel)) {
 		remmina_ssh_set_application_error (REMMINA_SSH (tunnel), "Failed to initialize pthread.");
 		tunnel->thread = 0;
 		return FALSE;
@@ -1180,8 +1058,7 @@ remmina_ssh_tunnel_xport (RemminaSSHTunnel *tunnel, gboolean bindlocalhost)
 	tunnel->bindlocalhost = bindlocalhost;
 	tunnel->running = TRUE;
 
-	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel))
-	{
+	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel)) {
 		remmina_ssh_set_application_error (REMMINA_SSH (tunnel), "Failed to initialize pthread.");
 		tunnel->thread = 0;
 		return FALSE;
@@ -1198,8 +1075,7 @@ remmina_ssh_tunnel_reverse (RemminaSSHTunnel *tunnel, gint port, gint local_port
 	tunnel->localport = local_port;
 	tunnel->running = TRUE;
 
-	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel))
-	{
+	if (pthread_create (&tunnel->thread, NULL, remmina_ssh_tunnel_main_thread, tunnel)) {
 		remmina_ssh_set_application_error (REMMINA_SSH (tunnel), "Failed to initialize pthread.");
 		tunnel->thread = 0;
 		return FALSE;
@@ -1221,21 +1097,18 @@ remmina_ssh_tunnel_free (RemminaSSHTunnel* tunnel)
 	pthread_t thread;
 
 	thread = tunnel->thread;
-	if (thread != 0)
-	{
+	if (thread != 0) {
 		tunnel->running = FALSE;
 		pthread_cancel (thread);
 		pthread_join (thread, NULL);
 		tunnel->thread = 0;
 	}
 
-	if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_XPORT && tunnel->remotedisplay > 0)
-	{
+	if (tunnel->tunnel_type == REMMINA_SSH_TUNNEL_XPORT && tunnel->remotedisplay > 0) {
 		ssh_channel_cancel_forward (REMMINA_SSH (tunnel)->session,
-				NULL, 6000 + tunnel->remotedisplay);
+									NULL, 6000 + tunnel->remotedisplay);
 	}
-	if (tunnel->server_sock >= 0)
-	{
+	if (tunnel->server_sock >= 0) {
 		close (tunnel->server_sock);
 		tunnel->server_sock = -1;
 	}
@@ -1286,13 +1159,11 @@ remmina_sftp_open (RemminaSFTP *sftp)
 {
 	TRACE_CALL("remmina_sftp_open");
 	sftp->sftp_sess = sftp_new (sftp->ssh.session);
-	if (!sftp->sftp_sess)
-	{
+	if (!sftp->sftp_sess) {
 		remmina_ssh_set_error (REMMINA_SSH (sftp), _("Failed to create sftp session: %s"));
 		return FALSE;
 	}
-	if (sftp_init (sftp->sftp_sess))
-	{
+	if (sftp_init (sftp->sftp_sess)) {
 		remmina_ssh_set_error (REMMINA_SSH (sftp), _("Failed to initialize sftp session: %s"));
 		return FALSE;
 	}
@@ -1303,8 +1174,7 @@ void
 remmina_sftp_free (RemminaSFTP *sftp)
 {
 	TRACE_CALL("remmina_sftp_free");
-	if (sftp->sftp_sess)
-	{
+	if (sftp->sftp_sess) {
 		sftp_free (sftp->sftp_sess);
 		sftp->sftp_sess = NULL;
 	}
@@ -1374,8 +1244,7 @@ remmina_ssh_shell_thread (gpointer data)
 	LOCK_SSH (shell)
 
 	if ((channel = ssh_channel_new (REMMINA_SSH (shell)->session)) == NULL ||
-			ssh_channel_open_session (channel))
-	{
+			ssh_channel_open_session (channel)) {
 		UNLOCK_SSH (shell)
 		remmina_ssh_set_error (REMMINA_SSH (shell), "Failed to open channel : %s");
 		if (channel) ssh_channel_free (channel);
@@ -1384,16 +1253,12 @@ remmina_ssh_shell_thread (gpointer data)
 	}
 
 	ssh_channel_request_pty (channel);
-	if (shell->exec && shell->exec[0])
-	{
+	if (shell->exec && shell->exec[0]) {
 		ret = ssh_channel_request_exec (channel, shell->exec);
-	}
-	else
-	{
+	} else {
 		ret = ssh_channel_request_shell (channel);
 	}
-	if (ret)
-	{
+	if (ret) {
 		UNLOCK_SSH (shell)
 		remmina_ssh_set_error (REMMINA_SSH (shell), "Failed to request shell : %s");
 		ssh_channel_close (channel);
@@ -1412,8 +1277,7 @@ remmina_ssh_shell_thread (gpointer data)
 	ch[0] = channel;
 	ch[1] = NULL;
 
-	while (!shell->closed)
-	{
+	while (!shell->closed) {
 		timeout.tv_sec = 1;
 		timeout.tv_usec = 0;
 
@@ -1424,40 +1288,34 @@ remmina_ssh_shell_thread (gpointer data)
 		if (ret == SSH_EINTR) continue;
 		if (ret == -1) break;
 
-		if (FD_ISSET (shell->master, &fds))
-		{
+		if (FD_ISSET (shell->master, &fds)) {
 			len = read (shell->master, buf, buf_len);
 			if (len <= 0) break;
 			LOCK_SSH (shell)
 			ssh_channel_write (channel, buf, len);
 			UNLOCK_SSH (shell)
 		}
-		for (i = 0; i < 2; i++)
-		{
+		for (i = 0; i < 2; i++) {
 			LOCK_SSH (shell)
 			len = ssh_channel_poll (channel, i);
 			UNLOCK_SSH (shell)
-			if (len == SSH_ERROR || len == SSH_EOF)
-			{
+			if (len == SSH_ERROR || len == SSH_EOF) {
 				shell->closed = TRUE;
 				break;
 			}
 			if (len <= 0) continue;
-			if (len > buf_len)
-			{
+			if (len > buf_len) {
 				buf_len = len;
 				buf = (gchar*) g_realloc (buf, buf_len + 1);
 			}
 			LOCK_SSH (shell)
 			len = ssh_channel_read_nonblocking (channel, buf, len, i);
 			UNLOCK_SSH (shell)
-			if (len <= 0)
-			{
+			if (len <= 0) {
 				shell->closed = TRUE;
 				break;
 			}
-			while (len > 0)
-			{
+			while (len > 0) {
 				ret = write (shell->master, buf, len);
 				if (ret <= 0) break;
 				len -= ret;
@@ -1474,8 +1332,7 @@ remmina_ssh_shell_thread (gpointer data)
 	g_free(buf);
 	shell->thread = 0;
 
-	if ( shell->exit_callback )
-	{
+	if ( shell->exit_callback ) {
 		IDLE_ADD ((GSourceFunc) remmina_ssh_call_exit_callback_on_main_thread, (gpointer)shell );
 	}
 	return NULL;
@@ -1494,8 +1351,7 @@ remmina_ssh_shell_open (RemminaSSHShell *shell, RemminaSSHExitFunc exit_callback
 			grantpt (shell->master) == -1 ||
 			unlockpt (shell->master) == -1 ||
 			(slavedevice = ptsname (shell->master)) == NULL ||
-			(shell->slave = open (slavedevice, O_RDWR | O_NOCTTY)) < 0)
-	{
+			(shell->slave = open (slavedevice, O_RDWR | O_NOCTTY)) < 0) {
 		REMMINA_SSH (shell)->error = g_strdup ("Failed to create pty device.");
 		return FALSE;
 	}
@@ -1520,8 +1376,7 @@ remmina_ssh_shell_set_size (RemminaSSHShell *shell, gint columns, gint rows)
 {
 	TRACE_CALL("remmina_ssh_shell_set_size");
 	LOCK_SSH (shell)
-	if (shell->channel)
-	{
+	if (shell->channel) {
 		ssh_channel_change_pty_size (shell->channel, columns, rows);
 	}
 	UNLOCK_SSH (shell)
@@ -1534,14 +1389,12 @@ remmina_ssh_shell_free (RemminaSSHShell *shell)
 	pthread_t thread = shell->thread;
 
 	shell->exit_callback = NULL;
-	if (thread)
-	{
+	if (thread) {
 		shell->closed = TRUE;
 		pthread_join (thread, NULL);
 	}
 	close (shell->master);
-	if (shell->exec)
-	{
+	if (shell->exec) {
 		g_free(shell->exec);
 		shell->exec = NULL;
 	}


### PR DESCRIPTION
in the libssh project they have changed all the function names in order to avoid name clashing.

As the libssh documentation doesn't provide since which version/date they have introduced a new function name, this merge request can impact some distributions.

You have to test ssh connections and any connections through a SSH tunnel.

The migration is still an in progress task, don't merge till will be finished.