### PR TITLE
Add disable_floating_toolbar option to disable the floating toolbar in full screen mode.

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3004,6 +3004,11 @@ static void remmina_connection_holder_create_overlay_ftb_overlay(RemminaConnecti
 {
 	TRACE_CALL("remmina_connection_holder_create_overlay_ftb_overlay");
 
+	if (remmina_pref.disable_floating_toolbar)
+	{
+		return;
+	}
+
 	GtkWidget* revealer;
 	RemminaConnectionWindowPriv* priv;
 	priv = cnnhld->cnnwin->priv;

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -296,10 +296,10 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.hide_toolbar = FALSE;
 
-    if (g_key_file_has_key(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL))
-  		remmina_pref.disable_floating_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL);
-  	else
-  		remmina_pref.disable_floating_toolbar = FALSE;
+	if (g_key_file_has_key(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL))
+		remmina_pref.disable_floating_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL);
+	else
+		remmina_pref.disable_floating_toolbar = FALSE;
 
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "hide_statusbar", NULL))
 		remmina_pref.hide_statusbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "hide_statusbar", NULL);
@@ -651,7 +651,7 @@ void remmina_pref_save(void)
 	g_key_file_set_boolean (gkeyfile, "remmina_pref", "vte_system_colors", remmina_pref.vte_system_colors);
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_foreground_color", remmina_pref.vte_foreground_color ? remmina_pref.vte_foreground_color : "");
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_background_color", remmina_pref.vte_background_color ? remmina_pref.vte_background_color : "");
-  g_key_file_set_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", remmina_pref.disable_floating_toolbar);
+	g_key_file_set_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", remmina_pref.disable_floating_toolbar);
 
 	content = g_key_file_to_data(gkeyfile, &length, NULL);
 	g_file_set_contents(remmina_pref_file, content, length, NULL);

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -296,6 +296,11 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.hide_toolbar = FALSE;
 
+    if (g_key_file_has_key(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL))
+  		remmina_pref.disable_floating_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL);
+  	else
+  		remmina_pref.disable_floating_toolbar = FALSE;
+
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "hide_statusbar", NULL))
 		remmina_pref.hide_statusbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "hide_statusbar", NULL);
 	else
@@ -646,6 +651,7 @@ void remmina_pref_save(void)
 	g_key_file_set_boolean (gkeyfile, "remmina_pref", "vte_system_colors", remmina_pref.vte_system_colors);
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_foreground_color", remmina_pref.vte_foreground_color ? remmina_pref.vte_foreground_color : "");
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_background_color", remmina_pref.vte_background_color ? remmina_pref.vte_background_color : "");
+  g_key_file_set_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", remmina_pref.disable_floating_toolbar);
 
 	content = g_key_file_to_data(gkeyfile, &length, NULL);
 	g_file_set_contents(remmina_pref_file, content, length, NULL);
@@ -852,4 +858,3 @@ remmina_pref_get_value(const gchar *key)
 
 	return value;
 }
-

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -163,6 +163,8 @@ typedef struct _RemminaPref
 
 	/* Remmina birthday julian format*/
 	guint32 bdate;
+
+	gboolean disable_floating_toolbar;
 } RemminaPref;
 
 #define DEFAULT_SSH_PARSECONFIG TRUE
@@ -195,4 +197,3 @@ gchar* remmina_pref_get_value(const gchar *key);
 G_END_DECLS
 
 #endif  /* __REMMINAPREF_H__  */
-


### PR DESCRIPTION
Adds a boolean option, disable_floating_toolbar, to completely disable the floating toolbar, for those of us that use Remmina like a thin client.  

Floating toolbar gets in the way in a Windows RDP when you move the cursor to the top of the screen.  Moving it to the bottom doesn't help either, because then it interferes with the taskbar.

