### PR TITLE
Pressing Enter in the Domain entry of Auth dialog submits

### DIFF
--- a/remmina/src/remmina_init_dialog.c
+++ b/remmina/src/remmina_init_dialog.c
@@ -392,6 +392,7 @@ gint remmina_init_dialog_authuserpwd(RemminaInitDialog *dialog, gboolean want_do
 		gtk_widget_show(domain_entry);
 		gtk_grid_attach(GTK_GRID(grid), domain_entry, 1, 3, 2, 1);
 		gtk_entry_set_max_length(GTK_ENTRY(domain_entry), 100);
+		gtk_entry_set_activates_default(GTK_ENTRY(domain_entry), TRUE);
 		if (default_domain && default_domain[0] != '\0')
 		{
 			gtk_entry_set_text(GTK_ENTRY(domain_entry), default_domain);


### PR DESCRIPTION
In the authentication dialog where the user name, password and domain are entered, currently the dialog is submitted by pressing the Enter key only in the password entry. With this modification, pressing the Enter key in the domain entry submits the dialog, too. Since the domain entry is the last entry of the form, I often try to submit the form by pressing the Enter key in vain.