### PR TITLE
Implementing RDP remote scaling and orientation

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -714,6 +714,7 @@ static gboolean remmina_rdp_main(RemminaProtocolWidget* gp)
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	gchar *gateway_host;
 	gint gateway_port;
+	gint desktopOrientation, desktopScaleFactor, deviceScaleFactor;
 
 	remminafile = remmina_plugin_service->protocol_plugin_get_file(gp);
 
@@ -906,6 +907,15 @@ static gboolean remmina_rdp_main(RemminaProtocolWidget* gp)
 	rfi->settings->FastPathInput = True;
 	rfi->settings->FastPathOutput = True;
 
+	/* Orientation and scaling settings */
+	remmina_rdp_settings_get_orientation_scale_prefs(&desktopOrientation, &desktopScaleFactor, &deviceScaleFactor);
+
+	rfi->settings->DesktopOrientation = desktopOrientation;
+	if (desktopScaleFactor != 0 && deviceScaleFactor != 0)
+	{
+		rfi->settings->DesktopScaleFactor = desktopScaleFactor;
+		rfi->settings->DeviceScaleFactor = deviceScaleFactor;
+	}
 
 	cs = remmina_plugin_service->file_get_string(remminafile, "sound");
 

--- a/remmina-plugins/rdp/rdp_settings.c
+++ b/remmina-plugins/rdp/rdp_settings.c
@@ -94,6 +94,15 @@ typedef struct _RemminaPluginRdpsetGrid
 	GtkWidget* composition_check;
 	GtkWidget* use_client_keymap_check;
 
+	/* FreeRDP /scale-desktop: Scaling of desktop app */
+	GtkWidget* desktop_scale_factor_spin;
+	/* FreeRDP /scale-device: Scaling of appstore app */
+	GtkListStore* device_scale_factor_store;
+	GtkWidget* device_scale_factor_combo;
+	/* FreeRDP /orientation: Orientation of display */
+	GtkListStore* desktop_orientation_store;
+	GtkWidget* desktop_orientation_combo;
+
 	guint quality_values[10];
 } RemminaPluginRdpsetGrid;
 
@@ -118,6 +127,7 @@ static void remmina_rdp_settings_grid_destroy(GtkWidget* widget, gpointer data)
 	guint new_layout;
 	GtkTreeIter iter;
 	RemminaPluginRdpsetGrid* grid;
+	gint val;
 
 	grid = REMMINA_RDPSET_GRID(widget);
 
@@ -154,6 +164,32 @@ static void remmina_rdp_settings_grid_destroy(GtkWidget* widget, gpointer data)
 	s = g_strdup_printf("%X", grid->quality_values[9]);
 	remmina_plugin_service->pref_set_value("rdp_quality_9", s);
 	g_free(s);
+
+	if (gtk_combo_box_get_active_iter(GTK_COMBO_BOX(grid->device_scale_factor_combo), &iter))
+	{
+		gtk_tree_model_get(GTK_TREE_MODEL(grid->device_scale_factor_store), &iter, 0, &val, -1);
+	} else {
+		val = 0;
+	}
+	s = g_strdup_printf("%d", val);
+	remmina_plugin_service->pref_set_value("rdp_deviceScaleFactor", s);
+	g_free(s);
+
+	val = gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin));
+	s = g_strdup_printf("%d", val);
+	remmina_plugin_service->pref_set_value("rdp_desktopScaleFactor", s);
+	g_free(s);
+
+	if (gtk_combo_box_get_active_iter(GTK_COMBO_BOX(grid->desktop_orientation_combo), &iter))
+	{
+		gtk_tree_model_get(GTK_TREE_MODEL(grid->desktop_orientation_store), &iter, 0, &val, -1);
+	} else {
+		val = 0;
+	}
+	s = g_strdup_printf("%d", val);
+	remmina_plugin_service->pref_set_value("rdp_desktopOrientation", s);
+	g_free(s);
+
 }
 
 static void remmina_rdp_settings_grid_load_layout(RemminaPluginRdpsetGrid* grid)
@@ -192,6 +228,40 @@ static void remmina_rdp_settings_grid_load_layout(RemminaPluginRdpsetGrid* grid)
 	free(layouts);
 }
 
+
+static void remmina_rdp_settings_grid_load_devicescalefactor_combo(RemminaPluginRdpsetGrid* grid)
+{
+	TRACE_CALL("remmina_rdp_settings_grid_load_devicescalefactor_combo");
+	GtkTreeIter iter;
+
+	gtk_list_store_append(grid->device_scale_factor_store, &iter);
+	gtk_list_store_set(grid->device_scale_factor_store, &iter, 0, 0, 1, _("<Not set>"), -1);
+	gtk_list_store_append(grid->device_scale_factor_store, &iter);
+	gtk_list_store_set(grid->device_scale_factor_store, &iter, 0, 100, 1, "100%", -1);
+	gtk_list_store_append(grid->device_scale_factor_store, &iter);
+	gtk_list_store_set(grid->device_scale_factor_store, &iter, 0, 140, 1, "140%", -1);
+	gtk_list_store_append(grid->device_scale_factor_store, &iter);
+	gtk_list_store_set(grid->device_scale_factor_store, &iter, 0, 180, 1, "180%", -1);
+
+}
+
+static void remmina_rdp_settings_grid_load_desktoporientation_combo(RemminaPluginRdpsetGrid* grid)
+{
+	TRACE_CALL("remmina_rdp_settings_grid_load_desktoporientation_combo");
+	GtkTreeIter iter;
+
+	gtk_list_store_append(grid->desktop_orientation_store, &iter);
+	gtk_list_store_set(grid->desktop_orientation_store, &iter, 0, 0, 1, "0°", -1);
+	gtk_list_store_append(grid->desktop_orientation_store, &iter);
+	gtk_list_store_set(grid->desktop_orientation_store, &iter, 0, 90, 1, "90°", -1);
+	gtk_list_store_append(grid->desktop_orientation_store, &iter);
+	gtk_list_store_set(grid->desktop_orientation_store, &iter, 0, 180, 1, "180°", -1);
+	gtk_list_store_append(grid->desktop_orientation_store, &iter);
+	gtk_list_store_set(grid->desktop_orientation_store, &iter, 0, 270, 1, "270°", -1);
+
+}
+
+
 static void remmina_rdp_settings_grid_load_quality(RemminaPluginRdpsetGrid* grid)
 {
 	TRACE_CALL("remmina_rdp_settings_grid_load_quality");
@@ -226,6 +296,30 @@ static void remmina_rdp_settings_grid_load_quality(RemminaPluginRdpsetGrid* grid
 	value = remmina_plugin_service->pref_get_value("rdp_quality_9");
 	grid->quality_values[9] = (value && value[0] ? strtoul(value, NULL, 16) : DEFAULT_QUALITY_9);
 	g_free(value);
+}
+
+static void remmina_rdp_settings_appscale_on_changed(GtkComboBox *widget, RemminaPluginRdpsetGrid *grid)
+{
+	TRACE_CALL("remmina_rdp_settings_appscale_on_changed");
+	GtkTreeIter iter;
+	guint i = 0;
+
+	if (gtk_combo_box_get_active_iter(GTK_COMBO_BOX(grid->device_scale_factor_combo), &iter))
+	{
+		gtk_tree_model_get(GTK_TREE_MODEL(grid->device_scale_factor_store), &iter, 0, &i, -1);
+	}
+	if (i == 0)
+	{
+		gtk_widget_set_sensitive(GTK_WIDGET(grid->desktop_scale_factor_spin), FALSE);
+		gtk_spin_button_set_range(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin), 0, 0);
+		gtk_spin_button_set_value(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin), 0);
+	}
+	else
+	{
+		gtk_widget_set_sensitive(GTK_WIDGET(grid->desktop_scale_factor_spin), TRUE);
+		gtk_spin_button_set_range(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin), 100, 500);
+		// gtk_spin_button_set_value(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin), i);
+	}
 }
 
 static void remmina_rdp_settings_quality_on_changed(GtkComboBox *widget, RemminaPluginRdpsetGrid *grid)
@@ -293,12 +387,39 @@ static void remmina_rdp_settings_quality_option_on_toggled(GtkToggleButton* togg
 	}
 }
 
+static void remmina_rdp_settings_set_combo_active_item(GtkComboBox* combo, int itemval)
+{
+	GtkTreeIter iter;
+	int i;
+	GtkTreeModel *m;
+	gboolean valid;
+
+	m = gtk_combo_box_get_model(combo);
+	if (!m)
+	{
+		return;
+	}
+
+	valid = gtk_tree_model_get_iter_first(m, &iter);
+	while(valid)
+	{
+		gtk_tree_model_get(m, &iter, 0, &i, -1);
+		if (i == itemval)
+		{
+			gtk_combo_box_set_active_iter(combo, &iter);
+		}
+		valid = gtk_tree_model_iter_next (m, &iter);
+	}
+
+}
+
 static void remmina_rdp_settings_grid_init(RemminaPluginRdpsetGrid *grid)
 {
 	TRACE_CALL("remmina_rdp_settings_grid_init");
 	gchar* s;
 	GtkWidget* widget;
 	GtkCellRenderer* renderer;
+	int desktopOrientation, desktopScaleFactor, deviceScaleFactor;
 
 	/* Create the grid */
 	g_signal_connect(G_OBJECT(grid), "destroy", G_CALLBACK(remmina_rdp_settings_grid_destroy), NULL);
@@ -421,6 +542,71 @@ static void remmina_rdp_settings_grid_init(RemminaPluginRdpsetGrid *grid)
 	grid->composition_check = widget;
 
 	gtk_combo_box_set_active(GTK_COMBO_BOX (grid->quality_combo), 0);
+
+
+	widget = gtk_label_new(_("Remote scale factor"));
+	gtk_widget_show(widget);
+	gtk_widget_set_halign (GTK_WIDGET(widget), GTK_ALIGN_START);
+	gtk_widget_set_valign (GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+	gtk_grid_attach(GTK_GRID(grid), widget, 0, 27, 1, 1);
+
+	grid->device_scale_factor_store = gtk_list_store_new(2, G_TYPE_INT, G_TYPE_STRING);
+	grid->desktop_orientation_store = gtk_list_store_new(2, G_TYPE_INT, G_TYPE_STRING);
+
+	remmina_rdp_settings_get_orientation_scale_prefs(&desktopOrientation, &desktopScaleFactor, &deviceScaleFactor);
+	remmina_rdp_settings_grid_load_devicescalefactor_combo(grid);
+	remmina_rdp_settings_grid_load_desktoporientation_combo(grid);
+
+	widget = gtk_label_new(_("Desktop scale factor %"));
+	gtk_widget_show(widget);
+	gtk_widget_set_halign (GTK_WIDGET(widget), GTK_ALIGN_START);
+	gtk_widget_set_valign (GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+	gtk_grid_attach(GTK_GRID(grid), widget, 1, 27, 1, 1);
+
+	widget = gtk_spin_button_new_with_range(0, 10000, 1);
+	gtk_widget_show(widget);
+	gtk_grid_attach(GTK_GRID(grid), widget, 2, 27, 1, 1);
+	grid->desktop_scale_factor_spin = widget;
+
+	widget = gtk_label_new(_("Device scale factor %"));
+	gtk_widget_show(widget);
+	gtk_widget_set_halign (GTK_WIDGET(widget), GTK_ALIGN_START);
+	gtk_widget_set_valign (GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+	gtk_grid_attach(GTK_GRID(grid), widget, 1, 28, 1, 1);
+
+	widget = gtk_combo_box_new_with_model(GTK_TREE_MODEL(grid->device_scale_factor_store));
+	gtk_widget_show(widget);
+	gtk_grid_attach(GTK_GRID(grid), widget, 2, 28, 1, 1);
+
+	renderer = gtk_cell_renderer_text_new();
+	gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(widget), renderer, TRUE);
+	gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(widget), renderer, "text", 1);
+	grid->device_scale_factor_combo = widget;
+
+	remmina_rdp_settings_set_combo_active_item(GTK_COMBO_BOX(grid->device_scale_factor_combo), deviceScaleFactor);
+	gtk_spin_button_set_value(GTK_SPIN_BUTTON(grid->desktop_scale_factor_spin), (gdouble)desktopScaleFactor);
+
+	g_signal_connect(G_OBJECT(widget), "changed",
+		G_CALLBACK(remmina_rdp_settings_appscale_on_changed), grid);
+	remmina_rdp_settings_appscale_on_changed(GTK_COMBO_BOX(grid->device_scale_factor_combo), grid);
+
+	widget = gtk_label_new(_("Desktop orientation"));
+	gtk_widget_show(widget);
+	gtk_widget_set_halign (GTK_WIDGET(widget), GTK_ALIGN_START);
+	gtk_widget_set_valign (GTK_WIDGET(widget), GTK_ALIGN_CENTER);
+	gtk_grid_attach(GTK_GRID(grid), widget, 0, 29, 1, 1);
+
+	widget = gtk_combo_box_new_with_model(GTK_TREE_MODEL(grid->desktop_orientation_store));
+	gtk_widget_show(widget);
+	gtk_grid_attach(GTK_GRID(grid), widget, 1, 29, 1, 1);
+
+	renderer = gtk_cell_renderer_text_new();
+	gtk_cell_layout_pack_start(GTK_CELL_LAYOUT(widget), renderer, TRUE);
+	gtk_cell_layout_add_attribute(GTK_CELL_LAYOUT(widget), renderer, "text", 1);
+	grid->desktop_orientation_combo = widget;
+
+	remmina_rdp_settings_set_combo_active_item(GTK_COMBO_BOX(grid->desktop_orientation_combo), desktopOrientation);
+
 }
 
 GtkWidget* remmina_rdp_settings_new(void)
@@ -434,3 +620,37 @@ GtkWidget* remmina_rdp_settings_new(void)
 	return widget;
 }
 
+void remmina_rdp_settings_get_orientation_scale_prefs(int *desktopOrientation, int *desktopScaleFactor, int *deviceScaleFactor)
+{
+	TRACE_CALL("remmina_rdp_settings_get_scaling_prefs");
+
+	/* See https://msdn.microsoft.com/en-us/library/cc240510.aspx */
+
+	int orientation, dpsf, desf;
+	gchar* s;
+
+	*desktopOrientation = *desktopScaleFactor = *deviceScaleFactor = 0;
+
+	s = remmina_plugin_service->pref_get_value("rdp_desktopOrientation");
+	orientation = s ? atoi(s) : 0;
+	g_free(s);
+	if (orientation != 90 && orientation != 180 && orientation != 270)
+		orientation = 0;
+	*desktopOrientation = orientation;
+
+	s = remmina_plugin_service->pref_get_value("rdp_desktopScaleFactor");
+	dpsf = s ? atoi(s) : 0;
+	g_free(s);
+	if (dpsf < 100 || dpsf > 500)
+		return;
+
+	s = remmina_plugin_service->pref_get_value("rdp_deviceScaleFactor");
+	desf = s ? atoi(s) : 0;
+	g_free(s);
+	if (desf != 100 && desf != 140 && desf != 180)
+		return;
+
+	*desktopScaleFactor = dpsf;
+	*deviceScaleFactor = desf;
+
+}

--- a/remmina-plugins/rdp/rdp_settings.h
+++ b/remmina-plugins/rdp/rdp_settings.h
@@ -1,6 +1,6 @@
 /*
  * Remmina - The GTK+ Remote Desktop Client
- * Copyright (C) 2010-2011 Vic Lee 
+ * Copyright (C) 2010-2011 Vic Lee
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,7 +14,7 @@
  *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin Street, Fifth Floor, 
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor,
  * Boston, MA  02110-1301, USA.
  *
  *  In addition, as a special exception, the copyright holders give
@@ -40,6 +40,8 @@ G_BEGIN_DECLS
 void remmina_rdp_settings_init(void);
 guint remmina_rdp_settings_get_keyboard_layout(void);
 GtkWidget* remmina_rdp_settings_new(void);
+
+void remmina_rdp_settings_get_orientation_scale_prefs(int *desktopOrientation, int *desktopScaleFactor, int *deviceScaleFactor);
 
 G_END_DECLS
 


### PR DESCRIPTION
This PR enables RDP server scaling in HiDPI display and screen orientation, and fixes #969.
Remote scaling and orientation are documented in [[MS-RDPBCGR] TS_UD_CS_CORE](https://msdn.microsoft.com/en-us/library/cc240510.aspx).
Settings are currently not automatically detected from your current monitor: you must manually enable them in remmina global setttings, RDP tab.
Orientation: can be 0, 90, 180, 270 degrees.
Desktop Scale Factor: scaling of desktop and desktop apps, range from 100% to 500%
Device Scale Factor: scaling of metro (appstore?) apps. Works on Win2012R2, windows 10 seems to ignore it. Can only be 100%, 140% or 180%.
