### PR TITLE
Fix german translation

### DIFF
--- a/remmina-plugins/rdp/rdp_event.c
+++ b/remmina-plugins/rdp/rdp_event.c
@@ -303,6 +303,7 @@ static gboolean remmina_rdp_event_on_draw(GtkWidget* widget, cairo_t* context, R
 		cairo_text_extents(context, msg, &extents);
 		cairo_move_to(context, (width - (extents.width + extents.x_bearing)) / 2, (height - (extents.height + extents.y_bearing)) / 2);
 		cairo_show_text(context, msg);
+		g_free(msg);
 
 	}
 	else

--- a/remmina/po/de.po
+++ b/remmina/po/de.po
@@ -473,7 +473,7 @@ msgstr "Verbindung als Windows-*.rdp-Datei exportieren"
 #: remmina-plugins/rdp/rdp_event.c:296
 #, c-format
 msgid "Reconnection in progress. Attempt %d of %d..."
-msgstr "Wiederherstellen der Verbindung. Versuch %s von %d..."
+msgstr "Wiederherstellen der Verbindung. Versuch %d von %d..."
 
 #: remmina-plugins/nx/nx_plugin.c:759 remmina/src/remmina_file_editor.c:331
 #: remmina/src/remmina_file_editor.c:338


### PR DESCRIPTION
Fixes a bad format string in the german translation which caused a crash, see issue #1080. Also fixes a small memory leak.