### PR TITLE
Fix multiple typos of 'transfered' word

### DIFF
--- a/remmina-plugins/rdp/rdp_cliprdr.c
+++ b/remmina-plugins/rdp/rdp_cliprdr.c
@@ -546,7 +546,7 @@ void remmina_rdp_cliprdr_request_data(GtkClipboard *gtkClipboard, GtkSelectionDa
 	} else {
 		clipboard->srv_clip_data_wait = SCDW_ASYNCWAIT;
 		if ( rc == ETIMEDOUT ) {
-			remmina_plugin_service->log_printf("[RDP] Clipboard data has not been transfered from the server in %d seconds. Try to paste later.\n",
+			remmina_plugin_service->log_printf("[RDP] Clipboard data has not been transferred from the server in %d seconds. Try to paste later.\n",
 				CLIPBOARD_TRANSFER_WAIT_TIME);
 		}
 		else {

--- a/remmina-plugins/spice/spice_plugin_file_transfer.c
+++ b/remmina-plugins/spice/spice_plugin_file_transfer.c
@@ -229,7 +229,7 @@ static void remmina_plugin_spice_file_transfer_finished_cb(SpiceFileTransferTask
 	else
 	{
 		notification = g_notification_new(_("Transfer completed"));
-		notification_message = g_strdup_printf(_("File %s transfered successfully"),
+		notification_message = g_strdup_printf(_("File %s transferred successfully"),
 		                                       filename);
 	}
 

--- a/remmina/po/ar.po
+++ b/remmina/po/ar.po
@@ -1320,7 +1320,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ast.po
+++ b/remmina/po/ast.po
@@ -1339,7 +1339,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/bg.po
+++ b/remmina/po/bg.po
@@ -1338,7 +1338,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/bn.po
+++ b/remmina/po/bn.po
@@ -1322,7 +1322,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/bs.po
+++ b/remmina/po/bs.po
@@ -1345,7 +1345,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ca.po
+++ b/remmina/po/ca.po
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ca@valencia.po
+++ b/remmina/po/ca@valencia.po
@@ -1335,7 +1335,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/cs.po
+++ b/remmina/po/cs.po
@@ -1342,7 +1342,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/da.po
+++ b/remmina/po/da.po
@@ -1336,7 +1336,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/de.po
+++ b/remmina/po/de.po
@@ -1363,7 +1363,7 @@ msgstr "Übertragung abgeschlossen"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "Datei %s erfolgreich übertragen"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/el.po
+++ b/remmina/po/el.po
@@ -1352,7 +1352,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/en_AU.po
+++ b/remmina/po/en_AU.po
@@ -1340,7 +1340,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/en_GB.po
+++ b/remmina/po/en_GB.po
@@ -1340,7 +1340,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/es.po
+++ b/remmina/po/es.po
@@ -1354,7 +1354,7 @@ msgstr "Transferencia completada"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "Archivos %s transferidos con éxito"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/et.po
+++ b/remmina/po/et.po
@@ -1325,7 +1325,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/eu.po
+++ b/remmina/po/eu.po
@@ -1343,7 +1343,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/fi.po
+++ b/remmina/po/fi.po
@@ -1341,7 +1341,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/fr.po
+++ b/remmina/po/fr.po
@@ -1362,7 +1362,7 @@ msgstr "Transfert effectué"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "Transfert du fichier %s effectué"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/gl.po
+++ b/remmina/po/gl.po
@@ -1338,7 +1338,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/he.po
+++ b/remmina/po/he.po
@@ -1337,7 +1337,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/hr.po
+++ b/remmina/po/hr.po
@@ -1323,7 +1323,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/hu.po
+++ b/remmina/po/hu.po
@@ -1350,7 +1350,7 @@ msgstr "Átvitel kész"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "A(z) %s fájl sikeresen átvíve"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/id.po
+++ b/remmina/po/id.po
@@ -1321,7 +1321,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/it.po
+++ b/remmina/po/it.po
@@ -1356,7 +1356,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ja.po
+++ b/remmina/po/ja.po
@@ -1345,7 +1345,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/kk.po
+++ b/remmina/po/kk.po
@@ -1332,7 +1332,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/km.po
+++ b/remmina/po/km.po
@@ -1324,7 +1324,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/kn.po
+++ b/remmina/po/kn.po
@@ -1321,7 +1321,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ko.po
+++ b/remmina/po/ko.po
@@ -1339,7 +1339,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/lt.po
+++ b/remmina/po/lt.po
@@ -1341,7 +1341,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/lv.po
+++ b/remmina/po/lv.po
@@ -1340,7 +1340,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ms.po
+++ b/remmina/po/ms.po
@@ -1339,7 +1339,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/my.po
+++ b/remmina/po/my.po
@@ -1323,7 +1323,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/nb.po
+++ b/remmina/po/nb.po
@@ -1340,7 +1340,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/nl.po
+++ b/remmina/po/nl.po
@@ -1350,7 +1350,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/oc.po
+++ b/remmina/po/oc.po
@@ -1341,7 +1341,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/pl.po
+++ b/remmina/po/pl.po
@@ -1345,7 +1345,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/pt.po
+++ b/remmina/po/pt.po
@@ -1346,7 +1346,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/pt_BR.po
+++ b/remmina/po/pt_BR.po
@@ -1347,7 +1347,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/pt_PT.po
+++ b/remmina/po/pt_PT.po
@@ -1346,7 +1346,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ro.po
+++ b/remmina/po/ro.po
@@ -1344,7 +1344,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ru.po
+++ b/remmina/po/ru.po
@@ -1356,7 +1356,7 @@ msgstr "Передача завершена"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "Файлы успешно переданы"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/shn.po
+++ b/remmina/po/shn.po
@@ -1317,7 +1317,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/si.po
+++ b/remmina/po/si.po
@@ -1319,7 +1319,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/sk.po
+++ b/remmina/po/sk.po
@@ -1338,7 +1338,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/sl.po
+++ b/remmina/po/sl.po
@@ -1343,7 +1343,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/sq.po
+++ b/remmina/po/sq.po
@@ -1328,7 +1328,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/sr.po
+++ b/remmina/po/sr.po
@@ -1334,7 +1334,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/sv.po
+++ b/remmina/po/sv.po
@@ -1338,7 +1338,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/te.po
+++ b/remmina/po/te.po
@@ -1319,7 +1319,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/th.po
+++ b/remmina/po/th.po
@@ -1333,7 +1333,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/tr.po
+++ b/remmina/po/tr.po
@@ -1347,7 +1347,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/ug.po
+++ b/remmina/po/ug.po
@@ -1341,7 +1341,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/uk.po
+++ b/remmina/po/uk.po
@@ -1346,7 +1346,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/uz@cyrillic.po
+++ b/remmina/po/uz@cyrillic.po
@@ -1346,7 +1346,7 @@ msgstr "Узатиш тугалланди"
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr "Файл %s муваффақиятли узатилди"
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/zh_CN.po
+++ b/remmina/po/zh_CN.po
@@ -1340,7 +1340,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51

--- a/remmina/po/zh_TW.po
+++ b/remmina/po/zh_TW.po
@@ -1339,7 +1339,7 @@ msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_file_transfer.c:232
 #, c-format
-msgid "File %s transfered successfully"
+msgid "File %s transferred successfully"
 msgstr ""
 
 #: remmina-plugins/spice/spice_plugin_usb.c:51


### PR DESCRIPTION
As already pointed to @giox069 this PR aims to fix a bunch of cosmetic typos in the code.