### PR TITLE
Ssh improvements

### DIFF
--- a/remmina/src/remmina_file.c
+++ b/remmina/src/remmina_file.c
@@ -177,6 +177,7 @@ static const RemminaProtocolSetting* find_protocol_setting(const gchar *name, Re
 
 static gboolean is_encrypted_setting(const RemminaProtocolSetting* setting)
 {
+	TRACE_CALL("is_encrypted_setting");
 	if (setting != NULL &&
 		(setting->type == REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD) )
 	{
@@ -187,8 +188,13 @@ static gboolean is_encrypted_setting(const RemminaProtocolSetting* setting)
 
 static gboolean is_encrypted_setting_by_name(const gchar *setting_name, RemminaProtocolPlugin* protocol_plugin)
 {
-	TRACE_CALL("is_encrypted_setting");
+	TRACE_CALL("is_encrypted_setting_by_name");
 	const RemminaProtocolSetting* setting;
+
+	if (strcmp(setting_name, "ssh_password") == 0)
+	{
+		return TRUE;
+	}
 
 	setting = find_protocol_setting(setting_name, protocol_plugin);
 	return is_encrypted_setting(setting);

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -854,15 +854,6 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 		priv->ssh_server_custom_radio = NULL;
 		priv->ssh_server_entry = NULL;
 
-/*
-		s = remmina_pref_get_recent ("SFTP");
-		priv->server_combo = remmina_file_editor_create_combo (gfe, grid, row + 1, 1,
-		                     _("Server"), s, remmina_file_get_string (priv->remmina_file, "server"));
-		gtk_widget_set_tooltip_markup (priv->server_combo, _(server_tips));
-		gtk_entry_set_activates_default (GTK_ENTRY(gtk_bin_get_child (GTK_BIN (priv->server_combo))), TRUE);
-		g_free(s);
-		row++;
-*/
 		break;
 
 	default:
@@ -951,8 +942,6 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 		                   cs ? cs : "");
 	}
 
-	//cs = remmina_file_get_string (priv->remmina_file, "ssh_username");
-	//gtk_entry_set_text(GTK_ENTRY(priv->ssh_username_entry), cs ? cs : "");
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(
 	                                  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_PUBLICKEY ?
 	                                  priv->ssh_auth_publickey_radio :
@@ -1274,7 +1263,6 @@ static void remmina_file_editor_init(RemminaFileEditor* gfe)
 	widget = gtk_dialog_add_button(GTK_DIALOG(gfe), (_("Default")), GTK_RESPONSE_OK);
 	gtk_button_set_image(GTK_BUTTON(widget), gtk_image_new_from_icon_name("preferences-system", GTK_ICON_SIZE_BUTTON));
 	g_signal_connect(G_OBJECT(widget), "clicked", G_CALLBACK(remmina_file_editor_on_default), gfe);
-	//gtk_widget_show(widget);
 
 	priv->setting_widgets = g_hash_table_new(g_str_hash, g_str_equal);
 

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -777,36 +777,25 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 	if (ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_NONE) return;
 
 	/* The SSH tab (implementation) */
-	if (ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SSH ||
-	        ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SFTP)
-	{
-		s = remmina_public_combo_get_active_text (GTK_COMBO_BOX (priv->protocol_combo));
-		grid = remmina_file_editor_create_notebook_tab (gfe, "dialog-password",
-		        (s ? s : "SSH Settings"), 8, 3);
-		g_free(s);
-	}
-	else
-	{
-		grid = remmina_file_editor_create_notebook_tab (gfe, "dialog-password",
-		        "SSH Settings", 9, 3);
+	grid = remmina_file_editor_create_notebook_tab (gfe, "dialog-password",
+		"SSH Settings", 9, 3);
 
-		hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
-		gtk_widget_show(hbox);
-		gtk_grid_attach (GTK_GRID(grid), hbox, 0, 0, 3, 1);
-		row++;
+	hbox = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 0);
+	gtk_widget_show(hbox);
+	gtk_grid_attach (GTK_GRID(grid), hbox, 0, 0, 3, 1);
+	row++;
 
-		widget = gtk_check_button_new_with_label (_("Enable SSH tunnel"));
-		gtk_widget_show(widget);
-		gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
-		g_signal_connect(G_OBJECT(widget), "toggled",
-		                 G_CALLBACK(remmina_file_editor_ssh_enabled_check_on_toggled), gfe);
-		priv->ssh_enabled_check = widget;
+	widget = gtk_check_button_new_with_label (_("Enable SSH tunnel"));
+	gtk_widget_show(widget);
+	gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
+	g_signal_connect(G_OBJECT(widget), "toggled",
+			 G_CALLBACK(remmina_file_editor_ssh_enabled_check_on_toggled), gfe);
+	priv->ssh_enabled_check = widget;
 
-		widget = gtk_check_button_new_with_label (_("Tunnel via loopback address"));
-		gtk_widget_show(widget);
-		gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
-		priv->ssh_loopback_check = widget;
-	}
+	widget = gtk_check_button_new_with_label (_("Tunnel via loopback address"));
+	gtk_widget_show(widget);
+	gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
+	priv->ssh_loopback_check = widget;
 
 	/* SSH Server group */
 	row++;

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -399,6 +399,7 @@ static void remmina_file_editor_create_server(RemminaFileEditor* gfe, const Remm
 
 	s = remmina_pref_get_recent(plugin->name);
 	widget = remmina_public_create_combo_entry(s, remmina_file_get_string(gfe->priv->remmina_file, "server"), TRUE);
+	gtk_widget_set_hexpand (widget, TRUE);
 	gtk_widget_show(widget);
 	gtk_widget_set_tooltip_markup(widget, _(server_tips));
 	gtk_entry_set_activates_default(GTK_ENTRY(gtk_bin_get_child(GTK_BIN(widget))), TRUE);
@@ -453,6 +454,7 @@ static GtkWidget* remmina_file_editor_create_password(RemminaFileEditor* gfe, Gt
 	gtk_grid_attach(GTK_GRID(grid), widget, 1, row, 1, 1);
 	gtk_entry_set_max_length(GTK_ENTRY(widget), 100);
 	gtk_entry_set_visibility(GTK_ENTRY(widget), FALSE);
+	gtk_widget_set_hexpand (widget, TRUE);
 
 	if (value)
 	{
@@ -560,6 +562,7 @@ static GtkWidget* remmina_file_editor_create_text(RemminaFileEditor* gfe, GtkWid
 	gtk_widget_show(widget);
 	gtk_grid_attach(GTK_GRID(grid), widget, 1, row, 1, 1);
 	gtk_entry_set_max_length(GTK_ENTRY(widget), 300);
+	gtk_widget_set_hexpand (widget, TRUE);
 
 	if (value)
 		gtk_entry_set_text(GTK_ENTRY(widget), value);

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -292,14 +292,24 @@ static void remmina_file_editor_ssh_auth_publickey_radio_on_toggled(GtkToggleBut
 	}
 }
 
-static void remmina_file_editor_ssh_enabled_check_on_toggled(GtkToggleButton* togglebutton, RemminaFileEditor* gfe)
+static void remmina_file_editor_ssh_enabled_check_on_toggled(GtkToggleButton* togglebutton,
+		RemminaFileEditor* gfe, RemminaProtocolSSHSetting ssh_setting)
 {
 	TRACE_CALL("remmina_file_editor_ssh_enabled_check_on_toggled");
 	gboolean enabled = TRUE;
 
 	if (gfe->priv->ssh_enabled_check)
 	{
-		enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gfe->priv->ssh_enabled_check));
+		if (ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SSH ||
+				ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SFTP)
+		{
+			gtk_widget_set_sensitive(gfe->priv->ssh_enabled_check, 1);
+			gtk_widget_set_sensitive(gfe->priv->ssh_loopback_check, 1);
+		}
+		else
+		{
+			enabled = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gfe->priv->ssh_enabled_check));
+		}
 		if (gfe->priv->ssh_loopback_check)
 			gtk_widget_set_sensitive(gfe->priv->ssh_loopback_check, enabled);
 		if (gfe->priv->ssh_server_default_radio)
@@ -785,20 +795,24 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 	gtk_grid_attach (GTK_GRID(grid), hbox, 0, 0, 3, 1);
 	row++;
 
-	widget = gtk_check_button_new_with_label (_("Enable SSH tunnel"));
-	gtk_widget_show(widget);
-	gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
-	g_signal_connect(G_OBJECT(widget), "toggled",
-			 G_CALLBACK(remmina_file_editor_ssh_enabled_check_on_toggled), gfe);
-	priv->ssh_enabled_check = widget;
+	if (!(ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SSH ||
+				ssh_setting == REMMINA_PROTOCOL_SSH_SETTING_SFTP))
+	{
+		widget = gtk_check_button_new_with_label (_("Enable SSH tunnel"));
+		gtk_widget_show(widget);
+		gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
+		g_signal_connect(G_OBJECT(widget), "toggled",
+				G_CALLBACK(remmina_file_editor_ssh_enabled_check_on_toggled), gfe);
+		priv->ssh_enabled_check = widget;
 
-	widget = gtk_check_button_new_with_label (_("Tunnel via loopback address"));
-	gtk_widget_show(widget);
-	gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
-	priv->ssh_loopback_check = widget;
+		widget = gtk_check_button_new_with_label (_("Tunnel via loopback address"));
+		gtk_widget_show(widget);
+		gtk_box_pack_start (GTK_BOX (hbox), widget, TRUE, TRUE, 0);
+		priv->ssh_loopback_check = widget;
 
+		row++;
+	}
 	/* SSH Server group */
-	row++;
 
 	switch (ssh_setting)
 	{
@@ -932,15 +946,15 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 	}
 
 	gtk_toggle_button_set_active (GTK_TOGGLE_BUTTON(
-	                                  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_PUBLICKEY ?
-	                                  priv->ssh_auth_publickey_radio :
-	                                  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_AUTO_PUBLICKEY ?
-	                                  priv->ssh_auth_auto_publickey_radio :
-	                                  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_AGENT ?
-	                                  priv->ssh_auth_agent_radio :
-	                                  priv->ssh_auth_password_radio), TRUE);
+				  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_PUBLICKEY ?
+				  priv->ssh_auth_publickey_radio :
+				  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_AUTO_PUBLICKEY ?
+				  priv->ssh_auth_auto_publickey_radio :
+				  remmina_file_get_int (priv->remmina_file, "ssh_auth", 0) == SSH_AUTH_AGENT ?
+				  priv->ssh_auth_agent_radio :
+				  priv->ssh_auth_password_radio), TRUE);
 
-	remmina_file_editor_ssh_enabled_check_on_toggled (NULL, gfe);
+	remmina_file_editor_ssh_enabled_check_on_toggled (NULL, gfe, ssh_setting);
 #endif
 }
 

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -2,6 +2,7 @@
  * Remmina - The GTK+ Remote Desktop Client
  * Copyright (C) 2009-2011 Vic Lee
  * Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+ * Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -608,7 +608,7 @@ static gboolean remmina_protocol_widget_init_tunnel (RemminaProtocolWidget* gp)
 			return FALSE;
 		}
 
-		ret = remmina_ssh_auth_gui (REMMINA_SSH (tunnel), REMMINA_INIT_DIALOG (gp->priv->init_dialog));
+		ret = remmina_ssh_auth_gui (REMMINA_SSH (tunnel), REMMINA_INIT_DIALOG (gp->priv->init_dialog), gp->priv->remmina_file);
 		if (ret <= 0)
 		{
 			if (ret == 0)
@@ -998,9 +998,7 @@ gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget* gp, RemminaAuth
 	          REMMINA_INIT_DIALOG(gp->priv->init_dialog),
 	          s,
 	          remmina_file_get_filename(remminafile) != NULL &&
-	          allow_password_saving &&
-	          authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PWD &&
-	          authpwd_type != REMMINA_AUTHPWD_TYPE_SSH_PRIVKEY);
+	          allow_password_saving);
 	g_free(s);
 
 	return ret;

--- a/remmina/src/remmina_sftp_plugin.c
+++ b/remmina/src/remmina_sftp_plugin.c
@@ -2,6 +2,7 @@
  * Remmina - The GTK+ Remote Desktop Client
  * Copyright (C) 2010 Vic Lee
  * Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+ * Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/remmina/src/remmina_sftp_plugin.c
+++ b/remmina/src/remmina_sftp_plugin.c
@@ -110,7 +110,7 @@ remmina_plugin_sftp_main_thread (gpointer data)
 			}
 
 			ret = remmina_ssh_auth_gui (REMMINA_SSH (sftp),
-			                            REMMINA_INIT_DIALOG (remmina_protocol_widget_get_init_dialog (gp)));
+			                            REMMINA_INIT_DIALOG (remmina_protocol_widget_get_init_dialog (gp)), remminafile);
 			if (ret == 0)
 			{
 				remmina_plugin_service->protocol_plugin_set_error (gp, "%s", REMMINA_SSH (sftp)->error);

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -2,6 +2,7 @@
  * Remmina - The GTK+ Remote Desktop Client
  * Copyright (C) 2009-2011 Vic Lee
  * Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+ * Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -242,27 +242,22 @@ remmina_ssh_auth_auto_pubkey (RemminaSSH* ssh)
 	TRACE_CALL("remmina_ssh_auth_auto_pubkey");
 	gint ret = ssh_userauth_autopubkey (ssh->session, NULL);
 
-	if(ret == SSH_AUTH_ERROR)
+	switch (ret)
 	{
-		remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication failed: %s"));
-		return ret;
+		case SSH_AUTH_ERROR:
+			remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication failed: %s"));
+			return 0;
+		case SSH_AUTH_SUCCESS:
+			remmina_log_printf ("[SSH] automatic public key succesfully authenticated");
+			ssh->authenticated = TRUE;
+			return 1;
+		case SSH_AUTH_PARTIAL:
+			remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication partially failed: %s"));
+			return 0;
+		default:
+			remmina_ssh_set_error (ssh, _("[SSH] automatic public key unknown error: %s"));
+			return 0;
 	}
-
-	if (ret != SSH_AUTH_SUCCESS)
-	{
-		remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication failed: %s"));
-		return ret;
-	}
-
-	if (ret != SSH_AUTH_PARTIAL)
-	{
-		remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication partially failed: %s"));
-		/* We should call remmina_ssh_auth_gui */
-		return ret;
-	}
-
-	ssh->authenticated = TRUE;
-	return 1;
 }
 
 static gint

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -245,7 +245,7 @@ remmina_ssh_auth_auto_pubkey (RemminaSSH* ssh)
 	switch (ret)
 	{
 		case SSH_AUTH_ERROR:
-			remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication failed: %s"));
+			remmina_ssh_set_error (ssh, _("[SSH] automatic public key error: %s"));
 			return 0;
 		case SSH_AUTH_SUCCESS:
 			remmina_log_printf ("[SSH] automatic public key succesfully authenticated");
@@ -253,6 +253,11 @@ remmina_ssh_auth_auto_pubkey (RemminaSSH* ssh)
 			return 1;
 		case SSH_AUTH_PARTIAL:
 			remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication partially failed: %s"));
+			// TODO: Test and eventually implement a dialog for the second authentication
+			return 1;
+		case SSH_AUTH_DENIED:
+			remmina_ssh_set_error (ssh, _("[SSH] automatic public key access denied: %s"));
+			// TODO: implement a dialog for the second authentication
 			return 0;
 		default:
 			remmina_ssh_set_error (ssh, _("[SSH] automatic public key unknown error: %s"));

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -105,6 +105,7 @@
 
 static const gchar *common_identities[] =
 {
+	".ssh/id_ed25519",
 	".ssh/id_rsa",
 	".ssh/id_dsa",
 	".ssh/identity",

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -253,11 +253,11 @@ remmina_ssh_auth_auto_pubkey (RemminaSSH* ssh)
 			return 1;
 		case SSH_AUTH_PARTIAL:
 			remmina_ssh_set_error (ssh, _("[SSH] automatic public key authentication partially failed: %s"));
-			// TODO: Test and eventually implement a dialog for the second authentication
+			/* TODO: Test and eventually implement a dialog for the second authenticatio */
 			return 1;
 		case SSH_AUTH_DENIED:
 			remmina_ssh_set_error (ssh, _("[SSH] automatic public key access denied: %s"));
-			// TODO: implement a dialog for the second authentication
+			/* TODO: implement a dialog for the second authentication */
 			return 0;
 		default:
 			remmina_ssh_set_error (ssh, _("[SSH] automatic public key unknown error: %s"));

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -72,9 +72,10 @@
 #include <termios.h>
 #endif
 #include "remmina_public.h"
+#include "remmina_file.h"
 #include "remmina_log.h"
-#include "remmina_ssh.h"
 #include "remmina_pref.h"
+#include "remmina_ssh.h"
 #include "remmina/remmina_trace_calls.h"
 
 #ifdef HAVE_NETINET_TCP_H
@@ -320,7 +321,7 @@ remmina_ssh_auth (RemminaSSH *ssh, const gchar *password)
 }
 
 gint
-remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog)
+remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog, RemminaFile *remminafile)
 {
 	TRACE_CALL("remmina_ssh_auth_gui");
 	gchar *tips;
@@ -403,9 +404,16 @@ remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog)
 		if (ssh->auth != SSH_AUTH_AUTO_PUBLICKEY)
 		{
 			remmina_init_dialog_set_status (dialog, tips, ssh->user, ssh->server);
-			ret = remmina_init_dialog_authpwd (dialog, keyname, FALSE);
+			ret = remmina_init_dialog_authpwd (dialog, keyname, TRUE);
 
-			if (ret != GTK_RESPONSE_OK) return -1;
+			if (ret == GTK_RESPONSE_OK)
+			{
+				remmina_file_set_string( remminafile, "ssh_password", dialog->password);
+			}
+			else
+			{
+				return -1;
+			}
 		}
 		ret = remmina_ssh_auth (ssh, dialog->password);
 	}

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -379,7 +379,7 @@ remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog, RemminaFile *r
 	}
 
 	/* Try empty password or existing password first */
-	ret = remmina_ssh_auth (ssh, NULL);
+	ret = remmina_ssh_auth (ssh, remmina_file_get_string(remminafile, "ssh_password"));
 	if (ret > 0) return 1;
 
 	/* Requested for a non-empty password */

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -312,10 +312,22 @@ remmina_ssh_auth (RemminaSSH *ssh, const gchar *password)
 			return remmina_ssh_auth_pubkey (ssh);
 
 		case SSH_AUTH_AGENT:
-			return remmina_ssh_auth_agent (ssh);
+			if (!remmina_ssh_auth_agent (ssh))
+			{
+				if (!remmina_ssh_auth_auto_pubkey (ssh))
+				{
+					return remmina_ssh_auth_password (ssh);
+				}
+				return 1;
+			}
+			return 1;
 
 		case SSH_AUTH_AUTO_PUBLICKEY:
-			return remmina_ssh_auth_auto_pubkey (ssh);
+			if (!remmina_ssh_auth_auto_pubkey (ssh))
+			{
+				return remmina_ssh_auth_password (ssh);
+			}
+			return 1;
 
 		default:
 			return 0;

--- a/remmina/src/remmina_ssh.h
+++ b/remmina/src/remmina_ssh.h
@@ -2,6 +2,7 @@
  * Remmina - The GTK+ Remote Desktop Client
  * Copyright (C) 2009-2011 Vic Lee
  * Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+ * Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/remmina/src/remmina_ssh.h
+++ b/remmina/src/remmina_ssh.h
@@ -91,7 +91,7 @@ gboolean remmina_ssh_init_session (RemminaSSH *ssh);
 gint remmina_ssh_auth (RemminaSSH *ssh, const gchar *password);
 
 /* -1: Cancelled; 0: Failed; 1: Succeeded */
-gint remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog);
+gint remmina_ssh_auth_gui (RemminaSSH *ssh, RemminaInitDialog *dialog, RemminaFile *remminafile);
 
 /* Error handling */
 #define remmina_ssh_has_error(ssh) (((RemminaSSH*)ssh)->error!=NULL)

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -2,6 +2,7 @@
  * Remmina - The GTK+ Remote Desktop Client
  * Copyright (C) 2010-2011 Vic Lee
  * Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+ * Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -431,6 +431,16 @@ remmina_plugin_ssh_vte_paste_clipboard (GtkMenuItem *menuitem, gpointer user_dat
 	vte_terminal_paste_clipboard (VTE_TERMINAL (user_data));
 }
 
+/* Send a keystroke to the plugin window */
+static void remmina_ssh_keystroke(RemminaProtocolWidget *gp, const guint keystrokes[], const gint keylen)
+{
+	TRACE_CALL("remmina_rdp_keystroke");
+	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
+	remmina_plugin_service->protocol_plugin_send_keys_signals(gpdata->vte,
+		keystrokes, keylen, GDK_KEY_PRESS | GDK_KEY_RELEASE);
+	return;
+}
+
 gboolean
 remmina_ssh_plugin_popup_menu(GtkWidget *widget, GdkEvent *event, GtkWidget *menu) {
 
@@ -687,7 +697,7 @@ static RemminaProtocolPlugin remmina_plugin_ssh =
 	remmina_plugin_ssh_close_connection,          // Plugin close connection
 	remmina_plugin_ssh_query_feature,             // Query for available features
 	remmina_plugin_ssh_call_feature,              // Call a feature
-	NULL                                          // Send a keystroke
+	remmina_ssh_keystroke                         // Send a keystroke
 };
 
 void

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -286,7 +286,8 @@ remmina_plugin_ssh_main_thread (gpointer data)
 			}
 
 			ret = remmina_ssh_auth_gui (REMMINA_SSH (shell),
-			                            REMMINA_INIT_DIALOG (remmina_protocol_widget_get_init_dialog (gp)));
+			                            REMMINA_INIT_DIALOG (remmina_protocol_widget_get_init_dialog (gp)),
+						    remminafile);
 			if (ret == 0)
 			{
 				remmina_plugin_service->protocol_plugin_set_error (gp, "%s", REMMINA_SSH (shell)->error);

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -434,7 +434,7 @@ remmina_plugin_ssh_vte_paste_clipboard (GtkMenuItem *menuitem, gpointer user_dat
 /* Send a keystroke to the plugin window */
 static void remmina_ssh_keystroke(RemminaProtocolWidget *gp, const guint keystrokes[], const gint keylen)
 {
-	TRACE_CALL("remmina_rdp_keystroke");
+	TRACE_CALL("remmina_ssh_keystroke");
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 	remmina_plugin_service->protocol_plugin_send_keys_signals(gpdata->vte,
 		keystrokes, keylen, GDK_KEY_PRESS | GDK_KEY_RELEASE);


### PR DESCRIPTION
This PR fixes some general issues, introduces some improvements and fixes the following issues:

- #708 the checkbox, 'Save SSH Password',  grayed out.
- #1078 SSH password can't save , terminal auto disconnection
- #1187 "Public Key (Automatic)" option does not work with ed25519 keys 

Some enhancements require  libssh 0.7.X, i.e the support for ed25519 keys
