### PR TITLE
Initial support for Wayland and Mir

### DIFF
--- a/remmina-plugins/nx/nx_plugin.c
+++ b/remmina-plugins/nx/nx_plugin.c
@@ -50,6 +50,9 @@
 
 #define REMMINA_PLUGIN_NX_FEATURE_TOOL_SENDCTRLALTDEL 1
 
+/* Forward declaration */
+static RemminaProtocolPlugin remmina_plugin_nx;
+
 RemminaPluginService *remmina_plugin_nx_service = NULL;
 
 static gchar *remmina_kbtype = "pc102/us";
@@ -619,6 +622,14 @@ static gboolean remmina_plugin_nx_open_connection(RemminaProtocolWidget *gp)
 	RemminaFile *remminafile;
 	const gchar *resolution;
 	gint width, height;
+
+	if (!remmina_plugin_nx_service->gtksocket_available())
+	{
+		remmina_plugin_nx_service->protocol_plugin_set_error (gp,
+			_("Protocol %s is unavailable because GtkSocket only works under Xorg"),
+			remmina_plugin_nx.name);
+		return FALSE;
+	}
 
 	remminafile = remmina_plugin_nx_service->protocol_plugin_get_file(gp);
 

--- a/remmina/include/remmina/plugin.h
+++ b/remmina/include/remmina/plugin.h
@@ -225,6 +225,7 @@ typedef struct _RemminaPluginService
     GtkWidget*   (* open_connection)                      (RemminaFile *remminafile, GCallback disconnect_cb, gpointer data, guint *handler);
     void         (* get_server_port)                      (const gchar *server, gint defaultport, gchar **host, gint *port);
     gboolean     (* is_main_thread)                       (void);
+    gboolean	 (* gtksocket_available)				  (void);
 
 } RemminaPluginService;
 

--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -206,7 +206,7 @@ int main(int argc, char* argv[])
 	GtkApplication *app;
 	int status;
 
-	gdk_set_allowed_backends("x11,broadway,quartz");
+	gdk_set_allowed_backends("x11,broadway,quartz,wayland,mir");
 
 	remmina_masterthread_exec_save_main_thread_id();
 
@@ -231,9 +231,7 @@ int main(int argc, char* argv[])
 	g_application_add_main_option_entries(G_APPLICATION(app), remmina_options);
 
 	g_application_set_inactivity_timeout(G_APPLICATION(app), 10000);
-
 	status = g_application_run(G_APPLICATION(app), argc, argv);
-
 	g_object_unref(app);
 
 	return status;

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3481,6 +3481,7 @@ remmina_connection_window_open_from_file_full(RemminaFile* remminafile, GCallbac
 {
 	TRACE_CALL("remmina_connection_window_open_from_file_full");
 	RemminaConnectionObject* cnnobj;
+	GtkWidget* protocolwidget;
 
 	remmina_file_update_screen_resolution(remminafile);
 
@@ -3491,7 +3492,7 @@ remmina_connection_window_open_from_file_full(RemminaFile* remminafile, GCallbac
 	remmina_plugin_cmdexec_new(cnnobj->remmina_file, "precommand");
 
 	/* Create the RemminaProtocolWidget */
-	cnnobj->proto = remmina_protocol_widget_new();
+	protocolwidget = cnnobj->proto = remmina_protocol_widget_new();
 
 	/* Set a name for the widget, for CSS selector */
 	gtk_widget_set_name(GTK_WIDGET(cnnobj->proto),"remmina-protocol-widget");
@@ -3541,7 +3542,7 @@ remmina_connection_window_open_from_file_full(RemminaFile* remminafile, GCallbac
 
 	remmina_protocol_widget_open_connection(REMMINA_PROTOCOL_WIDGET(cnnobj->proto), remminafile);
 
-	return cnnobj->proto;
+	return protocolwidget;
 
 }
 

--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -35,9 +35,12 @@
 
 #include "config.h"
 
+
 #include <gtk/gtk.h>
 #include <glib/gi18n.h>
 #include <string.h>
+
+#include <gdk/gdkx.h>
 
 #include "remmina_public.h"
 #include "remmina_file_manager.h"
@@ -83,6 +86,29 @@ static gboolean remmina_plugin_manager_register_plugin(RemminaPlugin *plugin)
 	/* g_print("Remmina plugin %s (type=%s) registered.\n", plugin->name, _(remmina_plugin_type_name[plugin->type])); */
 	return TRUE;
 }
+
+static gboolean remmina_gtksocket_available()
+{
+	GdkDisplayManager* dm;
+	GdkDisplay* d;
+	gboolean available;
+
+	dm = gdk_display_manager_get();
+	d = gdk_display_manager_get_default_display(dm);
+	available = FALSE;
+
+#ifdef GDK_WINDOWING_X11
+	if (GDK_IS_X11_DISPLAY(d))
+	{
+		/* GtkSocket support is available only under Xorg */
+		available = TRUE;
+	}
+#endif
+
+	return available;
+
+}
+
 
 RemminaPluginService remmina_plugin_manager_service =
 {
@@ -155,7 +181,8 @@ RemminaPluginService remmina_plugin_manager_service =
 
 	remmina_connection_window_open_from_file_full,
 	remmina_public_get_server_port,
-	remmina_masterthread_exec_is_main_thread
+	remmina_masterthread_exec_is_main_thread,
+	remmina_gtksocket_available
 
 };
 

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -449,7 +449,6 @@ gboolean remmina_protocol_widget_plugin_screenshot(RemminaProtocolWidget* gp, Re
 
 }
 
-
 void remmina_protocol_widget_emit_signal(RemminaProtocolWidget* gp, const gchar* signal_name)
 {
 	TRACE_CALL("remmina_protocol_widget_emit_signal");

--- a/remmina/src/remmina_protocol_widget.h
+++ b/remmina/src/remmina_protocol_widget.h
@@ -151,6 +151,7 @@ void remmina_protocol_widget_send_keystrokes(RemminaProtocolWidget* gp, GtkMenuI
 /* Take screenshot of plugin */
 gboolean remmina_protocol_widget_plugin_screenshot(RemminaProtocolWidget* gp, RemminaPluginScreenshotData *rpsd);
 
+
 G_END_DECLS
 
 #endif  /* __REMMINAPROTOCOLWIDGET_H__  */


### PR DESCRIPTION
Allow remmina to be run under native wayland.
Tested under Arch Gnome on Wayland, with
```
GDK_BACKEND=wayland remmina
```
- Plugins which use GtkSocket will report a correct error and will never be able to run
- Remmina still need to be linked to Xorg libraries for some extra functions (ie: keyboard mapping in RDP)
