### PR TITLE
Selected item is lost after editing a profile. Closes #786

### DIFF
--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -569,6 +569,11 @@ void remmina_main_on_action_connection_copy(GtkAction *action, gpointer user_dat
 		gtk_window_set_transient_for(GTK_WINDOW(widget), remminamain->window);
 		gtk_widget_show(widget);
 	}
+	/* Select the file previously selected */
+	if (remminamain->priv->selected_filename)
+	{
+		remmina_main_select_file(remminamain->priv->selected_filename);
+	}
 }
 
 void remmina_main_on_action_connection_edit(GtkAction *action, gpointer user_data)
@@ -584,6 +589,11 @@ void remmina_main_on_action_connection_edit(GtkAction *action, gpointer user_dat
 	{
 		gtk_window_set_transient_for(GTK_WINDOW(widget), remminamain->window);
 		gtk_widget_show(widget);
+	}
+	/* Select the file previously selected */
+	if (remminamain->priv->selected_filename)
+	{
+		remmina_main_select_file(remminamain->priv->selected_filename);
 	}
 }
 


### PR DESCRIPTION
After showing the remmina_file_editor dialog, the previous selected file is highlighted.

This PR closes #786 
