### PR TITLE
Screenshot segfault

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,11 +11,14 @@ Authors of Remmina Project
             Antonio Guillen <antonio@guillen.com.es>
             Benjamin Podszun <benjamin.podszun@gmail.com>
             Ben Kohler <bkohler@gmail.com>
+            Christian Persch <chpe@gnome.org>
             Christopher Rawlings <chris.rawlings+git@gmail.com>
             Daniel M. Weeks <dan@danweeks.net>
             Daniele Tieghi <notdisclosed>
+            Dennis Koot <koter84@gmail.com>
             Dmitry Kubatkin <maelnor@gmail.com>
             dupondje <jean-louis@dupondje.be>
+            Egmont Koblinger <egmont@gmail.com>
             Emmanuel Grognet <emmanuel@grognet.fr>
             Frank Bongrand <fbongrand@free.fr>
             Funda Wang <fundawang@gmail.com>

--- a/THANKS.md
+++ b/THANKS.md
@@ -2,14 +2,17 @@
 
 ## The Remmina sponsors
 
-### 2015
+### 2016
 
  - Daniel Bolter
- - Richard Pendlebury
- - Michael Gruben
+ - Artur Mroczko
  - Gustavo Uceda
- - Paul Johnson
+ - Lynne Lawrence
+ - Michael Gruben
  - Nic Galler
+ - Paul Johnson
+ - Richard Pendlebury
+ - Troy Lea
  - Viktor Sik
 
 ## The Remmina community
@@ -40,3 +43,8 @@ trust in us (Antenore & Giovanni) to represent Remmina.
 
 Least but not last, the [FreeRDP](https://github.com/FreeRDP/FreeRDP) project the most advanced and updated RDP library
 to date.
+
+## The Gnome VTE project
+
+Particulary **Egmont Koblinger** ([@egmontkob](https://github.com/egmontkob)) and **Christian Persch** for their support.
+

--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -64,148 +64,104 @@ GCRY_THREAD_OPTION_PTHREAD_IMPL;
 # endif
 #endif
 
-static gboolean remmina_option_about;
-static gchar *remmina_option_connect;
-static gchar *remmina_option_edit;
-static gboolean remmina_option_help;
-static gboolean remmina_option_new;
-static gchar *remmina_option_pref;
-static gchar *remmina_option_plugin;
-static gboolean remmina_option_quit;
-static gboolean remmina_option_version;
-static gchar *remmina_option_server;
-static gchar *remmina_option_protocol;
-static gchar *remmina_option_icon;
-
-
 static GOptionEntry remmina_options[] =
 {
-	{ "about", 'a', 0, G_OPTION_ARG_NONE, &remmina_option_about, N_("Show about dialog"), NULL },
-	{ "connect", 'c', 0, G_OPTION_ARG_FILENAME, &remmina_option_connect, N_("Connect to a .remmina file"), "FILE" },
-	{ "edit", 'e', 0, G_OPTION_ARG_FILENAME, &remmina_option_edit, N_("Edit a .remmina file"), "FILE" },
-	{ "help", '?', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, &remmina_option_help, NULL, NULL },
-	{ "new", 'n', 0, G_OPTION_ARG_NONE, &remmina_option_new, N_("Create a new connection profile"), NULL },
-	{ "pref", 'p', 0, G_OPTION_ARG_STRING, &remmina_option_pref, N_("Show preferences dialog page"), "PAGENR" },
-	{ "plugin", 'x', 0, G_OPTION_ARG_STRING, &remmina_option_plugin, N_("Execute the plugin"), "PLUGIN" },
-	{ "quit", 'q', 0, G_OPTION_ARG_NONE, &remmina_option_quit, N_("Quit the application"), NULL },
-	{ "server", 's', 0, G_OPTION_ARG_STRING, &remmina_option_server, N_("Use default server name"), "SERVER" },
-	{ "protocol", 't', 0, G_OPTION_ARG_STRING, &remmina_option_protocol, N_("Use default protocol"), "PROTOCOL" },
-	{ "icon", 'i', 0, G_OPTION_ARG_NONE, &remmina_option_icon, N_("Start as tray icon"), NULL },
-	{ "version", 'v', 0, G_OPTION_ARG_NONE, &remmina_option_version, N_("Show the application's version"), NULL },
+	{ "about", 'a', 0, G_OPTION_ARG_NONE, NULL, N_("Show about dialog"), NULL },
+	{ "connect", 'c', 0, G_OPTION_ARG_FILENAME, NULL, N_("Connect to a .remmina file"), "FILE" },
+	{ "edit", 'e', 0, G_OPTION_ARG_FILENAME, NULL, N_("Edit a .remmina file"), "FILE" },
+	{ "help", '?', G_OPTION_FLAG_HIDDEN, G_OPTION_ARG_NONE, NULL, NULL, NULL },
+	{ "new", 'n', 0, G_OPTION_ARG_NONE, NULL, N_("Create a new connection profile"), NULL },
+	{ "pref", 'p', 0, G_OPTION_ARG_STRING, NULL, N_("Show preferences dialog page"), "PAGENR" },
+	{ "plugin", 'x', 0, G_OPTION_ARG_STRING, NULL, N_("Execute the plugin"), "PLUGIN" },
+	{ "quit", 'q', 0, G_OPTION_ARG_NONE, NULL, N_("Quit the application"), NULL },
+	{ "server", 's', 0, G_OPTION_ARG_STRING, NULL, N_("Use default server name (for --new)"), "SERVER" },
+	{ "protocol", 't', 0, G_OPTION_ARG_STRING, NULL, N_("Use default protocol (for --new)"), "PROTOCOL" },
+	{ "icon", 'i', 0, G_OPTION_ARG_NONE, NULL, N_("Start as tray icon"), NULL },
+	{ "version", 'v', 0, G_OPTION_ARG_NONE, NULL, N_("Show the application's version"), NULL },
 	{ NULL }
 };
 
 static gint remmina_on_command_line(GApplication *app, GApplicationCommandLine *cmdline)
 {
 	TRACE_CALL("remmina_on_command_line");
+
 	gint status = 0;
-	gint argc;
-	gchar **argv;
-	GError *error = NULL;
-	GOptionContext *context;
-	gboolean parsed;
-	gchar *s;
 	gboolean executed = FALSE;
+	GVariantDict *opts;
+	gchar *str;
+	gchar *protocol;
+	gchar *server;
 
-	remmina_option_about = FALSE;
-	remmina_option_connect = NULL;
-	remmina_option_edit = NULL;
-	remmina_option_help = FALSE;
-	remmina_option_new = FALSE;
-	remmina_option_pref = NULL;
-	remmina_option_plugin = NULL;
-	remmina_option_server = NULL;
-	remmina_option_protocol = NULL;
-	remmina_option_icon = FALSE;
-	remmina_option_version = FALSE;
+	opts = g_application_command_line_get_options_dict(cmdline);
 
-	argv = g_application_command_line_get_arguments(cmdline, &argc);
-
-	context = g_option_context_new("- The GTK+ Remote Desktop Client");
-	g_option_context_add_main_entries(context, remmina_options, GETTEXT_PACKAGE);
-	g_option_context_add_group(context, gtk_get_option_group(FALSE));
-	g_option_context_set_help_enabled(context, TRUE);
-
-	parsed = g_option_context_parse(context, &argc, &argv, &error);
-	g_strfreev(argv);
-
-	if (!parsed)
-	{
-		g_print("option parsing failed: %s\n", error->message);
-		status = 1;
-	}
-
-	if (remmina_option_version)
-	{
-		remmina_exec_command(REMMINA_COMMAND_VERSION, NULL);
-		executed = TRUE;
-		status = 1;
-	}
-
-	if (remmina_option_quit)
+	if (g_variant_dict_lookup_value(opts, "quit", NULL))
 	{
 		remmina_exec_command(REMMINA_COMMAND_EXIT, NULL);
 		executed = TRUE;
 		status = 1;
 	}
 
-	if (remmina_option_about)
+	if (g_variant_dict_lookup_value(opts, "about", NULL))
 	{
 		remmina_exec_command(REMMINA_COMMAND_ABOUT, NULL);
 		executed = TRUE;
 	}
-	if (remmina_option_connect)
+
+	if (g_variant_dict_lookup(opts, "connect", "^ay", &str))
 	{
-		remmina_exec_command(REMMINA_COMMAND_CONNECT, remmina_option_connect);
+		remmina_exec_command(REMMINA_COMMAND_CONNECT, str);
+		g_free(str);
 		executed = TRUE;
 	}
-	if (remmina_option_edit)
+
+	if (g_variant_dict_lookup(opts, "edit", "^ay", &str))
 	{
-		remmina_exec_command(REMMINA_COMMAND_EDIT, remmina_option_edit);
+		remmina_exec_command(REMMINA_COMMAND_EDIT, str);
+		g_free(str);
 		executed = TRUE;
 	}
-	if (remmina_option_help)
+
+	if (g_variant_dict_lookup_value(opts, "new", NULL))
 	{
-		s = g_option_context_get_help(context, TRUE, NULL);
-		g_print("%s", s);
-		g_free(s);
-		status = 1;
-	}
-	if (remmina_option_new)
-	{
-		if (remmina_option_server)
+		if (!g_variant_dict_lookup(opts, "protocol", "&s", &protocol))
+			protocol = NULL;
+
+		if (g_variant_dict_lookup(opts, "server", "&s", &server))
 		{
-			s = g_strdup_printf("%s,%s", remmina_option_protocol, remmina_option_server);
+			str = g_strdup_printf("%s,%s", protocol, server);
 		}
 		else
 		{
-			s = g_strdup(remmina_option_protocol);
+			str = g_strdup(protocol);
 		}
-		remmina_exec_command(REMMINA_COMMAND_NEW, s);
-		g_free(s);
+
+		remmina_exec_command(REMMINA_COMMAND_NEW, str);
+		g_free(str);
 		executed = TRUE;
 	}
-	if (remmina_option_pref)
+
+	if (g_variant_dict_lookup(opts, "pref", "&s", &str))
 	{
-		remmina_exec_command(REMMINA_COMMAND_PREF, remmina_option_pref);
+		remmina_exec_command(REMMINA_COMMAND_PREF, str);
 		executed = TRUE;
 	}
-	if (remmina_option_plugin)
+
+	if (g_variant_dict_lookup(opts, "plugin", "&s", &str))
 	{
-		remmina_exec_command(REMMINA_COMMAND_PLUGIN, remmina_option_plugin);
+		remmina_exec_command(REMMINA_COMMAND_PLUGIN, str);
 		executed = TRUE;
 	}
-	if (remmina_option_icon)
+
+	if (g_variant_dict_lookup_value(opts, "icon", NULL))
 	{
-		remmina_exec_command(REMMINA_COMMAND_NONE, remmina_option_icon);
+		remmina_exec_command(REMMINA_COMMAND_NONE, NULL);
 		executed = TRUE;
 	}
+
 	if (!executed)
 	{
 		remmina_exec_command(REMMINA_COMMAND_MAIN, NULL);
 	}
-
-	g_option_context_free(context);
 
 	return status;
 }
@@ -229,45 +185,25 @@ static void remmina_on_startup(GApplication *app)
 	g_application_hold(app);
 }
 
-static gboolean remmina_on_local_cmdline (GApplication *app, gchar ***arguments, gint *exit_status)
+static gint remmina_on_local_cmdline (GApplication *app, GVariantDict *options, gpointer user_data)
 {
 	TRACE_CALL("remmina_on_local_cmdline");
-	/* Partially unimplemented local command line only used to append the
-	 * command line arguments to the help text and to parse the --help/-h
-	 * arguments locally instead of forwarding them to the remote instance */
-	GOptionContext *context;
-	gint i = 0;
-	gchar **argv;
 
-	context = g_option_context_new("- The GTK+ Remote Desktop Client");
-	g_option_context_add_group(context, gtk_get_option_group(FALSE));
-	g_option_context_set_help_enabled(context, TRUE);
-	g_option_context_add_main_entries(context, remmina_options, GETTEXT_PACKAGE);
-	g_option_context_set_translation_domain(context, GETTEXT_PACKAGE);
-	*exit_status = 0;
+	int status = -1;
 
-	// Parse the command line arguments for --help/-h
-	argv = *arguments;
-	for (i = 0; argv[i] != NULL; i++)
+	if (g_variant_dict_lookup_value(options, "version", NULL))
 	{
-		if ((g_strcmp0(argv[i], "--help") == 0 || g_strcmp0(argv[i], "-h") == 0))
-		{
-			g_print("%s", g_option_context_get_help(context, TRUE, NULL));
-			*exit_status = EXIT_FAILURE;
-		}
+		remmina_exec_command(REMMINA_COMMAND_VERSION, NULL);
+		status = 1;
 	}
-	g_option_context_free(context);
-	// Exit from the local instance whenever the exit status is not zero
-	if (*exit_status != 0)
-		exit(*exit_status);
-	return FALSE;
+
+	return status;
 }
 
 int main(int argc, char* argv[])
 {
 	TRACE_CALL("main");
 	GtkApplication *app;
-	GApplicationClass *app_class;
 	int status;
 
 	gdk_set_allowed_backends("x11,broadway,quartz");
@@ -288,10 +224,12 @@ int main(int argc, char* argv[])
 #endif
 
 	app = gtk_application_new("org.Remmina", G_APPLICATION_HANDLES_COMMAND_LINE);
-	app_class = G_APPLICATION_CLASS(G_OBJECT_GET_CLASS (G_APPLICATION(app)));
-	app_class->local_command_line = remmina_on_local_cmdline;
 	g_signal_connect(app, "startup", G_CALLBACK(remmina_on_startup), NULL);
 	g_signal_connect(app, "command-line", G_CALLBACK(remmina_on_command_line), NULL);
+	g_signal_connect(app, "handle-local-options", G_CALLBACK(remmina_on_local_cmdline), NULL);
+
+	g_application_add_main_option_entries(G_APPLICATION(app), remmina_options);
+
 	g_application_set_inactivity_timeout(G_APPLICATION(app), 10000);
 
 	status = g_application_run(G_APPLICATION(app), argc, argv);

--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -137,7 +137,6 @@ static gint remmina_on_command_line(GApplication *app, GApplicationCommandLine *
 
 	if (remmina_option_version)
 	{
-		//g_print ("%s - Version %s (git %s)\n", g_get_application_name (), VERSION, GIT_REVISION);
 		remmina_exec_command(REMMINA_COMMAND_VERSION, NULL);
 		executed = TRUE;
 		status = 1;
@@ -227,6 +226,7 @@ static void remmina_on_startup(GApplication *app)
 
 	gtk_icon_theme_append_search_path (gtk_icon_theme_get_default (),
 	                                   REMMINA_DATADIR G_DIR_SEPARATOR_S "icons");
+	g_application_hold(app);
 }
 
 static gboolean remmina_on_local_cmdline (GApplication *app, gchar ***arguments, gint *exit_status)
@@ -266,7 +266,7 @@ static gboolean remmina_on_local_cmdline (GApplication *app, gchar ***arguments,
 int main(int argc, char* argv[])
 {
 	TRACE_CALL("main");
-	GApplication *app;
+	GtkApplication *app;
 	GApplicationClass *app_class;
 	int status;
 
@@ -287,21 +287,14 @@ int main(int argc, char* argv[])
 	gcry_control (GCRYCTL_INITIALIZATION_FINISHED, 0);
 #endif
 
-	gtk_init(&argc, &argv);
-
-	app = g_application_new("org.Remmina", G_APPLICATION_HANDLES_COMMAND_LINE);
-	app_class = G_APPLICATION_CLASS(G_OBJECT_GET_CLASS (app));
+	app = gtk_application_new("org.Remmina", G_APPLICATION_HANDLES_COMMAND_LINE);
+	app_class = G_APPLICATION_CLASS(G_OBJECT_GET_CLASS (G_APPLICATION(app)));
 	app_class->local_command_line = remmina_on_local_cmdline;
 	g_signal_connect(app, "startup", G_CALLBACK(remmina_on_startup), NULL);
 	g_signal_connect(app, "command-line", G_CALLBACK(remmina_on_command_line), NULL);
-	g_application_set_inactivity_timeout(app, 10000);
+	g_application_set_inactivity_timeout(G_APPLICATION(app), 10000);
 
-	status = g_application_run(app, argc, argv);
-
-	if (status == 0 && !g_application_get_is_remote(app))
-	{
-		gtk_main();
-	}
+	status = g_application_run(G_APPLICATION(app), argc, argv);
 
 	g_object_unref(app);
 

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1595,6 +1595,8 @@ static void remmina_connection_holder_toolbar_screenshot(GtkWidget* widget, Remm
 
 		if (rpsd.bitsPerPixel == 32)
 			cairo_format = CAIRO_FORMAT_ARGB32;
+		else if (rpsd.bitsPerPixel == 24)
+			cairo_format = CAIRO_FORMAT_RGB24;
 		else
 			cairo_format = CAIRO_FORMAT_RGB16_565;
 

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1659,6 +1659,8 @@ static void remmina_connection_holder_toolbar_screenshot(GtkWidget* widget, Remm
 			g_date_time_get_seconds (date));
 
 	g_date_time_unref (date);
+	if (remminafile == NULL)
+		remminafile = "remmina_screenshot";
 	pngname = g_strdup_printf("%s/%s-%s.png", remmina_pref.screenshot_path,
 			g_path_get_basename(remminafile), pngdate);
 

--- a/remmina/src/remmina_exec.c
+++ b/remmina/src/remmina_exec.c
@@ -76,7 +76,7 @@ void remmina_exec_exitremmina()
 	remmina_icon_destroy();
 
 	/* Exit from Remmina */
-	gtk_main_quit();
+	g_application_quit(g_application_get_default());
 }
 
 void remmina_exec_command(RemminaCommandType command, const gchar* data)

--- a/remmina/src/remmina_masterthread_exec.c
+++ b/remmina/src/remmina_masterthread_exec.c
@@ -108,7 +108,9 @@ static gboolean remmina_masterthread_exec_callback(RemminaMTExecData *d)
 		case FUNC_VTE_TERMINAL_SET_ENCODING_AND_PTY:
 #if defined (HAVE_LIBSSH) && defined (HAVE_LIBVTE)
 			remmina_plugin_ssh_vte_terminal_set_encoding_and_pty( d->p.vte_terminal_set_encoding_and_pty.terminal,
-			        d->p.vte_terminal_set_encoding_and_pty.codeset, d->p.vte_terminal_set_encoding_and_pty.slave );
+			        d->p.vte_terminal_set_encoding_and_pty.codeset,
+				d->p.vte_terminal_set_encoding_and_pty.master,
+				d->p.vte_terminal_set_encoding_and_pty.slave);
 #endif
 			break;
 		}

--- a/remmina/src/remmina_masterthread_exec.h
+++ b/remmina/src/remmina_masterthread_exec.h
@@ -152,6 +152,7 @@ typedef struct remmina_masterthread_exec_data
 		{
 			VteTerminal *terminal;
 			const char *codeset;
+			int master;
 			int slave;
 		} vte_terminal_set_encoding_and_pty;
 #endif

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -397,6 +397,8 @@ void remmina_pref_init(void)
 		remmina_pref.screenshot_path = g_key_file_get_string(gkeyfile, "remmina_pref", "screenshot_path", NULL);
 	}else{
 		remmina_pref.screenshot_path = g_get_user_special_dir(G_USER_DIRECTORY_PICTURES);
+		if (remmina_pref.screenshot_path == NULL)
+			remmina_pref.screenshot_path = g_get_home_dir();
 	}
 
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "ssh_parseconfig", NULL))

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -1531,15 +1531,15 @@ remmina_ssh_shell_thread (gpointer data)
 		timeout.tv_usec = 0;
 
 		FD_ZERO (&fds);
-		FD_SET (shell->master, &fds);
+		FD_SET (shell->slave, &fds);
 
-		ret = ssh_select (ch, chout, shell->master + 1, &fds, &timeout);
+		ret = ssh_select (ch, chout, shell->slave + 1, &fds, &timeout);
 		if (ret == SSH_EINTR) continue;
 		if (ret == -1) break;
 
-		if (FD_ISSET (shell->master, &fds))
+		if (FD_ISSET (shell->slave, &fds))
 		{
-			len = read (shell->master, buf, buf_len);
+			len = read (shell->slave, buf, buf_len);
 			if (len <= 0) break;
 			LOCK_SSH (shell)
 			ssh_channel_write (channel, buf, len);
@@ -1571,7 +1571,7 @@ remmina_ssh_shell_thread (gpointer data)
 			}
 			while (len > 0)
 			{
-				ret = write (shell->master, buf, len);
+				ret = write (shell->slave, buf, len);
 				if (ret <= 0) break;
 				len -= ret;
 			}

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -337,6 +337,8 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	remmina_plugin_ssh_set_vte_pref (gp);
 	g_signal_connect(G_OBJECT(vte), "size-allocate", G_CALLBACK(remmina_plugin_ssh_on_size_allocate), gp);
 
+	remmina_plugin_ssh_on_size_allocate(GTK_WIDGET (vte), NULL, gp);
+
 	remmina_plugin_service->protocol_plugin_register_hostkey (gp, vte);
 
 	vscrollbar = gtk_scrollbar_new (GTK_ORIENTATION_VERTICAL, gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (vte)));

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -57,13 +57,181 @@
 
 #define GET_PLUGIN_DATA(gp) (RemminaPluginSshData*) g_object_get_data(G_OBJECT(gp), "plugin-data");
 
+/* Palette colors taken from sakura */
+#define PALETTE_SIZE 16
+
+/* 16 color palettes in GdkRGBA format (red, green, blue, alpha)
+ * Text displayed in the first 8 colors (0-7) is meek (uses thin strokes).
+ * Text displayed in the second 8 colors (8-15) is bold (uses thick strokes). */
+
+const GdkRGBA gruvbox_palette[PALETTE_SIZE] = {
+        {0.156863, 0.156863, 0.156863, 1.000000},
+        {0.800000, 0.141176, 0.113725, 1.000000},
+        {0.596078, 0.592157, 0.101961, 1.000000},
+        {0.843137, 0.600000, 0.129412, 1.000000},
+        {0.270588, 0.521569, 0.533333, 1.000000},
+        {0.694118, 0.384314, 0.525490, 1.000000},
+        {0.407843, 0.615686, 0.415686, 1.000000},
+        {0.658824, 0.600000, 0.517647, 1.000000},
+        {0.572549, 0.513725, 0.454902, 1.000000},
+        {0.984314, 0.286275, 0.203922, 1.000000},
+        {0.721569, 0.733333, 0.149020, 1.000000},
+        {0.980392, 0.741176, 0.184314, 1.000000},
+        {0.513725, 0.647059, 0.596078, 1.000000},
+        {0.827451, 0.525490, 0.607843, 1.000000},
+        {0.556863, 0.752941, 0.486275, 1.000000},
+        {0.921569, 0.858824, 0.698039, 1.000000},
+};
+
+const GdkRGBA tango_palette[PALETTE_SIZE] = {
+	{0,        0,        0,        1},
+	{0.8,      0,        0,        1},
+	{0.305882, 0.603922, 0.023529, 1},
+	{0.768627, 0.627451, 0,        1},
+	{0.203922, 0.396078, 0.643137, 1},
+	{0.458824, 0.313725, 0.482353, 1},
+	{0.0235294,0.596078, 0.603922, 1},
+	{0.827451, 0.843137, 0.811765, 1},
+	{0.333333, 0.341176, 0.32549,  1},
+	{0.937255, 0.160784, 0.160784, 1},
+	{0.541176, 0.886275, 0.203922, 1},
+	{0.988235, 0.913725, 0.309804, 1},
+	{0.447059, 0.623529, 0.811765, 1},
+	{0.678431, 0.498039, 0.658824, 1},
+	{0.203922, 0.886275, 0.886275, 1},
+	{0.933333, 0.933333, 0.92549,  1}
+};
+
+const GdkRGBA linux_palette[PALETTE_SIZE] = {
+	{0,        0,        0,        1},
+	{0.666667, 0,        0,        1},
+	{0,        0.666667, 0,        1},
+	{0.666667, 0.333333, 0,        1},
+	{0,        0,        0.666667, 1},
+	{0.666667, 0,        0.666667, 1},
+	{0,        0.666667, 0.666667, 1},
+	{0.666667, 0.666667, 0.666667, 1},
+	{0.333333, 0.333333, 0.333333, 1},
+	{1,        0.333333, 0.333333, 1},
+	{0.333333, 1,        0.333333, 1},
+	{1,        1,        0.333333, 1},
+	{0.333333, 0.333333, 1,        1},
+	{1,        0.333333, 1,        1},
+	{0.333333, 1,        1,        1},
+	{1,        1,        1,        1}
+};
+
+const GdkRGBA solarized_dark_palette[PALETTE_SIZE] = {
+	{0.027451, 0.211765, 0.258824, 1},
+	{0.862745, 0.196078, 0.184314, 1},
+	{0.521569, 0.600000, 0.000000, 1},
+	{0.709804, 0.537255, 0.000000, 1},
+	{0.149020, 0.545098, 0.823529, 1},
+	{0.827451, 0.211765, 0.509804, 1},
+	{0.164706, 0.631373, 0.596078, 1},
+	{0.933333, 0.909804, 0.835294, 1},
+	{0.000000, 0.168627, 0.211765, 1},
+	{0.796078, 0.294118, 0.086275, 1},
+	{0.345098, 0.431373, 0.458824, 1},
+	{0.396078, 0.482353, 0.513725, 1},
+	{0.513725, 0.580392, 0.588235, 1},
+	{0.423529, 0.443137, 0.768627, 1},
+	{0.576471, 0.631373, 0.631373, 1},
+	{0.992157, 0.964706, 0.890196, 1}
+#if 0
+    { 0, 0x0707, 0x3636, 0x4242 }, // 0  base02 black (used as background color)
+    { 0, 0xdcdc, 0x3232, 0x2f2f }, // 1  red
+    { 0, 0x8585, 0x9999, 0x0000 }, // 2  green
+    { 0, 0xb5b5, 0x8989, 0x0000 }, // 3  yellow
+    { 0, 0x2626, 0x8b8b, 0xd2d2 }, // 4  blue
+    { 0, 0xd3d3, 0x3636, 0x8282 }, // 5  magenta
+    { 0, 0x2a2a, 0xa1a1, 0x9898 }, // 6  cyan
+    { 0, 0xeeee, 0xe8e8, 0xd5d5 }, // 7  base2 white (used as foreground color)
+    { 0, 0x0000, 0x2b2b, 0x3636 }, // 8  base3 bright black
+    { 0, 0xcbcb, 0x4b4B, 0x1616 }, // 9  orange
+    { 0, 0x5858, 0x6e6e, 0x7575 }, // 10 base01 bright green
+    { 0, 0x6565, 0x7b7b, 0x8383 }, // 11 base00 bright yellow
+    { 0, 0x8383, 0x9494, 0x9696 }, // 12 base0 brigth blue
+    { 0, 0x6c6c, 0x7171, 0xc4c4 }, // 13 violet
+    { 0, 0x9393, 0xa1a1, 0xa1a1 }, // 14 base1 cyan
+    { 0, 0xfdfd, 0xf6f6, 0xe3e3 }  // 15 base3 white
+#endif
+};
+
+const GdkRGBA solarized_light_palette[PALETTE_SIZE] = {
+	{0.933333, 0.909804, 0.835294, 1},
+	{0.862745, 0.196078, 0.184314, 1},
+	{0.521569, 0.600000, 0.000000, 1},
+	{0.709804, 0.537255, 0.000000, 1},
+	{0.149020, 0.545098, 0.823529, 1},
+	{0.827451, 0.211765, 0.509804, 1},
+	{0.164706, 0.631373, 0.596078, 1},
+	{0.027451, 0.211765, 0.258824, 1},
+	{0.992157, 0.964706, 0.890196, 1},
+	{0.796078, 0.294118, 0.086275, 1},
+	{0.576471, 0.631373, 0.631373, 1},
+	{0.513725, 0.580392, 0.588235, 1},
+	{0.396078, 0.482353, 0.513725, 1},
+	{0.423529, 0.443137, 0.768627, 1},
+	{0.345098, 0.431373, 0.458824, 1},
+	{0.000000, 0.168627, 0.211765, 1}
+#if 0
+	{ 0, 0xeeee, 0xe8e8, 0xd5d5 }, // 0 S_base2
+	{ 0, 0xdcdc, 0x3232, 0x2f2f }, // 1 S_red
+	{ 0, 0x8585, 0x9999, 0x0000 }, // 2 S_green
+	{ 0, 0xb5b5, 0x8989, 0x0000 }, // 3 S_yellow
+	{ 0, 0x2626, 0x8b8b, 0xd2d2 }, // 4 S_blue
+	{ 0, 0xd3d3, 0x3636, 0x8282 }, // 5 S_magenta
+	{ 0, 0x2a2a, 0xa1a1, 0x9898 }, // 6 S_cyan
+	{ 0, 0x0707, 0x3636, 0x4242 }, // 7 S_base02
+	{ 0, 0xfdfd, 0xf6f6, 0xe3e3 }, // 8 S_base3
+	{ 0, 0xcbcb, 0x4b4B, 0x1616 }, // 9 S_orange
+	{ 0, 0x9393, 0xa1a1, 0xa1a1 }, // 10 S_base1
+	{ 0, 0x8383, 0x9494, 0x9696 }, // 11 S_base0
+	{ 0, 0x6565, 0x7b7b, 0x8383 }, // 12 S_base00
+	{ 0, 0x6c6c, 0x7171, 0xc4c4 }, // 13 S_violet
+	{ 0, 0x5858, 0x6e6e, 0x7575 }, // 14 S_base01
+	{ 0, 0x0000, 0x2b2b, 0x3636 } // 15 S_base03
+#endif
+};
+
+
+const GdkRGBA xterm_palette[PALETTE_SIZE] = {
+    {0,        0,        0,        1},
+    {0.803922, 0,        0,        1},
+    {0,        0.803922, 0,        1},
+    {0.803922, 0.803922, 0,        1},
+    {0.117647, 0.564706, 1,        1},
+    {0.803922, 0,        0.803922, 1},
+    {0,        0.803922, 0.803922, 1},
+    {0.898039, 0.898039, 0.898039, 1},
+    {0.298039, 0.298039, 0.298039, 1},
+    {1,        0,        0,        1},
+    {0,        1,        0,        1},
+    {1,        1,        0,        1},
+    {0.27451,  0.509804, 0.705882, 1},
+    {1,        0,        1,        1},
+    {0,        1,        1,        1},
+    {1,        1,        1,        1}
+};
+
+static struct {
+	const GdkRGBA *palette;
+} remminavte;
+#define DEFAULT_PALETTE "linux_palette"
+
+
 /***** The SSH plugin implementation *****/
 typedef struct _RemminaPluginSshData
 {
 	RemminaSSHShell *shell;
 	GtkWidget *vte;
+
+	const GdkRGBA *palette;
+
 	pthread_t thread;
 } RemminaPluginSshData;
+
 
 static RemminaPluginService *remmina_plugin_service = NULL;
 
@@ -143,14 +311,14 @@ remmina_plugin_ssh_main_thread (gpointer data)
 	gpdata->shell = shell;
 
 	charset = REMMINA_SSH (shell)->charset;
-	remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VTE_TERMINAL (gpdata->vte), charset, shell->slave);
+	remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VTE_TERMINAL (gpdata->vte), charset, shell->master, shell->slave);
 	remmina_plugin_service->protocol_plugin_emit_signal (gp, "connect");
 
 	gpdata->thread = 0;
 	return NULL;
 }
 
-void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal, const char *codeset, int slave)
+void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal, const char *codeset, int master, int slave)
 {
 	TRACE_CALL("remmina_plugin_ssh_vte_terminal_set_encoding_and_pty");
 	if ( !remmina_masterthread_exec_is_main_thread() )
@@ -161,7 +329,7 @@ void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal,
 		d->func = FUNC_VTE_TERMINAL_SET_ENCODING_AND_PTY;
 		d->p.vte_terminal_set_encoding_and_pty.terminal = terminal;
 		d->p.vte_terminal_set_encoding_and_pty.codeset = codeset;
-		d->p.vte_terminal_set_encoding_and_pty.slave = slave;
+		d->p.vte_terminal_set_encoding_and_pty.master = master;
 		remmina_masterthread_exec_and_wait(d);
 		g_free(d);
 		return;
@@ -170,21 +338,22 @@ void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal,
 	setlocale(LC_ALL, "");
 	if (codeset && codeset[0] != '\0')
 	{
-#if !VTE_CHECK_VERSION(0,38,0)
+#if VTE_CHECK_VERSION(0,38,0)
+		vte_terminal_set_encoding (terminal, codeset, NULL);
+#else
 		vte_terminal_set_emulation(terminal, "xterm");
 		vte_terminal_set_encoding (terminal, codeset);
-#else
-		vte_terminal_set_encoding (terminal, codeset, NULL);
 #endif
 	}
 
 	vte_terminal_set_backspace_binding(terminal, VTE_ERASE_ASCII_DELETE);
 	vte_terminal_set_delete_binding(terminal, VTE_ERASE_DELETE_SEQUENCE);
 
-#if !VTE_CHECK_VERSION(0,38,0)
-	vte_terminal_set_pty (terminal, slave);
+#if VTE_CHECK_VERSION(0,38,0)
+	/* vte_pty_new_foreig expect master FD, see https://bugzilla.gnome.org/show_bug.cgi?id=765382 */
+	vte_terminal_set_pty (terminal, vte_pty_new_foreign_sync(master, NULL, NULL));
 #else
-	vte_terminal_set_pty (terminal, vte_pty_new_foreign_sync(slave, NULL, NULL));
+	vte_terminal_set_pty (terminal, master);
 #endif
 
 }
@@ -275,6 +444,33 @@ remmina_ssh_plugin_popup_menu(GtkWidget *widget, GdkEvent *event, GtkWidget *men
 	return FALSE;
 }
 
+void remmina_plugin_ssh_popup_ui(RemminaProtocolWidget *gp)
+{
+	TRACE_CALL("remmina_plugin_ssh_popup_ui");
+	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
+	/* Context menu for slection and clipboard */
+	GtkWidget *menu = gtk_menu_new();
+
+	GtkWidget *select_all = gtk_menu_item_new_with_label(_("Select All (Host+a)"));
+	GtkWidget *copy = gtk_menu_item_new_with_label(_("Copy (Host+c)"));
+	GtkWidget *paste = gtk_menu_item_new_with_label(_("Paste (Host+v)"));
+
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), select_all);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), copy);
+	gtk_menu_shell_append(GTK_MENU_SHELL(menu), paste);
+
+	g_signal_connect (G_OBJECT(gpdata->vte), "button_press_event",
+			G_CALLBACK(remmina_ssh_plugin_popup_menu), menu);
+
+	g_signal_connect(G_OBJECT(select_all), "activate",
+			G_CALLBACK(remmina_plugin_ssh_vte_select_all), gpdata->vte);
+	g_signal_connect(G_OBJECT(copy), "activate",
+			G_CALLBACK(remmina_plugin_ssh_vte_copy_clipboard), gpdata->vte);
+	g_signal_connect(G_OBJECT(paste), "activate",
+			G_CALLBACK(remmina_plugin_ssh_vte_paste_clipboard), gpdata->vte);
+
+	gtk_widget_show_all(menu);
+}
 
 static void
 remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
@@ -282,15 +478,17 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	TRACE_CALL("remmina_plugin_ssh_init");
 	RemminaPluginSshData *gpdata;
 	GtkWidget *hbox;
+	GtkAdjustment *vadjustment;
 	GtkWidget *vscrollbar;
 	GtkWidget *vte;
 	GtkStyleContext *style_context;
+#if VTE_CHECK_VERSION(0,38,0)
 	GdkRGBA foreground_color;
 	GdkRGBA background_color;
-#if !VTE_CHECK_VERSION(0,38,0)
+#else /* VTE_CHECK_VERSION(0,38,0) */
 	GdkColor foreground_gdkcolor;
 	GdkColor background_gdkcolor;
-#endif
+#endif /* VTE_CHECK_VERSION(0,38,0) */
 
 	gpdata = g_new0 (RemminaPluginSshData, 1);
 	g_object_set_data_full (G_OBJECT(gp), "plugin-data", gpdata, g_free);
@@ -317,7 +515,11 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 		gdk_rgba_parse(&foreground_color, remmina_pref.vte_foreground_color);
 		gdk_rgba_parse(&background_color, remmina_pref.vte_background_color);
 	}
-#if !VTE_CHECK_VERSION(0,38,0)
+#if VTE_CHECK_VERSION(0,38,0)
+	/* Set colors to GdkRGBA */
+	remminavte.palette = linux_palette;
+	vte_terminal_set_colors (VTE_TERMINAL(vte), &foreground_color, &background_color, remminavte.palette, PALETTE_SIZE);
+#else
 	/* VTE <= 2.90 doesn't support GdkRGBA so we must convert GdkRGBA to GdkColor */
 	foreground_gdkcolor.red = (guint16)(foreground_color.red * 0xFFFF);
 	foreground_gdkcolor.green = (guint16)(foreground_color.green * 0xFFFF);
@@ -327,9 +529,6 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	background_gdkcolor.blue = (guint16)(background_color.blue * 0xFFFF);
 	/* Set colors to GdkColor */
 	vte_terminal_set_colors (VTE_TERMINAL(vte), &foreground_gdkcolor, &background_gdkcolor, NULL, 0);
-#else
-	/* Set colors to GdkRGBA */
-	vte_terminal_set_colors (VTE_TERMINAL(vte), &foreground_color, &background_color, NULL, 0);
 #endif
 
 	gtk_box_pack_start (GTK_BOX (hbox), vte, TRUE, TRUE, 0);
@@ -341,33 +540,18 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 
 	remmina_plugin_service->protocol_plugin_register_hostkey (gp, vte);
 
-	vscrollbar = gtk_scrollbar_new (GTK_ORIENTATION_VERTICAL, gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (vte)));
+#if VTE_CHECK_VERSION(0, 28, 0) && GTK_CHECK_VERSION(3, 0, 0)
+	vadjustment = gtk_scrollable_get_vadjustment (GTK_SCROLLABLE (vte));
+#else
+	vadjustment = vte_terminal_get_adjustment(VTE_TERMINAL(vc->vte.terminal));
+#endif
+
+	vscrollbar = gtk_scrollbar_new(GTK_ORIENTATION_VERTICAL, vadjustment);
 
 	gtk_widget_show(vscrollbar);
 	gtk_box_pack_start (GTK_BOX (hbox), vscrollbar, FALSE, TRUE, 0);
 
-	/* Context menu for slection and clipboard */
-	GtkWidget *menu = gtk_menu_new();
-
-	GtkWidget *select_all = gtk_menu_item_new_with_label(_("Select All (Host+a)"));
-	GtkWidget *copy = gtk_menu_item_new_with_label(_("Copy (Host+c)"));
-	GtkWidget *paste = gtk_menu_item_new_with_label(_("Paste (Host+v)"));
-
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), select_all);
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), copy);
-	gtk_menu_shell_append(GTK_MENU_SHELL(menu), paste);
-
-	gtk_widget_show_all(menu);
-
-	g_signal_connect (G_OBJECT(vte), "button_press_event",
-			G_CALLBACK(remmina_ssh_plugin_popup_menu), menu);
-
-	g_signal_connect(G_OBJECT(select_all), "activate",
-			G_CALLBACK(remmina_plugin_ssh_vte_select_all), vte);
-	g_signal_connect(G_OBJECT(copy), "activate",
-			G_CALLBACK(remmina_plugin_ssh_vte_copy_clipboard), vte);
-	g_signal_connect(G_OBJECT(paste), "activate",
-			G_CALLBACK(remmina_plugin_ssh_vte_paste_clipboard), vte);
+	remmina_plugin_ssh_popup_ui(gp);
 }
 
 static gboolean

--- a/remmina/src/remmina_ssh_plugin.h
+++ b/remmina/src/remmina_ssh_plugin.h
@@ -46,7 +46,7 @@ void remmina_ssh_plugin_register(void);
 
 /* For callback in main thread */
 #if defined (HAVE_LIBSSH) && defined (HAVE_LIBVTE)
-void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal, const char *codeset, int slave);
+void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal, const char *codeset, int master, int slave);
 void remmina_plugin_ssh_vte_select_all (GtkMenuItem *menuitem, gpointer user_data);
 void remmina_plugin_ssh_vte_copy_clipboard (GtkMenuItem *menuitem, gpointer user_data);
 void remmina_plugin_ssh_vte_paste_clipboard (GtkMenuItem *menuitem, gpointer user_data);

--- a/remmina/ui/remmina_about.glade
+++ b/remmina/ui/remmina_about.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 
+<!-- Generated with glade 3.18.3
 
 Remmina - The GTK+ Remmina Remote Desktop Client
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2016
@@ -50,11 +50,13 @@ Antonio Guillen &lt;antonio@guillen.com.es&gt;
 Armin Novak &lt;armin.novak@gmail.com&gt;
 Benjamin Podszun &lt;benjamin.podszun@gmail.com&gt;
 Ben Kohler &lt;bkohler@gmail.com&gt;
+Christian Persch &lt;chpe@gnome.org&gt;
 Christopher Rawlings &lt;chris.rawlings+git@gmail.com&gt;
 Daniel M. Weeks &lt;dan@danweeks.net&gt;
 Daniele Tieghi &lt;notdisclosed&gt;
 Dmitry Kubatkin &lt;maelnor@gmail.com&gt;
 dupondje &lt;jean-louis@dupondje.be&gt;
+Egmont Koblinger &lt;egmont@gmail.com&gt;
 Emmanuel Grognet &lt;emmanuel@grognet.fr&gt;
 Frank Bongrand &lt;fbongrand@free.fr&gt;
 Funda Wang &lt;fundawang@gmail.com&gt;

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3
+<!-- Generated with glade 3.19.0 
 
 Remmina Preferences Dialog -
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2016
@@ -1153,7 +1153,7 @@ Author: Antenore Gatta
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label_terminal_keyboard1">
+                      <object class="GtkLabel" id="label_terminal_clipboard">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
@@ -1166,7 +1166,7 @@ Author: Antenore Gatta
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label_terminal_keyboard2">
+                      <object class="GtkLabel" id="label_terminal_clipboard2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
@@ -1270,6 +1270,7 @@ Author: Antenore Gatta
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
                         <property name="title" translatable="yes">Foreground color</property>
+                        <property name="rgba">rgb(255,255,255)</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1416,6 +1417,16 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">3</property>
+                        <property name="top_attach">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_terminal_clipboard3">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
                         <property name="top_attach">9</property>
                       </packing>
                     </child>


### PR DESCRIPTION
This PR fixes issue #836, but also makes remmina compliant with GtkApplication object, converting commandline parsing as described in GApplication for GLib 2.40 and above.
Some minor fixes are included for correct screenshot creation.
