### PR TITLE
Enter key doesn't "Connect" when in Edit menu and password field is in focus  - #1233

### DIFF
--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -456,6 +456,7 @@ static GtkWidget* remmina_file_editor_create_password(RemminaFileEditor* gfe, Gt
 	gtk_entry_set_max_length(GTK_ENTRY(widget), 100);
 	gtk_entry_set_visibility(GTK_ENTRY(widget), FALSE);
 	gtk_widget_set_hexpand (widget, TRUE);
+	gtk_entry_set_activates_default(GTK_ENTRY(widget),TRUE);
 
 	if (value)
 	{


### PR DESCRIPTION
This seems to fix the issue on being able to use the Enter key while in the Edit menu and password field is in focus.  Issue #1233.