### PR TITLE
Remmina Connection Window at the center of its parent

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -2342,6 +2342,7 @@ static void remmina_connection_window_init(RemminaConnectionWindow* cnnwin)
 	priv->view_mode = AUTO_MODE;
 	priv->floating_toolbar_opacity = 1.0;
 
+	gtk_window_set_position (GTK_WINDOW(cnnwin), GTK_WIN_POS_CENTER_ON_PARENT);
 	gtk_container_set_border_width(GTK_CONTAINER(cnnwin), 0);
 
 	remmina_widget_pool_register(GTK_WIDGET(cnnwin));

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -2342,7 +2342,7 @@ static void remmina_connection_window_init(RemminaConnectionWindow* cnnwin)
 	priv->view_mode = AUTO_MODE;
 	priv->floating_toolbar_opacity = 1.0;
 
-	gtk_window_set_position (GTK_WINDOW(cnnwin), GTK_WIN_POS_CENTER_ON_PARENT);
+	gtk_window_set_position (GTK_WINDOW(cnnwin), GTK_WIN_POS_CENTER_ALWAYS);
 	gtk_container_set_border_width(GTK_CONTAINER(cnnwin), 0);
 
 	remmina_widget_pool_register(GTK_WIDGET(cnnwin));

--- a/remmina/src/remmina_init_dialog.c
+++ b/remmina/src/remmina_init_dialog.c
@@ -850,7 +850,6 @@ gint remmina_init_dialog_serverkey_confirm(RemminaInitDialog *dialog, const gcha
 	return ret;
 }
 
-
 gint remmina_init_dialog_serverkey_unknown(RemminaInitDialog *dialog, const gchar *serverkey)
 {
 	TRACE_CALL("remmina_init_dialog_serverkey_unknown");
@@ -869,4 +868,3 @@ gint remmina_init_dialog_serverkey_changed(RemminaInitDialog *dialog, const gcha
 	        _("WARNING: The server has changed its public key. This means either you are under attack,\n"
 	          "or the administrator has changed the key. The new public key fingerprint is:"));
 }
-

--- a/remmina/src/remmina_init_dialog.c
+++ b/remmina/src/remmina_init_dialog.c
@@ -88,6 +88,7 @@ static void remmina_init_dialog_init(RemminaInitDialog *dialog)
 
 	gtk_dialog_set_default_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
 
+	gtk_window_set_position(GTK_WINDOW(dialog), GTK_WIN_POS_CENTER_ALWAYS);
 	gtk_window_set_resizable(GTK_WINDOW(dialog), FALSE);
 
 	/**** Create the dialog content from here ****/


### PR DESCRIPTION
This PR should fix #873 , placing the remmina connection window at the center of it parent.