### PR TITLE
Reduce main window icons size fixes #701

### DIFF
--- a/remmina/ui/remmina_main.glade
+++ b/remmina/ui/remmina_main.glade
@@ -911,7 +911,7 @@
                     <property name="sort_column_id">1</property>
                     <child>
                       <object class="GtkCellRendererPixbuf" id="renderer_files_list_icon">
-                        <property name="stock_size">3</property>
+                        <property name="stock_size">2</property>
                       </object>
                       <attributes>
                         <attribute name="icon-name">0</attribute>


### PR DESCRIPTION
Icons in the main window are bigger than their original size making the icons looks ugly.