### PR TITLE
RDP client keyboard mapping with GTK3

### DIFF
--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -88,6 +88,14 @@ static BOOL rf_process_event_queue(RemminaProtocolWidget* gp)
 				input->KeyboardEvent(input, flags, event->key_event.key_code);
 				break;
 
+			case REMMINA_RDP_EVENT_TYPE_SCANCODE_UNICODE:
+				/*
+				 * TS_UNICODE_KEYBOARD_EVENT RDP message, see https://msdn.microsoft.com/en-us/library/cc240585.aspx
+				 */
+				flags = event->key_event.up ? KBD_FLAGS_RELEASE : KBD_FLAGS_DOWN;
+				input->UnicodeKeyboardEvent(input, flags, event->key_event.unicode_code);
+				break;
+
 			case REMMINA_RDP_EVENT_TYPE_MOUSE:
 				if (event->mouse_event.extended)
 					input->ExtendedMouseEvent(input, event->mouse_event.flags,

--- a/remmina-plugins/rdp/rdp_plugin.h
+++ b/remmina-plugins/rdp/rdp_plugin.h
@@ -109,6 +109,7 @@ typedef struct rf_glyph rfGlyph;
 typedef enum
 {
 	REMMINA_RDP_EVENT_TYPE_SCANCODE,
+	REMMINA_RDP_EVENT_TYPE_SCANCODE_UNICODE,
 	REMMINA_RDP_EVENT_TYPE_MOUSE,
 	REMMINA_RDP_EVENT_TYPE_CLIPBOARD_SEND_CLIENT_FORMAT_LIST,
 	REMMINA_RDP_EVENT_TYPE_CLIPBOARD_SEND_CLIENT_FORMAT_DATA_RESPONSE,
@@ -125,6 +126,7 @@ struct remmina_plugin_rdp_event
 			BOOL up;
 			BOOL extended;
 			UINT8 key_code;
+			UINT32 unicode_code;
 		} key_event;
 		struct
 		{


### PR DESCRIPTION
This patch upgrades the RDP settings "Use client keyboard mapping" by

- removing old legacy X11 code and replacing it with GTK3 code
- using TS_UNICODE_KEYBOARD_EVENT RDP message to send the server keystrokes already processed at the client side

This should fixes or help fixing issues #440 #1026 and #434 
