### PR TITLE
SPICE plugin: USB redirection support + minor fixes

### DIFF
--- a/remmina-plugins/spice/spice_plugin.c
+++ b/remmina-plugins/spice/spice_plugin.c
@@ -40,6 +40,8 @@
 #  include <spice-widget.h>
 #endif
 
+#define XSPICE_DEFAULT_PORT 5900
+
 #define GET_PLUGIN_DATA(gp) (RemminaPluginSpiceData*) g_object_get_data(G_OBJECT(gp), "plugin-data")
 
 enum
@@ -84,7 +86,7 @@ static void remmina_plugin_spice_init(RemminaProtocolWidget *gp)
 
 	remminafile = remmina_plugin_service->protocol_plugin_get_file(gp);
 	remmina_plugin_service->get_server_port(remmina_plugin_service->file_get_string(remminafile, "server"),
-	                                        5900,
+	                                        XSPICE_DEFAULT_PORT,
 	                                        &host,
 	                                        &port);
 
@@ -208,7 +210,7 @@ static void remmina_plugin_spice_main_channel_event_cb(SpiceChannel *channel, Sp
 	{
 		case SPICE_CHANNEL_CLOSED:
 			remmina_plugin_service->get_server_port(remmina_plugin_service->file_get_string(remminafile, "server"),
-			                                        5900,
+			                                        XSPICE_DEFAULT_PORT,
 			                                        &server,
 			                                        &port);
 			remmina_plugin_service->protocol_plugin_set_error(gp, _("Disconnected from SPICE server %s."), server);

--- a/remmina/src/remmina_masterthread_exec.h
+++ b/remmina/src/remmina_masterthread_exec.h
@@ -139,7 +139,7 @@ typedef struct remmina_masterthread_exec_data
 			RemminaProtocolWidget* gp;
 			const gchar* signal_name;
 		} protocolwidget_emit_signal;
-#if defined (HAVE_LIBSSH) && defined (HAVE_LIBVTE)
+#ifdef HAVE_LIBSSH
 		struct
 		{
 			RemminaSFTPClient *client;

--- a/remmina/src/remmina_public.c
+++ b/remmina/src/remmina_public.c
@@ -355,38 +355,42 @@ void remmina_public_get_server_port(const gchar *server, gint defaultport, gchar
 
 	str = g_strdup(server);
 
-	/* [server]:port format */
-	ptr = strchr(str, '[');
-	if (ptr)
+	if (str)
 	{
-		ptr++;
-		ptr2 = strchr(ptr, ']');
-		if (ptr2)
+		/* [server]:port format */
+		ptr = strchr(str, '[');
+		if (ptr)
 		{
-			*ptr2++ = '\0';
-			if (*ptr2 == ':')
-				defaultport = atoi(ptr2 + 1);
+			ptr++;
+			ptr2 = strchr(ptr, ']');
+			if (ptr2)
+			{
+				*ptr2++ = '\0';
+				if (*ptr2 == ':')
+					defaultport = atoi(ptr2 + 1);
+			}
+			if (host)
+				*host = g_strdup(ptr);
+			if (port)
+				*port = defaultport;
+			g_free(str);
+			return;
 		}
-		if (host)
-			*host = g_strdup(ptr);
-		if (port)
-			*port = defaultport;
-		g_free(str);
-		return;
+
+		/* server:port format, IPv6 cannot use this format */
+		ptr = strchr(str, ':');
+		if (ptr)
+		{
+			ptr2 = strchr(ptr + 1, ':');
+			if (ptr2 == NULL)
+			{
+				*ptr++ = '\0';
+				defaultport = atoi(ptr);
+			}
+			/* More than one ':' means this is IPv6 address. Treat it as a whole address */
+		}
 	}
 
-	/* server:port format, IPv6 cannot use this format */
-	ptr = strchr(str, ':');
-	if (ptr)
-	{
-		ptr2 = strchr(ptr + 1, ':');
-		if (ptr2 == NULL)
-		{
-			*ptr++ = '\0';
-			defaultport = atoi(ptr);
-		}
-		/* More than one ':' means this is IPv6 address. Treat it as a whole address */
-	}
 	if (host)
 		*host = str;
 	else


### PR DESCRIPTION
The implementation has been taken from `spicy`.

Testing it on ArchLinux requires [this workaround](https://bbs.archlinux.org/viewtopic.php?id=210135) due to a [bug](https://bugs.archlinux.org/task/49179) in the latest version of the package `spice-gtk3`.

Could you test it on other distributions ?