### PR TITLE
Exit keep sessions open preference

### DIFF
--- a/remmina/src/remmina_exec.c
+++ b/remmina/src/remmina_exec.c
@@ -39,6 +39,7 @@
 #include <stdlib.h>
 #include "remmina_main.h"
 #include "remmina_widget_pool.h"
+#include "remmina_pref.h"
 #include "remmina_pref_dialog.h"
 #include "remmina_file.h"
 #include "remmina_file_editor.h"
@@ -62,11 +63,13 @@ void remmina_exec_exitremmina()
 
 	int n;
 
-	/* Destroy all widgets, main window included */
-	n = remmina_widget_pool_foreach(cb_closewidget, NULL);
-
-	/* Remove systray menu */
-	remmina_icon_destroy();
+	if (!remmina_pref.exit_keep_sessions_open) {
+		/* Destroy all widgets, main window included */
+		n = remmina_widget_pool_foreach(cb_closewidget, NULL);
+	
+		/* Remove systray menu */
+		remmina_icon_destroy();
+	}
 
 	/* Exit from Remmina */
 	gtk_main_quit();

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -519,6 +519,7 @@ void remmina_pref_save(void)
 
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "save_view_mode", remmina_pref.save_view_mode);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "save_when_connect", remmina_pref.save_when_connect);
+	g_key_file_set_boolean(gkeyfile, "remmina_pref", "exit_keep_sessions_open", remmina_pref.exit_keep_sessions_open);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "invisible_toolbar", remmina_pref.invisible_toolbar);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "floating_toolbar_placement", remmina_pref.floating_toolbar_placement);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "toolbar_placement", remmina_pref.toolbar_placement);

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -198,6 +198,11 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.save_when_connect = TRUE;
 
+	if (g_key_file_has_key(gkeyfile, "remmina_pref", "exit_keep_sessions_open", NULL))
+		remmina_pref.exit_keep_sessions_open = g_key_file_get_boolean(gkeyfile, "remmina_pref", "exit_keep_sessions_open", NULL);
+	else
+		remmina_pref.exit_keep_sessions_open = FALSE;
+
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "invisible_toolbar", NULL))
 		remmina_pref.invisible_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "invisible_toolbar", NULL);
 	else

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -90,6 +90,7 @@ typedef struct _RemminaPref
 	/* In RemminaPrefDialog options tab */
 	gboolean save_view_mode;
 	gboolean save_when_connect;
+	gboolean exit_keep_sessions_open;
 	gint default_action;
 	gint scale_quality;
 	gint ssh_loglevel;

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -125,6 +125,7 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 
 	remmina_pref.save_view_mode = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode));
 	remmina_pref.save_when_connect = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_save_settings));
+	remmina_pref.exit_keep_sessions_open = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_exit_keep_sessions_open));
 	remmina_pref.invisible_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_invisible_toolbar));
 	remmina_pref.always_show_tab = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs));
 	remmina_pref.hide_connection_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar));
@@ -281,6 +282,7 @@ static void remmina_pref_dialog_init(void)
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode), remmina_pref.save_view_mode);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_save_settings), remmina_pref.save_when_connect);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_exit_keep_sessions_open), remmina_pref.exit_keep_sessions_open);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_invisible_toolbar), remmina_pref.invisible_toolbar);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs), remmina_pref.always_show_tab);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar), remmina_pref.hide_connection_toolbar);
@@ -380,6 +382,7 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 
 	remmina_pref_dialog->checkbutton_options_remember_last_view_mode = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_options_remember_last_view_mode"));
 	remmina_pref_dialog->checkbutton_options_save_settings = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_options_save_settings"));
+	remmina_pref_dialog->checkbutton_options_exit_keep_sessions_open = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_options_exit_keep_sessions_open"));
 	remmina_pref_dialog->checkbutton_appearance_invisible_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_invisible_toolbar"));
 	remmina_pref_dialog->checkbutton_appearance_show_tabs = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_show_tabs"));
 	remmina_pref_dialog->checkbutton_appearance_hide_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_hide_toolbar"));

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -52,6 +52,7 @@ typedef struct _RemminaPrefDialog
 
 	GtkCheckButton *checkbutton_options_remember_last_view_mode;
 	GtkCheckButton *checkbutton_options_save_settings;
+	GtkCheckButton *checkbutton_options_exit_keep_sessions_open;
 	GtkCheckButton *checkbutton_appearance_invisible_toolbar;
 	GtkCheckButton *checkbutton_appearance_show_tabs;
 	GtkCheckButton *checkbutton_appearance_hide_toolbar;

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -97,6 +97,21 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkCheckButton" id="checkbutton_options_exit_keep_sessions_open">
+                        <property name="label" translatable="yes">Keep sessions open when closing main window</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="xalign">0</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">2</property>
+                        <property name="width">3</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkLabel" id="label_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -105,7 +120,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">3</property>
                       </packing>
                     </child>
                     <child>
@@ -120,7 +135,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">3</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -133,7 +148,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
@@ -150,7 +165,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">4</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -163,7 +178,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -174,7 +189,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -187,7 +202,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -198,7 +213,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -211,7 +226,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -223,7 +238,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -236,7 +251,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">2</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">9</property>
                       </packing>
                     </child>
                     <child>
@@ -248,7 +263,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">10</property>
                       </packing>
                     </child>
                     <child>
@@ -261,7 +276,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">10</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -274,7 +289,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">10</property>
+                        <property name="top_attach">11</property>
                       </packing>
                     </child>
                     <child>
@@ -287,7 +302,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">10</property>
+                        <property name="top_attach">11</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -302,7 +317,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
@@ -321,7 +336,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -334,7 +349,7 @@
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
Personally I missed the old "closing the main window but keep the other windows alive" way Remmina worked. Therefor I added the option "Keep sessions open when closing main window", which by default is false (the current behavior), but when enabled it doesn't close the other windows.