### PR TITLE
Quickfind fixes - Close #791

### DIFF
--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -552,6 +552,7 @@ void remmina_main_on_action_connections_new(GtkAction *action, gpointer user_dat
 	g_signal_connect(G_OBJECT(widget), "destroy", G_CALLBACK(remmina_main_file_editor_destroy), remminamain);
 	gtk_window_set_transient_for(GTK_WINDOW(widget), remminamain->window);
 	gtk_widget_show(widget);
+	remmina_main_load_files(TRUE);
 }
 
 void remmina_main_on_action_connection_copy(GtkAction *action, gpointer user_data)

--- a/remmina/ui/remmina_main.glade
+++ b/remmina/ui/remmina_main.glade
@@ -813,7 +813,7 @@
                       <object class="GtkLabel" id="label_quick_search">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Quick _Find</property>
+                        <property name="label" translatable="yes">Quick Find</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>


### PR DESCRIPTION
This PR close #791

1. Underscore in Quick Find removed as reported by #791 
2. Refresh file list in the remmina main after adding a new entry

