### PR TITLE
Code optimization for commit 2a6647a

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -1190,9 +1190,11 @@ static gboolean remmina_rdp_close_connection(RemminaProtocolWidget* gp)
 	freerdp* instance;
 	RemminaPluginRdpUiObject* ui;
 
-	if (freerdp_get_last_error(rfi->instance->context) == 0x10005)
+	gchar buf[1024];
+	if (freerdp_get_last_error(rfi->instance->context) == ((FREERDP_ERROR_ERRINFO_CLASS << 16) | ERRINFO_DISCONNECTED_BY_OTHER_CONNECTION))
 	{
-		remmina_plugin_service->protocol_plugin_set_error(gp, "Another user connected to the server, forcing the disconnection of the current connection.");
+		sprintf(buf, "ERRINFO_DISCONNECTED_BY_OTHER_CONNECTION (0x%08"PRIX32") %s", ((FREERDP_ERROR_ERRINFO_CLASS << 16) | ERRINFO_DISCONNECTED_BY_OTHER_CONNECTION), freerdp_get_error_info_string(ERRINFO_DISCONNECTED_BY_OTHER_CONNECTION));
+		remmina_plugin_service->protocol_plugin_set_error(gp, buf);
 	}
 	instance = rfi->instance;
 	if (rfi->thread)


### PR DESCRIPTION
No prompt information while another login using the same account #1114
More detailed error messages
Use the function to get the error message instead of the specified string