### PR TITLE
Add an option to completely disable the floating toolbar in fullscreen mode

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3212,20 +3212,25 @@ static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder*
 
 	/* Create the floating toolbar */
 #if FLOATING_TOOLBAR_WIDGET
-	remmina_connection_holder_create_overlay_ftb_overlay(cnnhld);
-	/* Add drag and drop capabilities to the drop/dest target for floating toolbar */
-	gtk_drag_dest_set(GTK_WIDGET(priv->overlay), GTK_DEST_DEFAULT_MOTION | GTK_DEST_DEFAULT_HIGHLIGHT,
-			dnd_targets_ftb, sizeof dnd_targets_ftb / sizeof *dnd_targets_ftb, GDK_ACTION_MOVE);
-	gtk_drag_dest_set_track_motion(GTK_WIDGET(priv->notebook), TRUE);
-	g_signal_connect(GTK_WIDGET(priv->overlay), "drag-drop", G_CALLBACK(remmina_connection_window_ftb_drag_drop), cnnhld);
+	if (!remmina_pref.disable_floating_toolbar)
+	{
+		remmina_connection_holder_create_overlay_ftb_overlay(cnnhld);
+		/* Add drag and drop capabilities to the drop/dest target for floating toolbar */
+		gtk_drag_dest_set(GTK_WIDGET(priv->overlay), GTK_DEST_DEFAULT_MOTION | GTK_DEST_DEFAULT_HIGHLIGHT,
+				dnd_targets_ftb, sizeof dnd_targets_ftb / sizeof *dnd_targets_ftb, GDK_ACTION_MOVE);
+		gtk_drag_dest_set_track_motion(GTK_WIDGET(priv->notebook), TRUE);
+		g_signal_connect(GTK_WIDGET(priv->overlay), "drag-drop", G_CALLBACK(remmina_connection_window_ftb_drag_drop), cnnhld);
+	}
 #else
+	if (!remmina_pref.disable_floating_toolbar)
+	{
+		remmina_connection_holder_create_floating_toolbar(cnnhld, view_mode);
+		remmina_connection_holder_update_toolbar(cnnhld);
 
-	remmina_connection_holder_create_floating_toolbar(cnnhld, view_mode);
-	remmina_connection_holder_update_toolbar(cnnhld);
-
-	g_signal_connect(G_OBJECT(priv->floating_toolbar_window), "enter-notify-event", G_CALLBACK(remmina_connection_holder_floating_toolbar_on_enter), cnnhld);
-	g_signal_connect(G_OBJECT(priv->floating_toolbar_window), "scroll-event", G_CALLBACK(remmina_connection_holder_floating_toolbar_on_scroll), cnnhld);
-	gtk_widget_add_events(GTK_WIDGET(priv->floating_toolbar_window), GDK_SCROLL_MASK);
+		g_signal_connect(G_OBJECT(priv->floating_toolbar_window), "enter-notify-event", G_CALLBACK(remmina_connection_holder_floating_toolbar_on_enter), cnnhld);
+		g_signal_connect(G_OBJECT(priv->floating_toolbar_window), "scroll-event", G_CALLBACK(remmina_connection_holder_floating_toolbar_on_scroll), cnnhld);
+		gtk_widget_add_events(GTK_WIDGET(priv->floating_toolbar_window), GDK_SCROLL_MASK);
+	}
 #endif
 
 	remmina_connection_holder_check_resize(cnnhld);

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -657,7 +657,7 @@ static gboolean remmina_connection_holder_floating_toolbar_motion(RemminaConnect
 			y = t;
 
 		gtk_window_move(GTK_WINDOW(priv->floating_toolbar_window), x + cnnwin_x, y + cnnwin_y);
-		if (remmina_pref.invisible_toolbar && !priv->pin_down)
+		if (remmina_pref.fullscreen_toolbar_visibility == FLOATING_TOOLBAR_VISIBILITY_INVISIBLE && !priv->pin_down)
 		{
 #if GTK_CHECK_VERSION(3, 8, 0)
 			gtk_widget_set_opacity(GTK_WIDGET(priv->floating_toolbar_window),
@@ -740,7 +740,7 @@ static void remmina_connection_holder_floating_toolbar_show(RemminaConnectionHol
 	{
 		/* If we are hiding and the toolbar must be made invisible, schedule
 		 * a later toolbar hide */
-		if (remmina_pref.invisible_toolbar)
+		if (remmina_pref.fullscreen_toolbar_visibility == FLOATING_TOOLBAR_VISIBILITY_INVISIBLE)
 		{
 			if (priv->ftb_hide_eventsource == 0)
 				priv->ftb_hide_eventsource = g_timeout_add(1000, remmina_connection_holder_floating_toolbar_make_invisible, priv);
@@ -2403,7 +2403,7 @@ static void remmina_connection_holder_create_floating_toolbar(RemminaConnectionH
 	priv->floating_toolbar_window = ftb_popup_window;
 
 	remmina_connection_holder_update_toolbar_opacity(cnnhld);
-	if (remmina_pref.invisible_toolbar && !priv->pin_down)
+	if (remmina_pref.fullscreen_toolbar_visibility == FLOATING_TOOLBAR_VISIBILITY_INVISIBLE && !priv->pin_down)
 	{
 #if GTK_CHECK_VERSION(3, 8, 0)
 		gtk_widget_set_opacity(GTK_WIDGET(ftb_popup_window), 0.0);
@@ -3212,7 +3212,7 @@ static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder*
 
 	/* Create the floating toolbar */
 #if FLOATING_TOOLBAR_WIDGET
-	if (!remmina_pref.disable_floating_toolbar)
+	if (remmina_pref.fullscreen_toolbar_visibility != FLOATING_TOOLBAR_VISIBILITY_DISABLE)
 	{
 		remmina_connection_holder_create_overlay_ftb_overlay(cnnhld);
 		/* Add drag and drop capabilities to the drop/dest target for floating toolbar */
@@ -3222,7 +3222,7 @@ static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder*
 		g_signal_connect(GTK_WIDGET(priv->overlay), "drag-drop", G_CALLBACK(remmina_connection_window_ftb_drag_drop), cnnhld);
 	}
 #else
-	if (!remmina_pref.disable_floating_toolbar)
+	if (remmina_pref.fullscreen_toolbar_visibility != FLOATING_TOOLBAR_VISIBILITY_DISABLE)
 	{
 		remmina_connection_holder_create_floating_toolbar(cnnhld, view_mode);
 		remmina_connection_holder_update_toolbar(cnnhld);

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -250,11 +250,6 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.save_when_connect = TRUE;
 
-	if (g_key_file_has_key(gkeyfile, "remmina_pref", "invisible_toolbar", NULL))
-		remmina_pref.invisible_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "invisible_toolbar", NULL);
-	else
-		remmina_pref.invisible_toolbar = FALSE;
-
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "fullscreen_on_auto", NULL))
 		remmina_pref.fullscreen_on_auto = g_key_file_get_boolean(gkeyfile, "remmina_pref", "fullscreen_on_auto", NULL);
 	else
@@ -295,11 +290,6 @@ void remmina_pref_init(void)
 		remmina_pref.hide_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "hide_toolbar", NULL);
 	else
 		remmina_pref.hide_toolbar = FALSE;
-
-	if (g_key_file_has_key(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL))
-		remmina_pref.disable_floating_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL);
-	else
-		remmina_pref.disable_floating_toolbar = FALSE;
 
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "hide_statusbar", NULL))
 		remmina_pref.hide_statusbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "hide_statusbar", NULL);
@@ -425,6 +415,11 @@ void remmina_pref_init(void)
 		remmina_pref.tab_mode = g_key_file_get_integer(gkeyfile, "remmina_pref", "tab_mode", NULL);
 	else
 		remmina_pref.tab_mode = 0;
+
+	if (g_key_file_has_key(gkeyfile, "remmina_pref", "fullscreen_toolbar_visibility", NULL))
+		remmina_pref.fullscreen_toolbar_visibility = g_key_file_get_integer(gkeyfile, "remmina_pref", "fullscreen_toolbar_visibility", NULL);
+	else
+		remmina_pref.fullscreen_toolbar_visibility = FLOATING_TOOLBAR_VISIBILITY_PEEKING;
 	/* Show buttons icons */
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "show_buttons_icons", NULL))
 	{
@@ -599,7 +594,6 @@ void remmina_pref_save(void)
 
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "save_view_mode", remmina_pref.save_view_mode);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "save_when_connect", remmina_pref.save_when_connect);
-	g_key_file_set_boolean(gkeyfile, "remmina_pref", "invisible_toolbar", remmina_pref.invisible_toolbar);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "floating_toolbar_placement", remmina_pref.floating_toolbar_placement);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "toolbar_placement", remmina_pref.toolbar_placement);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "always_show_tab", remmina_pref.always_show_tab);
@@ -610,7 +604,6 @@ void remmina_pref_save(void)
 	g_key_file_set_string(gkeyfile, "remmina_pref", "screenshot_path", remmina_pref.screenshot_path);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "ssh_parseconfig", remmina_pref.ssh_parseconfig);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_toolbar", remmina_pref.hide_toolbar);
-	g_key_file_set_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", remmina_pref.disable_floating_toolbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_statusbar", remmina_pref.hide_statusbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "small_toolbutton", remmina_pref.small_toolbutton);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "view_file_mode", remmina_pref.view_file_mode);
@@ -632,6 +625,7 @@ void remmina_pref_save(void)
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "recent_maximum", remmina_pref.recent_maximum);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "default_mode", remmina_pref.default_mode);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "tab_mode", remmina_pref.tab_mode);
+	g_key_file_set_integer(gkeyfile, "remmina_pref", "fullscreen_toolbar_visibility", remmina_pref.fullscreen_toolbar_visibility);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "show_buttons_icons", remmina_pref.show_buttons_icons);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "show_menu_icons", remmina_pref.show_menu_icons);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "auto_scroll_step", remmina_pref.auto_scroll_step);

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -296,6 +296,11 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.hide_toolbar = FALSE;
 
+	if (g_key_file_has_key(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL))
+		remmina_pref.disable_floating_toolbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", NULL);
+	else
+		remmina_pref.disable_floating_toolbar = FALSE;
+
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "hide_statusbar", NULL))
 		remmina_pref.hide_statusbar = g_key_file_get_boolean(gkeyfile, "remmina_pref", "hide_statusbar", NULL);
 	else
@@ -605,6 +610,7 @@ void remmina_pref_save(void)
 	g_key_file_set_string(gkeyfile, "remmina_pref", "screenshot_path", remmina_pref.screenshot_path);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "ssh_parseconfig", remmina_pref.ssh_parseconfig);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_toolbar", remmina_pref.hide_toolbar);
+	g_key_file_set_boolean(gkeyfile, "remmina_pref", "disable_floating_toolbar", remmina_pref.disable_floating_toolbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "hide_statusbar", remmina_pref.hide_statusbar);
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "small_toolbutton", remmina_pref.small_toolbutton);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "view_file_mode", remmina_pref.view_file_mode);
@@ -852,4 +858,3 @@ remmina_pref_get_value(const gchar *key)
 
 	return value;
 }
-

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -142,6 +142,7 @@ typedef struct _RemminaPref
 	gboolean hide_statusbar;
 	gboolean small_toolbutton;
 	gint view_file_mode;
+	gboolean disable_floating_toolbar;
 	/* In tray icon */
 	gboolean applet_enable_avahi;
 	/* Auto */
@@ -195,4 +196,3 @@ gchar* remmina_pref_get_value(const gchar *key);
 G_END_DECLS
 
 #endif  /* __REMMINAPREF_H__  */
-

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -85,6 +85,13 @@ enum
 	REMMINA_TAB_NONE = 3
 };
 
+enum
+{
+	FLOATING_TOOLBAR_VISIBILITY_PEEKING = 0,
+	FLOATING_TOOLBAR_VISIBILITY_INVISIBLE = 1, //"Invisible" corresponds to the "Hidden" option in the drop-down
+	FLOATING_TOOLBAR_VISIBILITY_DISABLE = 2
+};
+
 typedef struct _RemminaPref
 {
 	/* In RemminaPrefDialog options tab */
@@ -98,12 +105,12 @@ typedef struct _RemminaPref
 	gchar *resolutions;
 	gchar *keystrokes;
 	/* In RemminaPrefDialog appearance tab */
-	gboolean invisible_toolbar;
 	gboolean fullscreen_on_auto;
 	gboolean always_show_tab;
 	gboolean hide_connection_toolbar;
 	gint default_mode;
 	gint tab_mode;
+	gint fullscreen_toolbar_visibility;
 	gint show_buttons_icons;
 	gint show_menu_icons;
 	/* In RemminaPrefDialog applet tab */
@@ -142,7 +149,6 @@ typedef struct _RemminaPref
 	gboolean hide_statusbar;
 	gboolean small_toolbutton;
 	gint view_file_mode;
-	gboolean disable_floating_toolbar;
 	/* In tray icon */
 	gboolean applet_enable_avahi;
 	/* Auto */

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -125,15 +125,14 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 
 	remmina_pref.save_view_mode = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode));
 	remmina_pref.save_when_connect = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_save_settings));
-	remmina_pref.invisible_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_invisible_toolbar));
 	remmina_pref.fullscreen_on_auto = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_fullscreen_on_auto));
 	remmina_pref.always_show_tab = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs));
 	remmina_pref.hide_connection_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar));
-	remmina_pref.disable_floating_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_disable_floating_toolbar));
 
 	remmina_pref.default_action = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_options_double_click);
 	remmina_pref.default_mode = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_view_mode);
 	remmina_pref.tab_mode = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_tab_interface);
+	remmina_pref.fullscreen_toolbar_visibility = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_fullscreen_toolbar_visibility);
 	remmina_pref.show_buttons_icons = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons);
 	remmina_pref.show_menu_icons = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_show_menu_icons);
 	remmina_pref.scale_quality = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_options_scale_quality);
@@ -288,10 +287,8 @@ static void remmina_pref_dialog_init(void)
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode), remmina_pref.save_view_mode);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_save_settings), remmina_pref.save_when_connect);
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_invisible_toolbar), remmina_pref.invisible_toolbar);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs), remmina_pref.always_show_tab);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar), remmina_pref.hide_connection_toolbar);
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_disable_floating_toolbar), remmina_pref.disable_floating_toolbar);
 
 	g_snprintf(buf, sizeof(buf), "%i", remmina_pref.sshtunnel_port);
 	gtk_entry_set_text(remmina_pref_dialog->entry_options_ssh_port, buf);
@@ -359,6 +356,7 @@ static void remmina_pref_dialog_init(void)
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_options_double_click, remmina_pref.default_action);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_view_mode, remmina_pref.default_mode);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_tab_interface, remmina_pref.tab_mode);
+	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_fullscreen_toolbar_visibility, remmina_pref.fullscreen_toolbar_visibility);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons, remmina_pref.show_buttons_icons);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_appearance_show_menu_icons, remmina_pref.show_menu_icons);
 	gtk_combo_box_set_active(remmina_pref_dialog->comboboxtext_options_scale_quality, remmina_pref.scale_quality);
@@ -396,14 +394,13 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 
 	remmina_pref_dialog->checkbutton_options_remember_last_view_mode = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_options_remember_last_view_mode"));
 	remmina_pref_dialog->checkbutton_options_save_settings = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_options_save_settings"));
-	remmina_pref_dialog->checkbutton_appearance_invisible_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_invisible_toolbar"));
 	remmina_pref_dialog->checkbutton_appearance_fullscreen_on_auto = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_fullscreen_on_auto"));
 	remmina_pref_dialog->checkbutton_appearance_show_tabs = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_show_tabs"));
 	remmina_pref_dialog->checkbutton_appearance_hide_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_hide_toolbar"));
-	remmina_pref_dialog->checkbutton_disable_floating_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_disable_floating_toolbar"));
 	remmina_pref_dialog->comboboxtext_options_double_click = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_options_double_click"));
 	remmina_pref_dialog->comboboxtext_appearance_view_mode = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_view_mode"));
 	remmina_pref_dialog->comboboxtext_appearance_tab_interface = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_tab_interface"));
+	remmina_pref_dialog->comboboxtext_appearance_fullscreen_toolbar_visibility = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_fullscreen_toolbar_visibility"));
 	remmina_pref_dialog->comboboxtext_appearance_show_buttons_icons = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_show_buttons_icons"));
 	remmina_pref_dialog->comboboxtext_appearance_show_menu_icons = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_show_menu_icons"));
 	remmina_pref_dialog->comboboxtext_options_scale_quality = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_options_scale_quality"));

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -129,6 +129,7 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.fullscreen_on_auto = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_fullscreen_on_auto));
 	remmina_pref.always_show_tab = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs));
 	remmina_pref.hide_connection_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar));
+	remmina_pref.disable_floating_toolbar = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_disable_floating_toolbar));
 
 	remmina_pref.default_action = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_options_double_click);
 	remmina_pref.default_mode = gtk_combo_box_get_active(remmina_pref_dialog->comboboxtext_appearance_view_mode);
@@ -290,6 +291,7 @@ static void remmina_pref_dialog_init(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_invisible_toolbar), remmina_pref.invisible_toolbar);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_show_tabs), remmina_pref.always_show_tab);
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_appearance_hide_toolbar), remmina_pref.hide_connection_toolbar);
+	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_disable_floating_toolbar), remmina_pref.disable_floating_toolbar);
 
 	g_snprintf(buf, sizeof(buf), "%i", remmina_pref.sshtunnel_port);
 	gtk_entry_set_text(remmina_pref_dialog->entry_options_ssh_port, buf);
@@ -398,6 +400,7 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->checkbutton_appearance_fullscreen_on_auto = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_fullscreen_on_auto"));
 	remmina_pref_dialog->checkbutton_appearance_show_tabs = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_show_tabs"));
 	remmina_pref_dialog->checkbutton_appearance_hide_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_appearance_hide_toolbar"));
+	remmina_pref_dialog->checkbutton_disable_floating_toolbar = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_disable_floating_toolbar"));
 	remmina_pref_dialog->comboboxtext_options_double_click = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_options_double_click"));
 	remmina_pref_dialog->comboboxtext_appearance_view_mode = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_view_mode"));
 	remmina_pref_dialog->comboboxtext_appearance_tab_interface = GTK_COMBO_BOX(GET_OBJECT("comboboxtext_appearance_tab_interface"));
@@ -459,5 +462,3 @@ GtkDialog* remmina_pref_dialog_get_dialog()
 		return NULL;
 	return remmina_pref_dialog->dialog;
 }
-
-

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -56,6 +56,7 @@ typedef struct _RemminaPrefDialog
 	GtkCheckButton *checkbutton_appearance_fullscreen_on_auto;
 	GtkCheckButton *checkbutton_appearance_show_tabs;
 	GtkCheckButton *checkbutton_appearance_hide_toolbar;
+	GtkCheckButton *checkbutton_disable_floating_toolbar;
 	GtkComboBox *comboboxtext_options_double_click;
 	GtkComboBox *comboboxtext_appearance_view_mode;
 	GtkComboBox *comboboxtext_appearance_tab_interface;
@@ -122,4 +123,3 @@ GtkDialog* remmina_pref_dialog_get_dialog(void);
 G_END_DECLS
 
 #endif  /* __REMMINAPREFDIALOG_H__  */
-

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -52,11 +52,9 @@ typedef struct _RemminaPrefDialog
 
 	GtkCheckButton *checkbutton_options_remember_last_view_mode;
 	GtkCheckButton *checkbutton_options_save_settings;
-	GtkCheckButton *checkbutton_appearance_invisible_toolbar;
 	GtkCheckButton *checkbutton_appearance_fullscreen_on_auto;
 	GtkCheckButton *checkbutton_appearance_show_tabs;
 	GtkCheckButton *checkbutton_appearance_hide_toolbar;
-	GtkCheckButton *checkbutton_disable_floating_toolbar;
 	GtkComboBox *comboboxtext_options_double_click;
 	GtkComboBox *comboboxtext_appearance_view_mode;
 	GtkComboBox *comboboxtext_appearance_tab_interface;
@@ -64,6 +62,7 @@ typedef struct _RemminaPrefDialog
 	GtkComboBox *comboboxtext_appearance_show_menu_icons;
 	GtkComboBox *comboboxtext_options_scale_quality;
 	GtkComboBox *comboboxtext_options_ssh_loglevel;
+	GtkComboBox *comboboxtext_appearance_fullscreen_toolbar_visibility;
 	GtkFileChooser *filechooserbutton_options_screenshots_path;
 	GtkCheckButton *checkbutton_options_ssh_parseconfig;
 	GtkEntry *entry_options_ssh_port;

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 
+<!-- Generated with glade 3.18.3 
 
 Remmina Preferences Dialog -
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2017
@@ -128,8 +128,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Double-click action</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Double-click action</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -156,8 +156,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Scale quality</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Scale quality</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -186,8 +186,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Auto scroll step size</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Auto scroll step size</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -210,8 +210,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Maximum recent items</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Maximum recent items</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -247,8 +247,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_resolutions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Resolutions</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Resolutions</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -273,8 +273,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_keystrokes">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Keystrokes</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Keystrokes</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -299,8 +299,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_screenshot_folder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Screenshots folder</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Screenshots folder</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -408,12 +408,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Default view mode</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Default view mode</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -430,7 +430,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">5</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -438,12 +438,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Tab interface</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Tab interface</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -460,7 +460,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">6</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -468,12 +468,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_buttons_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Show buttons icons</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Show buttons icons</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -490,7 +490,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">7</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -498,12 +498,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_menu_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Show menu icons</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Show menu icons</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                       </packing>
                     </child>
                     <child>
@@ -520,7 +520,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">8</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -537,6 +537,21 @@ Author: Antenore Gatta
                       <packing>
                         <property name="left_attach">0</property>
                         <property name="top_attach">1</property>
+                        <property name="width">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="checkbutton_disable_floating_toolbar">
+                        <property name="label" translatable="yes">Disable the floating toolbar in fullscreen mode</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">False</property>
+                        <property name="xalign">0</property>
+                        <property name="draw_indicator">True</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">4</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
@@ -691,8 +706,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Host key</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Host key</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -719,8 +734,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Toggle fullscreen mode</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Toggle fullscreen mode</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -747,8 +762,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Auto-fit window</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Auto-fit window</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -775,8 +790,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Switch tab pages</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Switch tab pages</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -816,8 +831,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Toggle scaled mode</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Toggle scaled mode</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -844,8 +859,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Grab keyboard</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Grab keyboard</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -872,8 +887,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Minimize window</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Minimize window</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -900,8 +915,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Disconnect</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Disconnect</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -928,8 +943,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Show / hide toolbar</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Show / hide toolbar</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -956,9 +971,9 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
+                        <property name="xalign">0</property>
                         <property name="label" translatable="yes">Screenshot</property>
                         <property name="ellipsize">start</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1016,8 +1031,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">SSH tunnel local port</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">SSH tunnel local port</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1074,8 +1089,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_loglevel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">SSH log level</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">SSH log level</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1119,8 +1134,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Font</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Font</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1132,8 +1147,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Colors</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Colors</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1145,8 +1160,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Foreground color</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Foreground color</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1158,8 +1173,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Background color</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Background color</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1171,8 +1186,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Scrollback lines</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Scrollback lines</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1184,8 +1199,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Keyboard</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Keyboard</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1335,8 +1350,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Copy</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Copy</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1374,8 +1389,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Paste</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Paste</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1413,8 +1428,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Select All</property>
                         <property name="xalign">0</property>
+                        <property name="label" translatable="yes">Select All</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
@@ -1483,9 +1498,6 @@ Author: Antenore Gatta
           </packing>
         </child>
       </object>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -360,21 +360,6 @@ Author: Antenore Gatta
                     <property name="row_spacing">5</property>
                     <property name="column_spacing">7</property>
                     <child>
-                      <object class="GtkCheckButton" id="checkbutton_appearance_invisible_toolbar">
-                        <property name="label" translatable="yes">Invisible toolbar in fullscreen mode</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
                       <object class="GtkCheckButton" id="checkbutton_appearance_show_tabs">
                         <property name="label" translatable="yes">Always show tabs</property>
                         <property name="visible">True</property>
@@ -385,7 +370,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">1</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
@@ -400,7 +385,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">2</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
@@ -413,7 +398,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
@@ -430,7 +415,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">4</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -443,7 +428,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -460,7 +445,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">5</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -470,10 +455,11 @@ Author: Antenore Gatta
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="label" translatable="yes">Show buttons icons</property>
+                        <property name="justify">fill</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
@@ -490,7 +476,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">6</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -503,7 +489,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -520,7 +506,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
+                        <property name="top_attach">7</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -536,23 +522,37 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
+                        <property name="top_attach">0</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkCheckButton" id="checkbutton_disable_floating_toolbar">
-                        <property name="label" translatable="yes">Disable the floating toolbar in fullscreen mode</property>
+                      <object class="GtkComboBoxText" id="comboboxtext_appearance_fullscreen_toolbar_visibility">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="can_focus">False</property>
+                        <property name="active_id">0</property>
+                        <items>
+                          <item id="0" translatable="yes">Peeking</item>
+                          <item id="1" translatable="yes">Hidden</item>
+                          <item id="2" translatable="yes">Disabled</item>
+                        </items>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">3</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label_fullscreen_toolbar_visibility">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
                         <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="label" translatable="yes">Fullscreen toolbar visibility</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
-                        <property name="width">3</property>
+                        <property name="top_attach">3</property>
                       </packing>
                     </child>
                   </object>


### PR DESCRIPTION
Added an option to completely disable the floating toolbar in fullscreen mode.  This is useful for people like me who use Remmina like a thin client.

The floating toolbar interferes in a Windows RDP session when you bring the cursor to the top (I exit the session by accident all the time), and if you move it to the bottom, it interferes with the Windows taskbar.

I'm not very familiar with the Remmina code base, so please let me know if there's a better way to do something.  I tried to pattern my changes after your existing code.

By the way - thanks for a great product!  Remmina has been very handy over the years!!