### PR TITLE
Disable wayland backend 

### DIFF
--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -267,6 +267,8 @@ int main(int argc, char* argv[])
 	GApplicationClass *app_class;
 	int status;
 
+	gdk_set_allowed_backends("x11,broadway,quartz");
+
 	remmina_masterthread_exec_save_main_thread_id();
 
 	bindtextdomain(GETTEXT_PACKAGE, REMMINA_LOCALEDIR);


### PR DESCRIPTION
This is a temporary patch to disable wayland. It will be rolled back as soon as we will adapt remmina to work with wayland.

closes #677, closes #671, closes #672, closes #673, closes #674, closes #675, closes #676
