### PR TITLE
passphrase not yet used in sftp connection - closes #1257

### DIFF
--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -667,7 +667,6 @@ remmina_ssh_free (RemminaSSH *ssh)
 	g_free(ssh->server);
 	g_free(ssh->user);
 	g_free(ssh->password);
-	g_free(ssh->passphrase);
 	g_free(ssh->privkeyfile);
 	g_free(ssh->charset);
 	g_free(ssh->error);


### PR DESCRIPTION
Quick fix to close #1257
In the future I'll review entirely the sftp protocol.