### PR TITLE
XDG base directory spec

### DIFF
--- a/remmina/src/remmina_applet_menu.c
+++ b/remmina/src/remmina_applet_menu.c
@@ -273,7 +273,7 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 	GDir *dir;
 	const gchar *name;
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 	if (dir != NULL)
 	{
 		/* Iterate all remote desktop profiles */
@@ -281,7 +281,7 @@ void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 		{
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
-			g_snprintf(filename, sizeof(filename), "%s/%s", remmina_file_get_user_datadir(), name);
+			g_snprintf(filename, sizeof(filename), "%s/%s", remmina_file_get_datadir(), name);
 
 			menuitem = remmina_applet_menu_item_new(REMMINA_APPLET_MENU_ITEM_FILE, filename);
 			if (menuitem != NULL)

--- a/remmina/src/remmina_file.c
+++ b/remmina/src/remmina_file.c
@@ -157,9 +157,9 @@ void remmina_file_generate_filename(RemminaFile *remminafile)
 	g_free(remminafile->filename);
 	g_get_current_time(&gtime);
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 	if (dir != NULL)
-		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", remmina_file_get_user_datadir(), gtime.tv_sec,
+		remminafile->filename = g_strdup_printf("%s/%li%03li.remmina", remmina_file_get_datadir(), gtime.tv_sec,
 		                                        gtime.tv_usec / 1000);
 	else
 		remminafile->filename = NULL;

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -57,14 +57,12 @@ gchar *remmina_file_get_user_datadir(void)
 
 	/* Legacy ~/.remmina */
 	remminadir = g_build_path ("/", g_get_home_dir(), dir, NULL);
-	printf ("%s\n", remminadir);
 	if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
 		return remminadir;
 	g_free (remminadir), remminadir = NULL;
 
 	/* ~/.local/share/remmina */
 	remminadir = g_build_path ( "/", g_get_user_data_dir (), g_get_prgname (), NULL);
-	printf ("%s\n", remminadir);
 	if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
 		 return remminadir;
 	g_free (remminadir), remminadir = NULL;
@@ -75,7 +73,6 @@ gchar *remmina_file_get_user_datadir(void)
 	for (i = 0; dirs[i] != NULL; ++i)
 	{
 		remminadir = g_build_path ( "/", dirs[i], g_get_prgname (), NULL);
-		printf ("%s\n", remminadir);
 		if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
 			return remminadir;
 		g_free (remminadir), remminadir = NULL;
@@ -83,7 +80,6 @@ gchar *remmina_file_get_user_datadir(void)
 
 	/* The last case we use  the home ~/.local/share/remmina */
 	remminadir = g_build_path ( "/", g_get_user_data_dir (), g_get_prgname (), NULL);
-	printf ("Finallly choosen: %s\n", remminadir);
 	return remminadir;
 }
 

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -44,7 +44,6 @@
 #include "remmina_file_manager.h"
 #include "remmina/remmina_trace_calls.h"
 
-//static gchar remminadir[MAX_PATH_LEN];
 static gchar *remminadir;
 
 gchar *remmina_file_get_user_datadir(void)

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -130,7 +130,6 @@ void remmina_file_manager_init(void)
 					g_build_path ( "/", g_get_user_data_dir (),
 						g_get_prgname (), filename, NULL));
 			}
-			break;
 		}
 		g_free (remminadir), remminadir = NULL;
 	}

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -51,7 +51,6 @@ gchar *remmina_file_get_datadir(void)
 {
 	TRACE_CALL("remmina_file_get_datadir");
 	gchar *dir = g_strdup_printf (".%s", g_get_prgname ());
-	gchar *ret = NULL;
 	int i;
 	/* Legacy ~/.remmina */
 	remminadir = g_build_path ("/", g_get_home_dir(), dir, NULL);
@@ -95,7 +94,6 @@ void remmina_file_manager_init(void)
 	TRACE_CALL("remmina_file_manager_init");
 	GDir *dir;
 	gchar *legacy = g_strdup_printf (".%s", g_get_prgname ());
-	gchar *ret = NULL;
 	const gchar *filename;
 	int i;
 

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -50,17 +50,17 @@ gchar* remmina_file_get_user_datadir(void)
 {
 
 	TRACE_CALL("remmina_file_get_user_datadir");
-	GDir *old;
+	GDir *dir;
 
 	if (remminadir[0] == '\0') {
-		/* If the old .remmina exists, use it. */
+		/* If the old ~/.remmina exists, use it. */
 		g_snprintf(remminadir, sizeof(remminadir), "%s/.%s", g_get_home_dir(), remmina);
-		old = g_dir_open(remminadir, 0, NULL);
-		if (old == NULL)
+		dir = g_dir_open(remminadir, 0, NULL);
+		if (dir == NULL)
 			/* If the XDG directories exist, use them. */
 			g_snprintf(remminadir, sizeof(remminadir), "%s/%s", g_get_user_data_dir(), remmina);
 		else
-			g_dir_close(old);
+			g_dir_close(dir);
 	}
 	return remminadir;
 }

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -46,26 +46,23 @@
 
 static gchar *remminadir;
 
-gchar *remmina_file_get_user_datadir(void)
+/* return first found data dir as per XDG specs */
+gchar *remmina_file_get_datadir(void)
 {
-
-	TRACE_CALL("remmina_file_get_user_datadir");
+	TRACE_CALL("remmina_file_get_datadir");
 	gchar *dir = g_strdup_printf (".%s", g_get_prgname ());
 	gchar *ret = NULL;
 	int i;
-
 	/* Legacy ~/.remmina */
 	remminadir = g_build_path ("/", g_get_home_dir(), dir, NULL);
 	if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
 		return remminadir;
 	g_free (remminadir), remminadir = NULL;
-
 	/* ~/.local/share/remmina */
 	remminadir = g_build_path ( "/", g_get_user_data_dir (), g_get_prgname (), NULL);
 	if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
 		 return remminadir;
 	g_free (remminadir), remminadir = NULL;
-
 	/* /usr/local/share/remmina */
 	const gchar * const *dirs = g_get_system_data_dirs ();
 	g_free (remminadir), remminadir = NULL;
@@ -76,16 +73,51 @@ gchar *remmina_file_get_user_datadir(void)
 			return remminadir;
 		g_free (remminadir), remminadir = NULL;
 	}
-
 	/* The last case we use  the home ~/.local/share/remmina */
 	remminadir = g_build_path ( "/", g_get_user_data_dir (), g_get_prgname (), NULL);
 	return remminadir;
 }
 
+static gboolean remmina_file_manager_do_copy(const char *src_path, const char *dst_path)
+{
+	GFile *src = g_file_new_for_path(src_path), *dst = g_file_new_for_path(dst_path);
+	const gboolean ok = g_file_copy(src, dst, G_FILE_COPY_NONE, NULL, NULL, NULL, NULL);
+	g_object_unref(dst);
+	g_object_unref(src);
+
+	return ok;
+}
+
 void remmina_file_manager_init(void)
 {
 	TRACE_CALL("remmina_file_manager_init");
-	g_mkdir_with_parents(remmina_file_get_user_datadir(), 0700);
+	GDir *dir;
+	gchar *ret = NULL;
+	const gchar *filename;
+	int i;
+
+	remminadir = g_build_path ( "/", g_get_user_data_dir (), g_get_prgname (), NULL);
+	/* Create the XDG_USER_DATA dorectory */
+	g_mkdir_with_parents (remminadir, 0750);
+
+	/* /usr/local/share/remmina */
+	const gchar * const *dirs = g_get_system_data_dirs ();
+	g_free (remminadir), remminadir = NULL;
+	for (i = 0; dirs[i] != NULL; ++i)
+	{
+		remminadir = g_build_path ( "/", dirs[i], g_get_prgname (), NULL);
+		if (g_file_test (remminadir, G_FILE_TEST_IS_DIR))
+		{
+			dir = g_dir_open(remminadir, 0, NULL);
+			while ((filename = g_dir_read_name (dir)) != NULL) {
+				remmina_file_manager_do_copy(
+					g_build_path ( "/", remminadir, filename, NULL),
+					g_build_path ( "/", g_get_user_data_dir (),
+						g_get_prgname (), filename, NULL));
+			}
+		}
+		g_free (remminadir), remminadir = NULL;
+	}
 }
 
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
@@ -97,7 +129,7 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 	RemminaFile* remminafile;
 	gint items_count = 0;
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 
 	if (dir)
 	{
@@ -106,7 +138,7 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 			if (!g_str_has_suffix(name, ".remmina"))
 				continue;
 			g_snprintf(filename, MAX_PATH_LEN, "%s/%s",
-					remmina_file_get_user_datadir(), name);
+					remmina_file_get_datadir(), name);
 			remminafile = remmina_file_load(filename);
 			if (remminafile)
 			{
@@ -133,7 +165,7 @@ gchar* remmina_file_manager_get_groups(void)
 
 	array = remmina_string_array_new();
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 
 	if (dir == NULL)
 		return 0;
@@ -141,7 +173,7 @@ gchar* remmina_file_manager_get_groups(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_user_datadir(), name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_datadir(), name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		if (group && remmina_string_array_find(array, group) < 0)
@@ -236,7 +268,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 
 	root = g_node_new(NULL);
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 
 	if (dir == NULL)
 		return root;
@@ -244,7 +276,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 	{
 		if (!g_str_has_suffix(name, ".remmina"))
 			continue;
-		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_user_datadir(), name);
+		g_snprintf(filename, MAX_PATH_LEN, "%s/%s", remmina_file_get_datadir(), name);
 		remminafile = remmina_file_load(filename);
 		group = remmina_file_get_string(remminafile, "group");
 		remmina_file_manager_add_group(root, group);

--- a/remmina/src/remmina_file_manager.h
+++ b/remmina/src/remmina_file_manager.h
@@ -47,7 +47,7 @@ typedef struct _RemminaGroupData
 } RemminaGroupData;
 
 /* Initialize */
-gchar* remmina_file_get_user_datadir(void);
+gchar* remmina_file_get_datadir(void);
 void remmina_file_manager_init(void);
 /* Iterate all .remmina connections in the home directory */
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data);

--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -155,7 +155,7 @@ RemminaPluginService remmina_plugin_manager_service =
 	remmina_protocol_widget_chat_receive,
 	remmina_protocol_widget_send_keys_signals,
 
-	remmina_file_get_user_datadir,
+	remmina_file_get_datadir,
 
 	remmina_file_new,
 	remmina_file_get_filename,

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -243,15 +243,15 @@ void remmina_pref_init(void)
 	TRACE_CALL("remmina_pref_init");
 	GKeyFile *gkeyfile;
 	gchar dirname[MAX_PATH_LEN];
-	GDir *old;
+	GDir *dir;
 
 	g_snprintf(dirname, sizeof(dirname), "%s/.%s", g_get_home_dir(), remmina);
-	old = g_dir_open(dirname, 0, NULL);
-	if (old == NULL)
+	dir = g_dir_open(dirname, 0, NULL);
+	if (dir == NULL)
 		/*  If the XDG directories exist, use them. */
 		g_snprintf(dirname, sizeof(dirname), "%s/%s", g_get_user_config_dir(), remmina);
 	else
-		g_dir_close(old);
+		g_dir_close(dir);
 	g_mkdir_with_parents(dirname, 0700);
 	remmina_pref_file = g_strdup_printf("%s/remmina.pref", dirname);
 	remmina_keymap_file = g_strdup_printf("%s/remmina.keymap", dirname);

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -291,7 +291,6 @@ void remmina_pref_init(void)
 						g_build_path ( "/", remmina_dir, filename, NULL),
 						g_build_path ( "/", g_get_user_config_dir (),
 							g_get_prgname (), filename, NULL));
-				break;
 			}
 			g_free (remmina_dir), remmina_dir = NULL;
 		}

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -258,7 +258,6 @@ void remmina_pref_init(void)
 	const gchar *filename = g_strdup_printf("%s.pref", g_get_prgname());
 	GDir *dir;
 	gchar *legacy = g_strdup_printf (".%s", g_get_prgname ());
-	gchar *ret = NULL;
 	int i;
 
 	remmina_dir = g_build_path ( "/", g_get_user_config_dir (), g_get_prgname (), NULL);

--- a/remmina/src/remmina_survey.c
+++ b/remmina/src/remmina_survey.c
@@ -174,13 +174,13 @@ gboolean remmina_survey_valid_profile()
 	gint min_profiles=1;    /* TODO: Use a constant */
 	gint min_days = 30;     /* TODO: Use a constant */
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, &gerror);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, &gerror);
 	if (gerror != NULL)
 	{
 		/* This should not happen */
-		g_message("Cannot open %s, with error: %s", remmina_file_get_user_datadir(), gerror->message);
+		g_message("Cannot open %s, with error: %s", remmina_file_get_datadir(), gerror->message);
 		g_error_free(gerror);
-		g_snprintf(remmina_file_get_user_datadir(), sizeof(remmina_file_get_user_datadir()),
+		g_snprintf(remmina_file_get_datadir(), sizeof(remmina_file_get_datadir()),
 				"%s/%s", g_get_user_data_dir(), "remmina");
 	}else{
 
@@ -188,7 +188,7 @@ gboolean remmina_survey_valid_profile()
 			/* Olny *.remmina files */
 			if (!g_str_has_suffix(dir_entry, ".remmina\0"))
 				continue;
-			g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_user_datadir(), dir_entry);
+			g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_datadir(), dir_entry);
 
 			if (filename != NULL)
 				count_profile++;
@@ -255,7 +255,7 @@ static gchar *remmina_survey_files_iter_setting()
 	GHashTableIter iter;
 	gpointer key, value;
 
-	dir = g_dir_open(remmina_file_get_user_datadir(), 0, NULL);
+	dir = g_dir_open(remmina_file_get_datadir(), 0, NULL);
 
 	if (dir == NULL)
 		return FALSE;
@@ -266,7 +266,7 @@ static gchar *remmina_survey_files_iter_setting()
 		/* Olny *.remmina files */
 		if (!g_str_has_suffix(dir_entry, ".remmina\0"))
 			continue;
-		g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_user_datadir(), dir_entry);
+		g_snprintf(filename, PATH_MAX, "%s/%s", remmina_file_get_datadir(), dir_entry);
 
 		if (!g_key_file_load_from_file(gkeyfile, filename, G_KEY_FILE_NONE, NULL))
 			g_key_file_free(gkeyfile);
@@ -333,7 +333,7 @@ static void remmina_survey_stats_create_html_form()
 	const gchar old[] = "<!-- STATS HOLDER -->";
 	gchar *new;
 
-	output_file_path = g_strdup_printf("%s/%s", remmina_file_get_user_datadir(), output_file_name);
+	output_file_path = g_strdup_printf("%s/%s", remmina_file_get_datadir(), output_file_name);
 
 	template = g_file_new_for_uri(templateuri);
 	output_file = g_file_new_for_path(output_file_path);
@@ -433,7 +433,7 @@ void remmina_survey_start(GtkWindow *parent)
 
 	gtk_container_add(GTK_CONTAINER(remmina_survey->scrolledwindow), GTK_WIDGET(web_view));
 	gtk_widget_show(GTK_WIDGET(web_view));
-	g_snprintf(localurl, PATH_MAX, "%s%s/%s", "file://", remmina_file_get_user_datadir(), "local_remmina_form.html");
+	g_snprintf(localurl, PATH_MAX, "%s%s/%s", "file://", remmina_file_get_datadir(), "local_remmina_form.html");
 	webkit_web_view_load_uri(web_view, localurl);
 	g_object_unref(G_OBJECT(remmina_survey->builder));
 }


### PR DESCRIPTION
Added full support for XDG_DATA_DIRS and XDG_CONFIG_DIRS as requested by #818

To test you can move away your ~/.remmina, or ~/.config/remmina and ~/.local/share/remmina directories.

You can (manually at the moment), populate your $XDG_CONFIG_DIRS/remmina (it should be /etc/xdg/remmina) with your ~/.config/remmina/remmina.pref (and move away the ~/.config/remmina directory). Same for the .remmina files you have under ~/.local/share/remmina, that you can copy into $XDG_DATA_DIRS (normally /usr/share/remmina or /usr/local/share/remmina), again, removing the ~/.local/share/remmina directory.

As a last improvements I was thinking to add by default some template profiles to show up some different Remmina configurations in the XDG system directories.

I think there is still a big issue, but I don't get how should be the good behaviour.

If there are files in the system directories and the user data and config directories don't exists yet, remmina will try to save new profiles under the system directories.

This is quite normally as per my logic and comprehension of the spec.

I can write a script to migrate profiles if you like.
