### PR TITLE
XDG - make remmina user data dir global

### DIFF
--- a/remmina-plugins/tool_hello_world/plugin.c
+++ b/remmina-plugins/tool_hello_world/plugin.c
@@ -107,7 +107,6 @@ static RemminaProtocolPlugin remmina_plugin = {
 	NULL,                                    // Send a keystroke    */
 };
 
-
 G_MODULE_EXPORT gboolean remmina_plugin_entry(RemminaPluginService *service)
 {
 	TRACE_CALL("remmina_plugin_entry");

--- a/remmina/include/remmina/plugin.h
+++ b/remmina/include/remmina/plugin.h
@@ -197,6 +197,8 @@ typedef struct _RemminaPluginService
     void         (* protocol_plugin_chat_receive)         (RemminaProtocolWidget *gp, const gchar *text);
     void         (* protocol_plugin_send_keys_signals)    (GtkWidget *widget, const guint *keyvals, int length, GdkEventType action);
 
+    gchar*       (* file_get_user_datadir)                (void);
+
     RemminaFile* (* file_new)                             (void);
     const gchar* (* file_get_path)                        (RemminaFile *remminafile);
     void         (* file_set_string)                      (RemminaFile *remminafile, const gchar *setting, const gchar *value);

--- a/remmina/src/remmina_applet_menu.c
+++ b/remmina/src/remmina_applet_menu.c
@@ -60,8 +60,6 @@ enum
 static guint remmina_applet_menu_signals[LAST_SIGNAL] =
 { 0 };
 
-gchar remminadir[MAX_PATH_LEN];
-
 static void remmina_applet_menu_destroy(RemminaAppletMenu *menu, gpointer data)
 {
 	TRACE_CALL("remmina_applet_menu_destroy");
@@ -275,7 +273,7 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 	GDir *dir;
 	const gchar *name;
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 	if (dir != NULL)
 	{
 		/* Iterate all remote desktop profiles */
@@ -283,7 +281,7 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 		{
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
-			g_snprintf(filename, sizeof(filename), "%s/%s", remminadir, name);
+			g_snprintf(filename, sizeof(filename), "%s/%s", remmina_file_get_user_datadir(), name);
 
 			menuitem = remmina_applet_menu_item_new(REMMINA_APPLET_MENU_ITEM_FILE, filename);
 			if (menuitem != NULL)

--- a/remmina/src/remmina_applet_menu.c
+++ b/remmina/src/remmina_applet_menu.c
@@ -33,13 +33,16 @@
  *
  */
 
+#include "config.h"
+
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <string.h>
-#include "config.h"
+
 #include "remmina_public.h"
 #include "remmina_applet_menu_item.h"
 #include "remmina_applet_menu.h"
+#include "remmina_file_manager.h"
 #include "remmina/remmina_trace_calls.h"
 
 G_DEFINE_TYPE( RemminaAppletMenu, remmina_applet_menu, GTK_TYPE_MENU)
@@ -56,6 +59,8 @@ enum
 
 static guint remmina_applet_menu_signals[LAST_SIGNAL] =
 { 0 };
+
+gchar remminadir[MAX_PATH_LEN];
 
 static void remmina_applet_menu_destroy(RemminaAppletMenu *menu, gpointer data)
 {
@@ -266,19 +271,11 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 {
 	TRACE_CALL("remmina_applet_menu_populate");
 	GtkWidget *menuitem;
-	gchar dirname[MAX_PATH_LEN];
 	gchar filename[MAX_PATH_LEN];
-	GDir *old;
 	GDir *dir;
 	const gchar *name;
 
-	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
-		/* If the XDG directories exist, use them. */
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
-	dir = g_dir_open(dirname, 0, NULL);
+	dir = g_dir_open(remminadir, 0, NULL);
 	if (dir != NULL)
 	{
 		/* Iterate all remote desktop profiles */
@@ -286,7 +283,7 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 		{
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
-			g_snprintf(filename, sizeof(filename), "%s/%s", dirname, name);
+			g_snprintf(filename, sizeof(filename), "%s/%s", remminadir, name);
 
 			menuitem = remmina_applet_menu_item_new(REMMINA_APPLET_MENU_ITEM_FILE, filename);
 			if (menuitem != NULL)

--- a/remmina/src/remmina_file.c
+++ b/remmina/src/remmina_file.c
@@ -33,16 +33,18 @@
  *
  */
 
+#include "config.h"
+
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <glib/gstdio.h>
 #include <stdlib.h>
-#include "config.h"
+
 #include "remmina_public.h"
-#include "remmina_pref.h"
 #include "remmina_crypt.h"
+#include "remmina_file_manager.h"
 #include "remmina_plugin_manager.h"
-#include "remmina_file.h"
+#include "remmina_pref.h"
 #include "remmina_masterthread_exec.h"
 #include "remmina/remmina_trace_calls.h"
 
@@ -79,6 +81,7 @@ const RemminaSetting remmina_system_settings[] =
 	{ NULL, 0, FALSE }
 };
 
+gchar remminadir[MAX_PATH_LEN];
 
 static RemminaSettingGroup remmina_setting_get_group(const gchar *setting, gboolean *encrypted)
 {
@@ -136,24 +139,14 @@ void remmina_file_generate_filename(RemminaFile *remminafile)
 {
 	TRACE_CALL("remmina_file_generate_filename");
 	GTimeVal gtime;
-	gchar dirname[MAX_PATH_LEN];
-	GDir *old;
 	GDir *dir;
 
 	g_free(remminafile->filename);
 	g_get_current_time(&gtime);
 
-	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
-	g_dir_close(old);
-
-	/* If the XDG directories exist, use them. */
-	dir = g_dir_open(dirname, 0, NULL);
+	dir = g_dir_open(remminadir, 0, NULL);
 	if (dir != NULL)
-		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", dirname, gtime.tv_sec,
+		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", remminadir, gtime.tv_sec,
 		                                        gtime.tv_usec / 1000);
 	else
 		remminafile->filename = NULL;

--- a/remmina/src/remmina_file.c
+++ b/remmina/src/remmina_file.c
@@ -81,8 +81,6 @@ const RemminaSetting remmina_system_settings[] =
 	{ NULL, 0, FALSE }
 };
 
-gchar remminadir[MAX_PATH_LEN];
-
 static RemminaSettingGroup remmina_setting_get_group(const gchar *setting, gboolean *encrypted)
 {
 	TRACE_CALL("remmina_setting_get_group");
@@ -144,9 +142,9 @@ void remmina_file_generate_filename(RemminaFile *remminafile)
 	g_free(remminafile->filename);
 	g_get_current_time(&gtime);
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 	if (dir != NULL)
-		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", remminadir, gtime.tv_sec,
+		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", remmina_file_get_user_datadir(), gtime.tv_sec,
 		                                        gtime.tv_usec / 1000);
 	else
 		remminafile->filename = NULL;

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -44,11 +44,11 @@
 #include "remmina_file_manager.h"
 #include "remmina/remmina_trace_calls.h"
 
-gchar remminadir[MAX_PATH_LEN];
 
-void remmina_file_manager_init(void)
+gchar* remmina_file_get_user_datadir(void)
 {
-	TRACE_CALL("remmina_file_manager_init");
+	gchar remminadir[MAX_PATH_LEN];
+	TRACE_CALL("remmina_file_get_user_datadir");
 	GDir *old;
 
 	/* If the old .remmina exists, use it. */
@@ -59,8 +59,13 @@ void remmina_file_manager_init(void)
 		g_snprintf(remminadir, sizeof(remminadir), "%s/%s", g_get_user_data_dir(), remmina);
 	else
 		g_dir_close(old);
+	return g_strdup(remminadir);
+}
 
-	g_mkdir_with_parents(remminadir, 0700);
+void remmina_file_manager_init(void)
+{
+	TRACE_CALL("remmina_file_manager_init");
+	g_mkdir_with_parents(remmina_file_get_user_datadir(), 0700);
 }
 
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
@@ -72,7 +77,7 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 	RemminaFile* remminafile;
 	gint items_count = 0;
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
 	if (dir)
 	{
@@ -80,7 +85,8 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 		{
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
-			g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
+			g_snprintf(filename, MAX_PATH_LEN, "%s/%s",
+					remmina_file_get_user_datadir(), name);
 			remminafile = remmina_file_load(filename);
 			if (remminafile)
 			{
@@ -107,7 +113,7 @@ gchar* remmina_file_manager_get_groups(void)
 
 	array = remmina_string_array_new();
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
 	if (dir == NULL)
 		return 0;
@@ -115,7 +121,7 @@ gchar* remmina_file_manager_get_groups(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_user_datadir(), name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		if (group && remmina_string_array_find(array, group) < 0)
@@ -207,7 +213,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 
 	root = g_node_new(NULL);
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
 	if (dir == NULL)
 		return root;
@@ -215,7 +221,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_user_datadir(), name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		remmina_file_manager_add_group(root, group);

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -33,54 +33,46 @@
  *
  */
 
+#include "config.h"
+
 #include <gtk/gtk.h>
 #include <string.h>
-#include "config.h"
+
 #include "remmina_public.h"
 #include "remmina_string_array.h"
 #include "remmina_plugin_manager.h"
 #include "remmina_file_manager.h"
 #include "remmina/remmina_trace_calls.h"
 
+gchar remminadir[MAX_PATH_LEN];
+
 void remmina_file_manager_init(void)
 {
 	TRACE_CALL("remmina_file_manager_init");
-	gchar dirname[MAX_PATH_LEN];
 	GDir *old;
 
 	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
+	g_snprintf(remminadir, sizeof(remminadir), "%s/.%s", g_get_home_dir(), remmina);
+	old = g_dir_open(remminadir, 0, NULL);
 	if (old == NULL)
 		/* If the XDG directories exist, use them. */
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
+		g_snprintf(remminadir, sizeof(remminadir), "%s/%s", g_get_user_data_dir(), remmina);
 	else
 		g_dir_close(old);
 
-	g_mkdir_with_parents(dirname, 0700);
+	g_mkdir_with_parents(remminadir, 0700);
 }
 
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 {
 	TRACE_CALL("remmina_file_manager_iterate");
-	gchar dirname[MAX_PATH_LEN];
 	gchar filename[MAX_PATH_LEN];
-	GDir *old;
 	GDir* dir;
 	const gchar* name;
 	RemminaFile* remminafile;
 	gint items_count = 0;
 
-	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
-	{
-		/* If the XDG directories exist, use them. */
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
-		dir = g_dir_open(dirname, 0, NULL);
-	} else
-		dir = old;
+	dir = g_dir_open(remminadir, 0, NULL);
 
 	if (dir)
 	{
@@ -88,7 +80,7 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 		{
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
-			g_snprintf(filename, MAX_PATH_LEN, "%s/%s", dirname, name);
+			g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
 			remminafile = remmina_file_load(filename);
 			if (remminafile)
 			{
@@ -105,10 +97,8 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 gchar* remmina_file_manager_get_groups(void)
 {
 	TRACE_CALL("remmina_file_manager_get_groups");
-	gchar dirname[MAX_PATH_LEN];
 	gchar filename[MAX_PATH_LEN];
 	GDir* dir;
-	GDir* old;
 	const gchar* name;
 	RemminaFile* remminafile;
 	RemminaStringArray* array;
@@ -117,16 +107,7 @@ gchar* remmina_file_manager_get_groups(void)
 
 	array = remmina_string_array_new();
 
-	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
-	{
-		/* If the XDG directories exist, use them. */
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
-		dir = g_dir_open(dirname, 0, NULL);
-	} else
-		dir = old;
+	dir = g_dir_open(remminadir, 0, NULL);
 
 	if (dir == NULL)
 		return 0;
@@ -134,7 +115,7 @@ gchar* remmina_file_manager_get_groups(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", dirname, name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		if (group && remmina_string_array_find(array, group) < 0)
@@ -217,10 +198,8 @@ static void remmina_file_manager_add_group(GNode* node, const gchar* group)
 GNode* remmina_file_manager_get_group_tree(void)
 {
 	TRACE_CALL("remmina_file_manager_get_group_tree");
-	gchar dirname[MAX_PATH_LEN];
 	gchar filename[MAX_PATH_LEN];
 	GDir* dir;
-	GDir* old;
 	const gchar* name;
 	RemminaFile* remminafile;
 	const gchar* group;
@@ -228,16 +207,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 
 	root = g_node_new(NULL);
 
-	/* If the old .remmina exists, use it. */
-	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
-	{
-		/* If the XDG directories exist, use them. */
-		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_data_dir(), remmina);
-		dir = g_dir_open(dirname, 0, NULL);
-	} else
-		dir = old;
+	dir = g_dir_open(remminadir, 0, NULL);
 
 	if (dir == NULL)
 		return root;
@@ -245,7 +215,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", dirname, name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remminadir, name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		remmina_file_manager_add_group(root, group);

--- a/remmina/src/remmina_file_manager.h
+++ b/remmina/src/remmina_file_manager.h
@@ -46,7 +46,7 @@ typedef struct _RemminaGroupData
 } RemminaGroupData;
 
 /* Initialize */
-extern gchar remminadir[];
+gchar* remmina_file_get_user_datadir(void);
 void remmina_file_manager_init(void);
 /* Iterate all .remmina connections in the home directory */
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data);

--- a/remmina/src/remmina_file_manager.h
+++ b/remmina/src/remmina_file_manager.h
@@ -46,6 +46,7 @@ typedef struct _RemminaGroupData
 } RemminaGroupData;
 
 /* Initialize */
+extern gchar remminadir[];
 void remmina_file_manager_init(void);
 /* Iterate all .remmina connections in the home directory */
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data);

--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -34,11 +34,13 @@
  */
 
 #include "config.h"
+
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <string.h>
+
 #include "remmina_public.h"
-#include "remmina_file.h"
+#include "remmina_file_manager.h"
 #include "remmina_pref.h"
 #include "remmina_protocol_widget.h"
 #include "remmina_log.h"
@@ -126,6 +128,8 @@ RemminaPluginService remmina_plugin_manager_service =
 	remmina_protocol_widget_chat_close,
 	remmina_protocol_widget_chat_receive,
 	remmina_protocol_widget_send_keys_signals,
+
+	remmina_file_get_user_datadir,
 
 	remmina_file_new,
 	remmina_file_get_filename,

--- a/remmina/src/remmina_survey.c
+++ b/remmina/src/remmina_survey.c
@@ -62,7 +62,6 @@ static RemminaSurveyDialog *remmina_survey;
 static WebKitWebView* web_view;
 
 gchar *remmina_pref_file;
-gchar remminadir[MAX_PATH_LEN];
 RemminaPref remmina_pref;
 
 #define GET_OBJECT(object_name) gtk_builder_get_object(remmina_survey->builder, object_name)
@@ -172,13 +171,13 @@ gboolean remmina_survey_valid_profile()
 	gint min_profiles=1;    /* TODO: Use a constant */
 	gint min_days = 30;     /* TODO: Use a constant */
 
-	dir = g_dir_open(remminadir, 0, &gerror);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, &gerror);
 	if (gerror != NULL)
 	{
 		/* This should not happen */
-		g_message("Cannot open %s, with error: %s", remminadir, gerror->message);
+		g_message("Cannot open %s, with error: %s", remmina_file_get_user_datadir(), gerror->message);
 		g_error_free(gerror);
-		g_snprintf(remminadir, sizeof(remminadir),
+		g_snprintf(remmina_file_get_user_datadir(), sizeof(remmina_file_get_user_datadir()),
 				"%s/%s", g_get_user_data_dir(), "remmina");
 	}else{
 
@@ -186,7 +185,7 @@ gboolean remmina_survey_valid_profile()
 			/* Olny *.remmina files */
 			if (!g_str_has_suffix(dir_entry, ".remmina\0"))
 				continue;
-			g_snprintf(filename, PATH_MAX, "%s/%s", remminadir, dir_entry);
+			g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_user_datadir(), dir_entry);
 
 			if (filename != NULL)
 				count_profile++;
@@ -254,7 +253,7 @@ static gchar *remmina_survey_files_iter_setting()
 	GHashTableIter iter;
 	gpointer key, value;
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
 	if (!dir)
 		return FALSE;
@@ -265,7 +264,7 @@ static gchar *remmina_survey_files_iter_setting()
 		/* Olny *.remmina files */
 		if (!g_str_has_suffix(dir_entry, ".remmina\0"))
 			continue;
-		g_snprintf(filename, PATH_MAX, "%s/%s", remminadir, dir_entry);
+		g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_user_datadir(), dir_entry);
 
 		if (!g_key_file_load_from_file(gkeyfile, filename, G_KEY_FILE_NONE, NULL))
 			g_key_file_free(gkeyfile);
@@ -331,7 +330,7 @@ static void remmina_survey_stats_create_html_form()
 	const gchar old[] = "<!-- STATS HOLDER -->";
 	gchar *new;
 
-	output_file_path = g_strdup_printf("%s/%s", remminadir, output_file_name);
+	output_file_path = g_strdup_printf("%s/%s", remmina_file_get_user_datadir(), output_file_name);
 
 	template = g_file_new_for_uri(templateuri);
 	output_file = g_file_new_for_path(output_file_path);
@@ -397,7 +396,7 @@ void remmina_survey_start(GtkWindow *parent)
 	GDir *dir;
 	gchar localurl[PATH_MAX];
 
-	dir = g_dir_open(remminadir, 0, NULL);
+	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
 	remmina_survey = g_new0(RemminaSurveyDialog, 1);
 
@@ -441,7 +440,7 @@ void remmina_survey_start(GtkWindow *parent)
 
 	gtk_container_add(GTK_CONTAINER(remmina_survey->scrolledwindow), GTK_WIDGET(web_view));
 	gtk_widget_show(GTK_WIDGET(web_view));
-	g_snprintf(localurl, PATH_MAX, "%s%s/%s", "file://", remminadir, "local_remmina_form.html");
+	g_snprintf(localurl, PATH_MAX, "%s%s/%s", "file://", remmina_file_get_user_datadir(), "local_remmina_form.html");
 	webkit_web_view_load_uri(web_view, localurl);
 	g_object_unref(G_OBJECT(remmina_survey->builder));
 }

--- a/remmina/src/remmina_survey.c
+++ b/remmina/src/remmina_survey.c
@@ -255,7 +255,7 @@ static gchar *remmina_survey_files_iter_setting()
 
 	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
 
-	if (!dir)
+	if (dir == NULL)
 		return FALSE;
 	gkeyfile = g_key_file_new();
 	hash_table = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);


### PR DESCRIPTION
I've made the remmina user data dir (~/.remmina or ~/.local/share/remmina) a global variable, to avoid to call continuously the same code in all the function where is needed.

@giox069 can you please validate and if it's fine merge it? Thx