### PR TITLE
remmina.desktop: add Quit desktop action for Unity

### DIFF
--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -71,7 +71,7 @@ Icon=remmina
 Terminal=false
 Type=Application
 Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
-Actions=Profile;Tray;
+Actions=Profile;Tray;Quit;
 
 [Desktop Action Profile]
 Name=Create a New Connection Profile
@@ -122,4 +122,4 @@ Exec=@CMAKE_INSTALL_FULL_BINDIR@/remmina --icon
 [Desktop Action Quit]
 Name=Quit
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/remmina --quit
-OnlyShowIn=Unity
+OnlyShowIn=Unity;

--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -118,3 +118,8 @@ Name[tr]=Remmina'yı Küçültülmüş Başlat
 Name[uk]=Запустити Rammina у системному лотку
 Name[zh_CN]=启动后自动最小化
 Exec=@CMAKE_INSTALL_FULL_BINDIR@/remmina --icon
+
+[Desktop Action Quit]
+Name=Quit
+Exec=@CMAKE_INSTALL_FULL_BINDIR@/remmina --quit
+OnlyShowIn=Unity


### PR DESCRIPTION
It allows to override the default "Quit" command in Unity launcher
Translations are not needed for this.