### PR TITLE
Fix fullscreen window position (#873)

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -94,7 +94,6 @@ G_DEFINE_TYPE( RemminaConnectionWindow, remmina_connection_window, GTK_TYPE_WIND
 	guint floating_toolbar_motion_handler;
 	/* Other event sources to remove when deleting the object */
 	guint ftb_hide_eventsource;
-	guint go_fullscreen_eventsource;
 
 	GtkWidget* toolbar;
 	GtkWidget* grid;
@@ -426,11 +425,6 @@ static void remmina_connection_window_destroy(GtkWidget* widget, RemminaConnecti
 	{
 		g_source_remove(priv->ftb_hide_eventsource);
 		priv->ftb_hide_eventsource = 0;
-	}
-	if (priv->go_fullscreen_eventsource)
-	{
-		g_source_remove(priv->go_fullscreen_eventsource);
-		priv->go_fullscreen_eventsource = 0;
 	}
 
 #if FLOATING_TOOLBAR_WIDGET
@@ -2875,7 +2869,7 @@ static void remmina_connection_holder_create_scrolled(RemminaConnectionHolder* c
 
 }
 
-static gboolean remmina_connection_window_go_fullscreen(gpointer data)
+static gboolean remmina_connection_window_go_fullscreen(GtkWidget *widget, GdkEvent *event, gpointer data)
 {
 	TRACE_CALL("remmina_connection_window_go_fullscreen");
 	RemminaConnectionHolder* cnnhld;
@@ -2885,7 +2879,6 @@ static gboolean remmina_connection_window_go_fullscreen(gpointer data)
 	priv = cnnhld->cnnwin->priv;
 
 	gtk_window_fullscreen(GTK_WINDOW(cnnhld->cnnwin));
-	priv->go_fullscreen_eventsource = 0;
 	return FALSE;
 }
 
@@ -3123,15 +3116,8 @@ static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder*
 
 	gtk_widget_show(window);
 
-	/* Put the window in fullscren, later.
-	 * Going immediately into fullscreen makes a black border on the top of the window
-	 * under gnome shell */
-
-	if (!priv->go_fullscreen_eventsource)
-	{
-		priv->go_fullscreen_eventsource = g_idle_add(remmina_connection_window_go_fullscreen, (gpointer)cnnhld);
-	}
-
+	/* Put the window in fullscreen after it is mapped to have it appear on the same monitor */
+	g_signal_connect(G_OBJECT(window), "map-event", G_CALLBACK(remmina_connection_window_go_fullscreen), (gpointer)cnnhld);
 }
 
 static gboolean remmina_connection_window_hostkey_func(RemminaProtocolWidget* gp, guint keyval, gboolean release,


### PR DESCRIPTION
From my testing on a Fedora 25 (Gnome 3.22) system, it looks like placing the window in fullscreen from the idle callback is too soon and always places the window on monitor 0 (left one).
If gtk_window_fullscreen() is called from the "map-event" event, it places the window on the same monitor where the window was.
I didn't experience the black border issue mentioned in the previous comment. Using a signal instead of the idle callback means we don't need to track the event source identifier, which removes some code.

I'd be happy if somebody could test this on other environments (non Gnome, or pre-3.22 versions).