### PR TITLE
Set Linux as the default terminal color scheme. Fixes #1238

### DIFF
--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -764,9 +764,9 @@ static gpointer ssh_charset_list[] =
 
 static gpointer ssh_terminal_palette[] =
 {
-	"0", "Gruvbox",
+	"0", "Linux",
 	"1", "Tango",
-	"2", "Linux",
+	"2", "Gruvbox",
 	"3", "Solarized Dark",
 	"4", "Solarized Light",
 	"5", "XTerm",


### PR DESCRIPTION
This set the Linux palette as the default color scheme.