### PR TITLE
When focus-in inside the quick search, select the whole text as per #544

### DIFF
--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -960,6 +960,7 @@ gboolean remmina_main_quickconnect_on_click(GtkWidget *widget, gpointer user_dat
 	return remmina_main_quickconnect();
 }
 
+/* Select all the text inside the quick search box if there is anything */
 void remmina_main_quick_search_enter(GtkWidget *widget, gpointer user_data)
 {
 	if (gtk_entry_get_text(remminamain->entry_quick_connect_server))

--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -960,6 +960,12 @@ gboolean remmina_main_quickconnect_on_click(GtkWidget *widget, gpointer user_dat
 	return remmina_main_quickconnect();
 }
 
+void remmina_main_quick_search_enter(GtkWidget *widget, gpointer user_data)
+{
+	if (gtk_entry_get_text(remminamain->entry_quick_connect_server))
+	gtk_editable_select_region(GTK_EDITABLE(remminamain->entry_quick_connect_server), 0, -1);
+}
+
 /* Handle double click on a row in the connections list */
 void remmina_main_file_list_on_row_activated(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data)
 {

--- a/remmina/ui/remmina_main.glade
+++ b/remmina/ui/remmina_main.glade
@@ -297,6 +297,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
                     <property name="input_hints">GTK_INPUT_HINT_WORD_COMPLETION | GTK_INPUT_HINT_NONE</property>
                     <signal name="activate" handler="remmina_main_quickconnect_on_click" swapped="no"/>
                     <signal name="changed" handler="remmina_main_quick_search_on_changed" swapped="no"/>
+                    <signal name="focus-in-event" handler="remmina_main_quick_search_enter" swapped="no"/>
                     <signal name="icon-press" handler="remmina_main_quick_search_on_icon_press" swapped="no"/>
                     <signal name="insert-at-cursor" handler="remmina_main_load_files_cb" swapped="no"/>
                     <accelerator key="f" signal="grab-focus" modifiers="GDK_CONTROL_MASK"/>


### PR DESCRIPTION
This PR does nothing special than just adding an event when entering the quick search entry widget.

It shouldn't break up anything, but please test it if you can.

To test, just enter some text in the quick search, leave the box, with TAB for example and go back again with the S-TAB (with the mouse it won't work and it's normal).