### PR TITLE
Custom Color schemes for SSH

### DIFF
--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -1152,7 +1152,6 @@ static void remmina_main_init(void)
 	/* Register the window in remmina_widget_pool with GType=GTK_WINDOW and TAG=remmina-main-window */
 	g_object_set_data(G_OBJECT(remminamain->window), "tag", "remmina-main-window");
 	remmina_widget_pool_register(GTK_WIDGET(remminamain->window));
-	remmina_pref_save();
 }
 
 /* RemminaMain instance */

--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -1152,6 +1152,7 @@ static void remmina_main_init(void)
 	/* Register the window in remmina_widget_pool with GType=GTK_WINDOW and TAG=remmina-main-window */
 	g_object_set_data(G_OBJECT(remminamain->window), "tag", "remmina-main-window");
 	remmina_widget_pool_register(GTK_WIDGET(remminamain->window));
+	remmina_pref_save();
 }
 
 /* RemminaMain instance */

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -534,16 +534,6 @@ void remmina_pref_init(void)
 		remmina_pref.vte_system_colors = g_key_file_get_boolean(gkeyfile, "remmina_pref", "vte_system_colors", NULL);
 	else
 		remmina_pref.vte_system_colors = FALSE;
-	/* Customized vte foreground color */
-	if (g_key_file_has_key (gkeyfile, "remmina_pref", "vte_foreground_color", NULL))
-		remmina_pref.vte_foreground_color = g_key_file_get_string (gkeyfile, "remmina_pref", "vte_foreground_color", NULL);
-	else
-		remmina_pref.vte_foreground_color = "rgb(192,192,192)";
-	/* Customized vte background color */
-	if (g_key_file_has_key (gkeyfile, "remmina_pref", "vte_background_color", NULL))
-		remmina_pref.vte_background_color = g_key_file_get_string (gkeyfile, "remmina_pref", "vte_background_color", NULL);
-	else
-		remmina_pref.vte_background_color = "rgb(0,0,0)";
 
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "vte_lines", NULL))
 		remmina_pref.vte_lines = g_key_file_get_integer(gkeyfile, "remmina_pref", "vte_lines", NULL);
@@ -753,8 +743,6 @@ void remmina_pref_save(void)
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "vte_allow_bold_text", remmina_pref.vte_allow_bold_text);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "vte_lines", remmina_pref.vte_lines);
 	g_key_file_set_boolean (gkeyfile, "remmina_pref", "vte_system_colors", remmina_pref.vte_system_colors);
-	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_foreground_color", remmina_pref.vte_foreground_color ? remmina_pref.vte_foreground_color : "");
-	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_background_color", remmina_pref.vte_background_color ? remmina_pref.vte_background_color : "");
 	g_key_file_set_string(gkeyfile, "ssh_colors", "background", remmina_pref.background ? remmina_pref.background : "");
 	g_key_file_set_string(gkeyfile, "ssh_colors", "cursor", remmina_pref.cursor ? remmina_pref.cursor : "");
 	g_key_file_set_string(gkeyfile, "ssh_colors", "foreground", remmina_pref.foreground ? remmina_pref.foreground : "");

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -570,7 +570,6 @@ void remmina_pref_init(void)
 	if (g_file_test (remmina_colors_file, G_FILE_TEST_IS_REGULAR))
 	{
 		remmina_pref_save();
-		//g_free(gkeyfile);
 		gkeyfile = g_key_file_new();
 		g_key_file_load_from_file(gkeyfile, remmina_colors_file, G_KEY_FILE_NONE, NULL);
 	}

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -689,11 +689,13 @@ void remmina_pref_init(void)
 
 	g_key_file_free(gkeyfile);
 
+#if 0
 	/* We delete the colorscheme file because we save its content in the remmina.pref */
 	if (g_file_test (remmina_colors_file, G_FILE_TEST_IS_REGULAR))
 	{
 		g_file_delete (path, NULL, NULL);
 	}
+#endif
 
 	if (remmina_pref.secret == NULL)
 		remmina_pref_gen_secret();

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -569,7 +569,6 @@ void remmina_pref_init(void)
 	 * remmina.pref file */
 	if (g_file_test (remmina_colors_file, G_FILE_TEST_IS_REGULAR))
 	{
-		remmina_pref_save();
 		gkeyfile = g_key_file_new();
 		g_key_file_load_from_file(gkeyfile, remmina_colors_file, G_KEY_FILE_NONE, NULL);
 	}
@@ -700,7 +699,6 @@ void remmina_pref_init(void)
 		remmina_pref_gen_secret();
 
 	remmina_pref_init_keymap();
-	remmina_pref_save();
 }
 
 void remmina_pref_save(void)

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -568,6 +568,121 @@ void remmina_pref_init(void)
 	else
 		remmina_pref.vte_shortcutkey_select_all = GDK_KEY_a;
 
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "background", NULL))
+		remmina_pref.background = g_key_file_get_string(gkeyfile, "ssh_colors", "background",
+						     NULL);
+	else
+		remmina_pref.background = "#d5ccba";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "cursor", NULL))
+		remmina_pref.cursor = g_key_file_get_string(gkeyfile, "ssh_colors", "cursor",
+						     NULL);
+	else
+		remmina_pref.cursor = "#45373c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "foreground", NULL))
+		remmina_pref.foreground = g_key_file_get_string(gkeyfile, "ssh_colors", "foreground",
+						     NULL);
+	else
+		remmina_pref.foreground = "#45373c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color0", NULL))
+		remmina_pref.color0 = g_key_file_get_string(gkeyfile, "ssh_colors", "color0",
+						     NULL);
+	else
+		remmina_pref.color0 = "#20111b";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color1", NULL))
+		remmina_pref.color1 = g_key_file_get_string(gkeyfile, "ssh_colors", "color1",
+						     NULL);
+	else
+		remmina_pref.color1 = "#be100e";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color2", NULL))
+		remmina_pref.color2 = g_key_file_get_string(gkeyfile, "ssh_colors", "color2",
+						     NULL);
+	else
+		remmina_pref.color2 = "#858162";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color3", NULL))
+		remmina_pref.color3 = g_key_file_get_string(gkeyfile, "ssh_colors", "color3",
+						     NULL);
+	else
+		remmina_pref.color3 = "#eaa549";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color4", NULL))
+		remmina_pref.color4 = g_key_file_get_string(gkeyfile, "ssh_colors", "color4",
+						     NULL);
+	else
+		remmina_pref.color4 = "#426a79";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color5", NULL))
+		remmina_pref.color5 = g_key_file_get_string(gkeyfile, "ssh_colors", "color5",
+						     NULL);
+	else
+		remmina_pref.color5 = "#97522c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color6", NULL))
+		remmina_pref.color6 = g_key_file_get_string(gkeyfile, "ssh_colors", "color6",
+						     NULL);
+	else
+		remmina_pref.color6 = "#989a9c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color7", NULL))
+		remmina_pref.color7 = g_key_file_get_string(gkeyfile, "ssh_colors", "color7",
+						     NULL);
+	else
+		remmina_pref.color7 = "#968c83";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color8", NULL))
+		remmina_pref.color8 = g_key_file_get_string(gkeyfile, "ssh_colors", "color8",
+						     NULL);
+	else
+		remmina_pref.color8 = "#5e5252";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color9", NULL))
+		remmina_pref.color9 = g_key_file_get_string(gkeyfile, "ssh_colors", "color9",
+						     NULL);
+	else
+		remmina_pref.color9 = "#be100e";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color10", NULL))
+		remmina_pref.color10 = g_key_file_get_string(gkeyfile, "ssh_colors", "color10",
+						     NULL);
+	else
+		remmina_pref.color10 = "#858162";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color11", NULL))
+		remmina_pref.color11 = g_key_file_get_string(gkeyfile, "ssh_colors", "color11",
+						     NULL);
+	else
+		remmina_pref.color11 = "#eaa549";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color12", NULL))
+		remmina_pref.color12 = g_key_file_get_string(gkeyfile, "ssh_colors", "color12",
+						     NULL);
+	else
+		remmina_pref.color12 = "#426a79";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color13", NULL))
+		remmina_pref.color13 = g_key_file_get_string(gkeyfile, "ssh_colors", "color13",
+						     NULL);
+	else
+		remmina_pref.color13 = "#97522c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color14", NULL))
+		remmina_pref.color14 = g_key_file_get_string(gkeyfile, "ssh_colors", "color14",
+						     NULL);
+	else
+		remmina_pref.color14 = "#989a9c";
+
+	if (g_key_file_has_key(gkeyfile, "ssh_colors", "color15", NULL))
+		remmina_pref.color15 = g_key_file_get_string(gkeyfile, "ssh_colors", "color15",
+						     NULL);
+	else
+		remmina_pref.color15 = "#d5ccba";
+
+
 	g_key_file_free(gkeyfile);
 
 	if (remmina_pref.secret == NULL)
@@ -640,6 +755,25 @@ void remmina_pref_save(void)
 	g_key_file_set_boolean (gkeyfile, "remmina_pref", "vte_system_colors", remmina_pref.vte_system_colors);
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_foreground_color", remmina_pref.vte_foreground_color ? remmina_pref.vte_foreground_color : "");
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_background_color", remmina_pref.vte_background_color ? remmina_pref.vte_background_color : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "background", remmina_pref.background ? remmina_pref.background : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "cursor", remmina_pref.cursor ? remmina_pref.cursor : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "foreground", remmina_pref.foreground ? remmina_pref.foreground : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color0", remmina_pref.color0 ? remmina_pref.color0 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color1", remmina_pref.color1 ? remmina_pref.color1 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color2", remmina_pref.color2 ? remmina_pref.color2 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color3", remmina_pref.color3 ? remmina_pref.color3 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color4", remmina_pref.color4 ? remmina_pref.color4 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color5", remmina_pref.color5 ? remmina_pref.color5 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color6", remmina_pref.color6 ? remmina_pref.color6 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color7", remmina_pref.color7 ? remmina_pref.color7 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color8", remmina_pref.color8 ? remmina_pref.color8 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color9", remmina_pref.color9 ? remmina_pref.color9 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color10", remmina_pref.color10 ? remmina_pref.color10 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color11", remmina_pref.color11 ? remmina_pref.color11 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color12", remmina_pref.color12 ? remmina_pref.color12 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color13", remmina_pref.color13 ? remmina_pref.color13 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color14", remmina_pref.color14 ? remmina_pref.color14 : "");
+	g_key_file_set_string(gkeyfile, "ssh_colors", "color15", remmina_pref.color15 ? remmina_pref.color15 : "");
 
 	content = g_key_file_to_data(gkeyfile, &length, NULL);
 	g_file_set_contents(remmina_pref_file, content, length, NULL);

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -169,6 +169,28 @@ typedef struct _RemminaPref
 
 	/* Remmina birthday julian format*/
 	guint32 bdate;
+
+	/* Color palette for VTE terminal */
+	gchar *background;
+	gchar *cursor;
+	gchar *foreground;
+	gchar *color0;
+	gchar *color1;
+	gchar *color2;
+	gchar *color3;
+	gchar *color4;
+	gchar *color5;
+	gchar *color6;
+	gchar *color7;
+	gchar *color8;
+	gchar *color9;
+	gchar *color10;
+	gchar *color11;
+	gchar *color12;
+	gchar *color13;
+	gchar *color14;
+	gchar *color15;
+
 } RemminaPref;
 
 #define DEFAULT_SSH_PARSECONFIG TRUE

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -137,8 +137,6 @@ typedef struct _RemminaPref
 	gchar *vte_font;
 	gboolean vte_allow_bold_text;
 	gboolean vte_system_colors;
-	gchar *vte_foreground_color;
-	gchar *vte_background_color;
 	gint vte_lines;
 	guint vte_shortcutkey_copy;
 	guint vte_shortcutkey_paste;

--- a/remmina/src/remmina_pref.h
+++ b/remmina/src/remmina_pref.h
@@ -198,6 +198,7 @@ typedef struct _RemminaPref
 
 extern const gchar *default_resolutions;
 extern gchar *remmina_pref_file;
+extern gchar *remmina_colors_file;
 extern RemminaPref remmina_pref;
 
 void remmina_pref_init(void);

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -84,6 +84,38 @@ void remmina_pref_on_button_resolutions_clicked(GtkWidget *widget, gpointer user
 	gtk_widget_destroy(GTK_WIDGET(dialog));
 }
 
+/* Re-initialize the remmina_pref_init to reload the color scheme when a color scheme
+ * file is selected*/
+void remmina_pref_on_color_scheme_selected(GtkWidget *widget, gpointer user_data)
+{
+	TRACE_CALL("remmina_pref_on_color_scheme_selected");
+	gchar *sourcepath;
+	gchar *remmina_dir;
+	gchar *destpath;
+	GFile *source;
+	GFile *destination;
+
+	sourcepath = gtk_file_chooser_get_filename(remmina_pref_dialog->filechooserbutton_terminal_color_scheme);
+	source = g_file_new_for_path (sourcepath);
+
+	remmina_dir = g_build_path ( "/", g_get_user_config_dir (), g_get_prgname (), NULL);
+	/* /home/foo/.config/remmina */
+	destpath = g_strdup_printf("%s/remmina.colors", remmina_dir);
+	destination = g_file_new_for_path (destpath);
+
+	if (g_file_test (sourcepath, G_FILE_TEST_IS_REGULAR))
+	{
+		g_file_copy (   source,
+				destination,
+				G_FILE_COPY_OVERWRITE,
+				NULL,
+				NULL,
+				NULL,
+				NULL);
+		/* Here we should reinitialize the widget */
+	}
+}
+
 void remmina_pref_dialog_clear_recent(GtkWidget *widget, gpointer user_data)
 {
 	TRACE_CALL("remmina_pref_dialog_clear_recent");
@@ -516,6 +548,7 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->colorbutton_color13 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color13"));
 	remmina_pref_dialog->colorbutton_color14 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color14"));
 	remmina_pref_dialog->colorbutton_color15 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color15"));
+	remmina_pref_dialog->filechooserbutton_terminal_color_scheme = GTK_FILE_CHOOSER(GET_OBJECT("filechooserbutton_terminal_color_scheme"));
 
 	/* Connect signals */
 	gtk_builder_connect_signals(remmina_pref_dialog->builder, NULL);

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -341,6 +341,10 @@ static void remmina_pref_dialog_init(void)
 	gchar buf[100];
 	GdkRGBA color;
 
+	/* We reinitialize the remmina_pref to load anything has changed.
+	 * This is needed when we change anything while remmina is running.
+	 * TODO: We should not call this the first time as it is rendundant */
+	remmina_pref_init();
 	gtk_dialog_set_default_response(GTK_DIALOG(remmina_pref_dialog->dialog), GTK_RESPONSE_CLOSE);
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode), remmina_pref.save_view_mode);

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -271,6 +271,9 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.vte_shortcutkey_paste = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_paste));
 	remmina_pref.vte_shortcutkey_select_all = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_select_all));
 
+	remmina_pref_save();
+	remmina_pref_init();
+
 	remmina_pref_dialog->dialog = NULL;
 }
 

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -195,18 +195,45 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	}
 	remmina_pref.vte_allow_bold_text = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_bold));
 	remmina_pref.vte_system_colors = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors));
-#if GTK_CHECK_VERSION(3, 4, 0)
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_foreground), &color);
-#else
-	gtk_color_button_get_rgba(remmina_pref_dialog->colorbutton_foreground, &color);
-#endif
-	remmina_pref.vte_foreground_color = gdk_rgba_to_string(&color);
-#if GTK_CHECK_VERSION(3, 4, 0)
+	remmina_pref.foreground = gdk_rgba_to_string(&color);
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_background), &color);
-#else
-	gtk_color_button_get_rgba(remmina_pref_dialog->colorbutton_background, &color);
-#endif
-	remmina_pref.vte_background_color = gdk_rgba_to_string(&color);
+	remmina_pref.background = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_cursor), &color);
+	remmina_pref.cursor = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color0), &color);
+	remmina_pref.color0 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color1), &color);
+	remmina_pref.color1 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color2), &color);
+	remmina_pref.color2 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color3), &color);
+	remmina_pref.color3 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color4), &color);
+	remmina_pref.color4 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color5), &color);
+	remmina_pref.color5 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color6), &color);
+	remmina_pref.color6 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color7), &color);
+	remmina_pref.color7 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color8), &color);
+	remmina_pref.color8 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color9), &color);
+	remmina_pref.color9 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color10), &color);
+	remmina_pref.color10 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color11), &color);
+	remmina_pref.color11 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color12), &color);
+	remmina_pref.color12 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color13), &color);
+	remmina_pref.color13 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color14), &color);
+	remmina_pref.color14 = gdk_rgba_to_string(&color);
+	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color15), &color);
+	remmina_pref.color15 = gdk_rgba_to_string(&color);
+	remmina_pref.vte_lines = atoi(gtk_entry_get_text(remmina_pref_dialog->entry_scrollback_lines));
 	remmina_pref.vte_lines = atoi(gtk_entry_get_text(remmina_pref_dialog->entry_scrollback_lines));
 	remmina_pref.vte_shortcutkey_copy = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_copy));
 	remmina_pref.vte_shortcutkey_paste = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_paste));
@@ -331,19 +358,48 @@ static void remmina_pref_dialog_init(void)
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors), remmina_pref.vte_system_colors);
 
 	/* Foreground color option */
-	gdk_rgba_parse(&color, remmina_pref.vte_foreground_color);
-#if GTK_CHECK_VERSION(3, 4, 0)
+	gdk_rgba_parse(&color, remmina_pref.foreground);
 	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_foreground), &color);
-#else
-	gtk_color_button_set_rgba(remmina_pref_dialog->colorbutton_foreground, &color);
-#endif
 	/* Background color option */
-	gdk_rgba_parse(&color, remmina_pref.vte_background_color);
-#if GTK_CHECK_VERSION(3, 4, 0)
+	gdk_rgba_parse(&color, remmina_pref.background);
 	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_background), &color);
-#else
-	gtk_color_button_set_rgba(remmina_pref_dialog->colorbutton_background, &color);
-#endif
+	/* Cursor color option */
+	gdk_rgba_parse(&color, remmina_pref.cursor);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_cursor), &color);
+	/* 16 colors */
+	gdk_rgba_parse(&color, remmina_pref.color0);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color0), &color);
+	gdk_rgba_parse(&color, remmina_pref.color1);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color1), &color);
+	gdk_rgba_parse(&color, remmina_pref.color2);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color2), &color);
+	gdk_rgba_parse(&color, remmina_pref.color3);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color3), &color);
+	gdk_rgba_parse(&color, remmina_pref.color4);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color4), &color);
+	gdk_rgba_parse(&color, remmina_pref.color5);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color5), &color);
+	gdk_rgba_parse(&color, remmina_pref.color6);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color6), &color);
+	gdk_rgba_parse(&color, remmina_pref.color7);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color7), &color);
+	gdk_rgba_parse(&color, remmina_pref.color8);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color8), &color);
+	gdk_rgba_parse(&color, remmina_pref.color9);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color9), &color);
+	gdk_rgba_parse(&color, remmina_pref.color10);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color10), &color);
+	gdk_rgba_parse(&color, remmina_pref.color11);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color11), &color);
+	gdk_rgba_parse(&color, remmina_pref.color12);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color12), &color);
+	gdk_rgba_parse(&color, remmina_pref.color13);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color13), &color);
+	gdk_rgba_parse(&color, remmina_pref.color14);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color14), &color);
+	gdk_rgba_parse(&color, remmina_pref.color15);
+	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color15), &color);
+
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors), remmina_pref.vte_system_colors);
 	remmina_pref_dialog_vte_color_on_toggled(GTK_WIDGET(remmina_pref_dialog->checkbutton_terminal_system_colors), NULL);
@@ -431,15 +487,35 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->checkbutton_terminal_font_system = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_terminal_font_system"));
 	remmina_pref_dialog->fontbutton_terminal_font = GTK_FONT_BUTTON(GET_OBJECT("fontbutton_terminal_font"));
 	remmina_pref_dialog->checkbutton_terminal_bold = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_terminal_bold"));
+	remmina_pref_dialog->entry_scrollback_lines = GTK_ENTRY(GET_OBJECT("entry_scrollback_lines"));
+	remmina_pref_dialog->button_keyboard_copy = GTK_BUTTON(GET_OBJECT("button_keyboard_copy"));
+	remmina_pref_dialog->button_keyboard_paste = GTK_BUTTON(GET_OBJECT("button_keyboard_paste"));
+	remmina_pref_dialog->button_keyboard_select_all = GTK_BUTTON(GET_OBJECT("button_keyboard_select_all"));
 	remmina_pref_dialog->checkbutton_terminal_system_colors = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_terminal_system_colors"));
 	remmina_pref_dialog->label_terminal_foreground = GTK_LABEL(GET_OBJECT("label_terminal_foreground"));
 	remmina_pref_dialog->colorbutton_foreground = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_foreground"));
 	remmina_pref_dialog->label_terminal_background = GTK_LABEL(GET_OBJECT("label_terminal_background"));
 	remmina_pref_dialog->colorbutton_background = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_background"));
-	remmina_pref_dialog->entry_scrollback_lines = GTK_ENTRY(GET_OBJECT("entry_scrollback_lines"));
-	remmina_pref_dialog->button_keyboard_copy = GTK_BUTTON(GET_OBJECT("button_keyboard_copy"));
-	remmina_pref_dialog->button_keyboard_paste = GTK_BUTTON(GET_OBJECT("button_keyboard_paste"));
-	remmina_pref_dialog->button_keyboard_select_all = GTK_BUTTON(GET_OBJECT("button_keyboard_select_all"));
+	remmina_pref_dialog->label_terminal_cursor_color = GTK_LABEL(GET_OBJECT("label_terminal_cursor_color"));
+	remmina_pref_dialog->colorbutton_cursor = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_cursor"));
+	remmina_pref_dialog->label_terminal_normal_colors = GTK_LABEL(GET_OBJECT("label_terminal_normal_colors"));
+	remmina_pref_dialog->colorbutton_color0 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color0"));
+	remmina_pref_dialog->colorbutton_color1 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color1"));
+	remmina_pref_dialog->colorbutton_color2 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color2"));
+	remmina_pref_dialog->colorbutton_color3 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color3"));
+	remmina_pref_dialog->colorbutton_color4 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color4"));
+	remmina_pref_dialog->colorbutton_color5 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color5"));
+	remmina_pref_dialog->colorbutton_color6 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color6"));
+	remmina_pref_dialog->colorbutton_color7 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color7"));
+	remmina_pref_dialog->label_terminal_bright_colors = GTK_LABEL(GET_OBJECT("label_terminal_bright_colors"));
+	remmina_pref_dialog->colorbutton_color8 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color8"));
+	remmina_pref_dialog->colorbutton_color9 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color9"));
+	remmina_pref_dialog->colorbutton_color10 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color10"));
+	remmina_pref_dialog->colorbutton_color11 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color11"));
+	remmina_pref_dialog->colorbutton_color12 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color12"));
+	remmina_pref_dialog->colorbutton_color13 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color13"));
+	remmina_pref_dialog->colorbutton_color14 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color14"));
+	remmina_pref_dialog->colorbutton_color15 = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_color15"));
 
 	/* Connect signals */
 	gtk_builder_connect_signals(remmina_pref_dialog->builder, NULL);

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -271,9 +271,6 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.vte_shortcutkey_paste = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_paste));
 	remmina_pref.vte_shortcutkey_select_all = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_select_all));
 
-	/* We do this to reload immediately whatever we have changed in the remmina preferences */
-	remmina_pref_init();
-
 	remmina_pref_dialog->dialog = NULL;
 }
 

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -271,7 +271,8 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.vte_shortcutkey_paste = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_paste));
 	remmina_pref.vte_shortcutkey_select_all = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_select_all));
 
-	remmina_pref_save();
+	/* We do this to reload immediately whatever we have changed in the remmina preferences */
+	remmina_pref_init();
 
 	remmina_pref_dialog->dialog = NULL;
 }
@@ -341,10 +342,6 @@ static void remmina_pref_dialog_init(void)
 	gchar buf[100];
 	GdkRGBA color;
 
-	/* We reinitialize the remmina_pref to load anything has changed.
-	 * This is needed when we change anything while remmina is running.
-	 * TODO: We should not call this the first time as it is rendundant */
-	remmina_pref_init();
 	gtk_dialog_set_default_response(GTK_DIALOG(remmina_pref_dialog->dialog), GTK_RESPONSE_CLOSE);
 
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_options_remember_last_view_mode), remmina_pref.save_view_mode);

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -101,6 +101,26 @@ typedef struct _RemminaPrefDialog
 	GtkButton *button_keyboard_copy;
 	GtkButton *button_keyboard_paste;
 	GtkButton *button_keyboard_select_all;
+	GtkLabel *label_terminal_cursor_color;
+	GtkLabel *label_terminal_normal_colors;
+	GtkLabel *label_terminal_bright_colors;
+	GtkColorButton *colorbutton_cursor;
+	GtkColorButton *colorbutton_color0;
+	GtkColorButton *colorbutton_color1;
+	GtkColorButton *colorbutton_color2;
+	GtkColorButton *colorbutton_color3;
+	GtkColorButton *colorbutton_color4;
+	GtkColorButton *colorbutton_color5;
+	GtkColorButton *colorbutton_color6;
+	GtkColorButton *colorbutton_color7;
+	GtkColorButton *colorbutton_color8;
+	GtkColorButton *colorbutton_color9;
+	GtkColorButton *colorbutton_color10;
+	GtkColorButton *colorbutton_color11;
+	GtkColorButton *colorbutton_color12;
+	GtkColorButton *colorbutton_color13;
+	GtkColorButton *colorbutton_color14;
+	GtkColorButton *colorbutton_color15;
 
 	RemminaPrefDialogPriv *priv;
 } RemminaPrefDialog;

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -121,6 +121,7 @@ typedef struct _RemminaPrefDialog
 	GtkColorButton *colorbutton_color13;
 	GtkColorButton *colorbutton_color14;
 	GtkColorButton *colorbutton_color15;
+	GtkFileChooser *filechooserbutton_terminal_color_scheme;
 
 	RemminaPrefDialogPriv *priv;
 } RemminaPrefDialog;

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -495,8 +495,8 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	else
 	{
 		/* Get customized colors */
-		gdk_rgba_parse(&foreground_color, remmina_pref.vte_foreground_color);
-		gdk_rgba_parse(&background_color, remmina_pref.vte_background_color);
+		gdk_rgba_parse(&foreground_color, remmina_pref.foreground);
+		gdk_rgba_parse(&background_color, remmina_pref.background);
 	}
 	remminafile = remmina_plugin_service->protocol_plugin_get_file (gp);
 

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -780,7 +780,7 @@ static gpointer ssh_terminal_palette[] =
 	"3", "Solarized Dark",
 	"4", "Solarized Light",
 	"5", "XTerm",
-	"6", "Custom",
+	"6", "Custom (Configured in Remmina preferences)",
 	NULL
 };
 

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -61,7 +61,7 @@
 /* Palette colors taken from sakura */
 #define PALETTE_SIZE 16
 
-enum color_schemes { GRUVBOX, TANGO, LINUX, SOLARIZED_DARK, SOLARIZED_LIGHT, XTERM };
+enum color_schemes { GRUVBOX, TANGO, LINUX, SOLARIZED_DARK, SOLARIZED_LIGHT, XTERM, CUSTOM};
 /* 16 color palettes in GdkRGBA format (red, green, blue, alpha)
  * Text displayed in the first 8 colors (0-7) is meek (uses thin strokes).
  * Text displayed in the second 8 colors (8-15) is bold (uses thick strokes). */
@@ -140,24 +140,6 @@ const GdkRGBA solarized_dark_palette[PALETTE_SIZE] = {
 	{0.423529, 0.443137, 0.768627, 1},
 	{0.576471, 0.631373, 0.631373, 1},
 	{0.992157, 0.964706, 0.890196, 1}
-#if 0
-    { 0, 0x0707, 0x3636, 0x4242 }, // 0  base02 black (used as background color)
-    { 0, 0xdcdc, 0x3232, 0x2f2f }, // 1  red
-    { 0, 0x8585, 0x9999, 0x0000 }, // 2  green
-    { 0, 0xb5b5, 0x8989, 0x0000 }, // 3  yellow
-    { 0, 0x2626, 0x8b8b, 0xd2d2 }, // 4  blue
-    { 0, 0xd3d3, 0x3636, 0x8282 }, // 5  magenta
-    { 0, 0x2a2a, 0xa1a1, 0x9898 }, // 6  cyan
-    { 0, 0xeeee, 0xe8e8, 0xd5d5 }, // 7  base2 white (used as foreground color)
-    { 0, 0x0000, 0x2b2b, 0x3636 }, // 8  base3 bright black
-    { 0, 0xcbcb, 0x4b4B, 0x1616 }, // 9  orange
-    { 0, 0x5858, 0x6e6e, 0x7575 }, // 10 base01 bright green
-    { 0, 0x6565, 0x7b7b, 0x8383 }, // 11 base00 bright yellow
-    { 0, 0x8383, 0x9494, 0x9696 }, // 12 base0 brigth blue
-    { 0, 0x6c6c, 0x7171, 0xc4c4 }, // 13 violet
-    { 0, 0x9393, 0xa1a1, 0xa1a1 }, // 14 base1 cyan
-    { 0, 0xfdfd, 0xf6f6, 0xe3e3 }  // 15 base3 white
-#endif
 };
 
 const GdkRGBA solarized_light_palette[PALETTE_SIZE] = {
@@ -177,24 +159,6 @@ const GdkRGBA solarized_light_palette[PALETTE_SIZE] = {
 	{0.423529, 0.443137, 0.768627, 1},
 	{0.345098, 0.431373, 0.458824, 1},
 	{0.000000, 0.168627, 0.211765, 1}
-#if 0
-	{ 0, 0xeeee, 0xe8e8, 0xd5d5 }, // 0 S_base2
-	{ 0, 0xdcdc, 0x3232, 0x2f2f }, // 1 S_red
-	{ 0, 0x8585, 0x9999, 0x0000 }, // 2 S_green
-	{ 0, 0xb5b5, 0x8989, 0x0000 }, // 3 S_yellow
-	{ 0, 0x2626, 0x8b8b, 0xd2d2 }, // 4 S_blue
-	{ 0, 0xd3d3, 0x3636, 0x8282 }, // 5 S_magenta
-	{ 0, 0x2a2a, 0xa1a1, 0x9898 }, // 6 S_cyan
-	{ 0, 0x0707, 0x3636, 0x4242 }, // 7 S_base02
-	{ 0, 0xfdfd, 0xf6f6, 0xe3e3 }, // 8 S_base3
-	{ 0, 0xcbcb, 0x4b4B, 0x1616 }, // 9 S_orange
-	{ 0, 0x9393, 0xa1a1, 0xa1a1 }, // 10 S_base1
-	{ 0, 0x8383, 0x9494, 0x9696 }, // 11 S_base0
-	{ 0, 0x6565, 0x7b7b, 0x8383 }, // 12 S_base00
-	{ 0, 0x6c6c, 0x7171, 0xc4c4 }, // 13 S_violet
-	{ 0, 0x5858, 0x6e6e, 0x7575 }, // 14 S_base01
-	{ 0, 0x0000, 0x2b2b, 0x3636 } // 15 S_base03
-#endif
 };
 
 const GdkRGBA xterm_palette[PALETTE_SIZE] = {
@@ -501,6 +465,9 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	GdkRGBA foreground_color;
 	GdkRGBA background_color;
 	GdkRGBA cursor_color;
+	GdkRGBA cp[PALETTE_SIZE];
+
+
 #if !VTE_CHECK_VERSION(0,38,0)
 	GdkColor foreground_gdkcolor;
 	GdkColor background_gdkcolor;
@@ -534,53 +501,97 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	remminafile = remmina_plugin_service->protocol_plugin_get_file (gp);
 
 #if VTE_CHECK_VERSION(0,38,0)
-		/* Set colors to GdkRGBA */
-		switch (remmina_plugin_service->file_get_int (remminafile, "ssh_color_scheme", FALSE))
-		{
-			case GRUVBOX:
-				remminavte.palette = gruvbox_palette;
-				gdk_rgba_parse(&foreground_color, "#ebdbb2");
-				gdk_rgba_parse(&background_color, "#282828");
-				gdk_rgba_parse(&cursor_color, "#d3869b");
-				break;
-			case TANGO:
-				remminavte.palette = tango_palette;
-				gdk_rgba_parse(&foreground_color, "#eeeeec");
-				gdk_rgba_parse(&background_color, "#2e3436");
-				gdk_rgba_parse(&cursor_color, "#8ae234");
-				break;
-			case LINUX:
-				gdk_rgba_parse(&foreground_color, "#ffffff");
-				gdk_rgba_parse(&background_color, "#000000");
-				gdk_rgba_parse(&cursor_color, "#ffffff");
-				remminavte.palette = linux_palette;
-				break;
-			case SOLARIZED_DARK:
-				remminavte.palette = solarized_dark_palette;
-				gdk_rgba_parse(&foreground_color, "#839496");
-				gdk_rgba_parse(&background_color, "#002b36");
-				gdk_rgba_parse(&cursor_color, "#93a1a1");
-				break;
-			case SOLARIZED_LIGHT:
-				remminavte.palette = solarized_light_palette;
-				gdk_rgba_parse(&foreground_color, "#657b83");
-				gdk_rgba_parse(&background_color, "#fdf6e3");
-				gdk_rgba_parse(&cursor_color, "#586e75");
-				break;
-			case XTERM:
-				gdk_rgba_parse(&foreground_color, "#000000");
-				gdk_rgba_parse(&background_color, "#ffffff");
-				gdk_rgba_parse(&cursor_color, "#000000");
-				remminavte.palette = xterm_palette;
-				break;
-			default:
-				remminavte.palette = linux_palette;
-				break;
-		}
+	/* Set colors to GdkRGBA */
+	switch (remmina_plugin_service->file_get_int (remminafile, "ssh_color_scheme", FALSE))
+	{
+		case GRUVBOX:
+			gdk_rgba_parse(&foreground_color, "#ebdbb2");
+			gdk_rgba_parse(&background_color, "#282828");
+			gdk_rgba_parse(&cursor_color, "#d3869b");
+			remminavte.palette = gruvbox_palette;
+			break;
+		case TANGO:
+			gdk_rgba_parse(&foreground_color, "#eeeeec");
+			gdk_rgba_parse(&background_color, "#2e3436");
+			gdk_rgba_parse(&cursor_color, "#8ae234");
+			remminavte.palette = tango_palette;
+			break;
+		case LINUX:
+			gdk_rgba_parse(&foreground_color, "#ffffff");
+			gdk_rgba_parse(&background_color, "#000000");
+			gdk_rgba_parse(&cursor_color, "#ffffff");
+			remminavte.palette = linux_palette;
+			break;
+		case SOLARIZED_DARK:
+			gdk_rgba_parse(&foreground_color, "#839496");
+			gdk_rgba_parse(&background_color, "#002b36");
+			gdk_rgba_parse(&cursor_color, "#93a1a1");
+			remminavte.palette = solarized_dark_palette;
+			break;
+		case SOLARIZED_LIGHT:
+			gdk_rgba_parse(&foreground_color, "#657b83");
+			gdk_rgba_parse(&background_color, "#fdf6e3");
+			gdk_rgba_parse(&cursor_color, "#586e75");
+			remminavte.palette = solarized_light_palette;
+			break;
+		case XTERM:
+			gdk_rgba_parse(&foreground_color, "#000000");
+			gdk_rgba_parse(&background_color, "#ffffff");
+			gdk_rgba_parse(&cursor_color, "#000000");
+			remminavte.palette = xterm_palette;
+			break;
+		case CUSTOM:
+			gdk_rgba_parse(&foreground_color, remmina_pref.foreground);
+			gdk_rgba_parse(&background_color, remmina_pref.background);
+			gdk_rgba_parse(&cursor_color, remmina_pref.cursor);
+
+			gdk_rgba_parse(&cp[0] , remmina_pref.color0);
+			gdk_rgba_parse(&cp[1] , remmina_pref.color1);
+			gdk_rgba_parse(&cp[2] , remmina_pref.color2);
+			gdk_rgba_parse(&cp[3] , remmina_pref.color3);
+			gdk_rgba_parse(&cp[4] , remmina_pref.color4);
+			gdk_rgba_parse(&cp[5] , remmina_pref.color5);
+			gdk_rgba_parse(&cp[6] , remmina_pref.color6);
+			gdk_rgba_parse(&cp[7] , remmina_pref.color7);
+			gdk_rgba_parse(&cp[8] , remmina_pref.color8);
+			gdk_rgba_parse(&cp[9] , remmina_pref.color9);
+			gdk_rgba_parse(&cp[10], remmina_pref.color10);
+			gdk_rgba_parse(&cp[11], remmina_pref.color11);
+			gdk_rgba_parse(&cp[12], remmina_pref.color12);
+			gdk_rgba_parse(&cp[13], remmina_pref.color13);
+			gdk_rgba_parse(&cp[14], remmina_pref.color14);
+			gdk_rgba_parse(&cp[15], remmina_pref.color15);
+
+			const GdkRGBA custom_palette[PALETTE_SIZE] = {  cp[0] ,
+									cp[1] ,
+									cp[2] ,
+									cp[3] ,
+									cp[4] ,
+									cp[5] ,
+									cp[6] ,
+									cp[7] ,
+									cp[8] ,
+									cp[9] ,
+									cp[10],
+									cp[11],
+									cp[12],
+									cp[13],
+									cp[14],
+									cp[15]
+			};
+
+			remminavte.palette = custom_palette;
+			break;
+		default:
+			remminavte.palette = linux_palette;
+			break;
+	}
 		vte_terminal_set_colors (VTE_TERMINAL(vte), &foreground_color, &background_color, remminavte.palette, PALETTE_SIZE);
 		vte_terminal_set_color_foreground (VTE_TERMINAL(vte), &foreground_color);
 		vte_terminal_set_color_background (VTE_TERMINAL(vte), &background_color);
-		vte_terminal_set_color_cursor (VTE_TERMINAL(vte), &cursor_color);
+		vte_terminal_set_cursor_shape (VTE_TERMINAL(vte), VTE_CURSOR_SHAPE_BLOCK);
+		vte_terminal_set_color_cursor (VTE_TERMINAL(vte), &foreground_color);
+		vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(vte), &background_color);
 #else
 		/* VTE <= 2.90 doesn't support GdkRGBA so we must convert GdkRGBA to GdkColor */
 		foreground_gdkcolor.red = (guint16)(foreground_color.red * 0xFFFF);
@@ -770,6 +781,7 @@ static gpointer ssh_terminal_palette[] =
 	"3", "Solarized Dark",
 	"4", "Solarized Light",
 	"5", "XTerm",
+	"6", "Custom",
 	NULL
 };
 

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -591,7 +591,6 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 		vte_terminal_set_color_background (VTE_TERMINAL(vte), &background_color);
 		vte_terminal_set_cursor_shape (VTE_TERMINAL(vte), VTE_CURSOR_SHAPE_BLOCK);
 		vte_terminal_set_color_cursor (VTE_TERMINAL(vte), &foreground_color);
-		vte_terminal_set_color_cursor_foreground (VTE_TERMINAL(vte), &background_color);
 #else
 		/* VTE <= 2.90 doesn't support GdkRGBA so we must convert GdkRGBA to GdkColor */
 		foreground_gdkcolor.red = (guint16)(foreground_color.red * 0xFFFF);

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 
+<!-- Generated with glade 3.20.0 
 
-Remmina Preferences Dialog -
+Remmina Preferences Dialog - 
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2017
 
 This program is free software; you can redistribute it and/or
@@ -22,7 +22,7 @@ Author: Antenore Gatta
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.4"/>
+  <requires lib="gtk+" version="3.10"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name Remmina Preferences Dialog -->
   <!-- interface-copyright Antenore Gatta & Giovanni Panozzo 2014-2017 -->
@@ -100,7 +100,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -113,12 +114,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Double-click action</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">1</property>
                       </packing>
                     </child>
                     <child>
@@ -133,7 +134,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
+                        <property name="top_attach">1</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -141,12 +142,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Scale quality</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">2</property>
                       </packing>
                     </child>
                     <child>
@@ -163,7 +164,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
+                        <property name="top_attach">2</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -171,12 +172,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Auto scroll step size</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">5</property>
                       </packing>
                     </child>
                     <child>
@@ -187,7 +188,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
+                        <property name="top_attach">5</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -195,12 +196,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Maximum recent items</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
@@ -212,7 +213,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
@@ -225,45 +226,32 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">2</property>
-                        <property name="top_attach">6</property>
+                        <property name="top_attach">4</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_options_resolutions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Resolutions</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_options_resolutions">
-                        <property name="label" translatable="yes">Configure resolutions</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <signal name="clicked" handler="remmina_pref_on_button_resolutions_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
-                        <property name="width">2</property>
+                        <property name="top_attach">6</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkLabel" id="label_options_keystrokes">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Keystrokes</property>
-                        <property name="xalign">0</property>
+                        <property name="justify">fill</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">7</property>
                       </packing>
                     </child>
                     <child>
@@ -276,7 +264,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">9</property>
+                        <property name="top_attach">7</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -284,12 +272,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_screenshot_folder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Screenshots folder</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">3</property>
                       </packing>
                     </child>
                     <child>
@@ -303,21 +291,23 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
+                        <property name="top_attach">3</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
                     <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
-                    </child>
-                    <child>
-                      <placeholder/>
+                      <object class="GtkButton" id="button_options_resolutions">
+                        <property name="label" translatable="yes">Configure resolutions</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="remmina_pref_on_button_resolutions_clicked" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">6</property>
+                        <property name="width">2</property>
+                      </packing>
                     </child>
                   </object>
                 </child>
@@ -353,7 +343,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -368,7 +359,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -381,8 +373,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Default view mode</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -411,8 +403,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Tab interface</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -441,9 +433,9 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_buttons_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Show buttons icons</property>
                         <property name="justify">fill</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -472,8 +464,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_menu_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Show menu icons</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -504,7 +496,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="active">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
@@ -535,8 +528,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_fullscreen_toolbar_visibility">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Fullscreen toolbar visibility</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -581,8 +574,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
+                        <property name="halign">start</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -597,8 +590,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
+                        <property name="halign">start</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -613,8 +606,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
+                        <property name="halign">start</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                         <signal name="toggled" handler="remmina_pref_dialog_disable_tray_icon_on_toggled" swapped="no"/>
                       </object>
@@ -630,8 +623,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
+                        <property name="halign">start</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -647,8 +640,8 @@ Author: Antenore Gatta
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
                         <property name="tooltip_text" translatable="yes">Choose this if your theme panel is light.</property>
+                        <property name="halign">start</property>
                         <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
@@ -693,9 +686,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_host_key">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Host key</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -709,6 +701,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -721,9 +714,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_fullscreen">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Toggle fullscreen mode</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -737,6 +729,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -749,9 +742,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_auto_fit">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Auto-fit window</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -765,6 +757,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -777,9 +770,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_switch_tab">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Switch tab pages</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -793,6 +785,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -807,6 +800,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -818,9 +812,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_scaled">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Toggle scaled mode</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -834,6 +827,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -846,9 +840,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_grab_keyboard">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Grab keyboard</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -862,6 +855,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -874,9 +868,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_minimize">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Minimize window</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -890,6 +883,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -902,9 +896,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_disconnect">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Disconnect</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -918,6 +911,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -930,9 +924,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_toolbar">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Show / hide toolbar</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -946,6 +939,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -958,10 +952,9 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_screenshot">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">Screenshot</property>
                         <property name="ellipsize">start</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -975,6 +968,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="hexpand">True</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -1019,8 +1013,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">SSH tunnel local port</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -1031,6 +1025,7 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
                         <property name="max_length">5</property>
                       </object>
                       <packing>
@@ -1045,12 +1040,13 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">False</property>
-                        <property name="xalign">0</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="draw_indicator">True</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="top_attach">2</property>
                         <property name="width">3</property>
                       </packing>
                     </child>
@@ -1069,7 +1065,7 @@ Author: Antenore Gatta
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">0</property>
                         <property name="width">2</property>
                       </packing>
                     </child>
@@ -1077,12 +1073,12 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_loglevel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">end</property>
                         <property name="label" translatable="yes">SSH log level</property>
-                        <property name="xalign">0</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                   </object>
@@ -1112,352 +1108,654 @@ Author: Antenore Gatta
                 <property name="left_padding">7</property>
                 <property name="right_padding">7</property>
                 <child>
-                  <object class="GtkGrid" id="grid_terminal">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="row_spacing">5</property>
-                    <property name="column_spacing">7</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkLabel" id="label_terminal_font1">
+                      <object class="GtkGrid" id="grid_terminal">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Font</property>
-                        <property name="xalign">0</property>
+                        <property name="row_spacing">5</property>
+                        <property name="column_spacing">7</property>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_font1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Terminal font</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_scrollback_lines">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Scrollback lines</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="checkbutton_terminal_font_system">
+                            <property name="label" translatable="yes">Use system default font</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="remmina_pref_dialog_vte_font_on_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                            <property name="width">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFontButton" id="fontbutton_terminal_font">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="font">Sans 12</property>
+                            <property name="preview_text"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                            <property name="width">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_font2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_font3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="hexpand">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="checkbutton_terminal_bold">
+                            <property name="label" translatable="yes">Allow bold text</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                            <property name="width">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="checkbutton_terminal_system_colors">
+                            <property name="label" translatable="yes">Use system theme colors</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">7</property>
+                            <property name="width">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="entry_scrollback_lines">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="max_length">5</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
+                            <property name="width">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_copy1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Clipboard copy shortcut</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_copy2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">(Host key +)</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_keyboard_copy">
+                            <property name="label">COPY</property>
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="hexpand">True</property>
+                            <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_paste1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Clipboard paste shortcut</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_paste2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">(Host key +)</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">5</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_keyboard_paste">
+                            <property name="label">PASTE</property>
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="hexpand">True</property>
+                            <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_select_all1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Select all shortcut</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">6</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_keyboard_select_all2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">(Host key +)</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">6</property>
+                            <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_keyboard_select_all">
+                            <property name="label">SELECT_ALL</property>
+                            <property name="width_request">100</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="hexpand">True</property>
+                            <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">6</property>
+                          </packing>
+                        </child>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkLabel" id="label_terminal_colors">
+                      <object class="GtkGrid">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Colors</property>
-                        <property name="xalign">0</property>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_foreground">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Foreground color</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_foreground">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Foreground color</property>
+                            <property name="rgba">rgb(255,255,255)</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_background">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Background color</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_background">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Background color</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_cursor_color">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Cursor color</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_cursor">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Cursor Color</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_normal_colors">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Normal colors</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel" id="label_terminal_bright_colors">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Bright colors</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color0">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for black</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color8">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright black</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color1">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for red</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color2">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for green</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for yellow</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">4</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color4">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for blue</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">5</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color5">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for magenta</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">6</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color6">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for Cyan</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">7</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color7">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for white</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">8</property>
+                            <property name="top_attach">3</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color9">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright red</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color10">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright green</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color11">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright yellow</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">4</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color12">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright blue</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">5</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color13">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright magenta</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">6</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color14">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright Cyan</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">7</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkColorButton" id="colorbutton_color15">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="title" translatable="yes">Pick a color for bright white</property>
+                            <property name="show_editor">True</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">8</property>
+                            <property name="top_attach">4</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <child>
+                          <placeholder/>
+                        </child>
                       </object>
                       <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_foreground">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Foreground color</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_background">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Background color</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">5</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_scrollback_lines">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Scrollback lines</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">6</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_clipboard">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Keyboard</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">7</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_clipboard2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">8</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="checkbutton_terminal_font_system">
-                        <property name="label" translatable="yes">Use system default font</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                        <signal name="toggled" handler="remmina_pref_dialog_vte_font_on_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkFontButton" id="fontbutton_terminal_font">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="font">Sans 12</property>
-                        <property name="preview_text"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_font2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_font3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">2</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="checkbutton_terminal_bold">
-                        <property name="label" translatable="yes">Allow bold text</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">2</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="checkbutton_terminal_system_colors">
-                        <property name="label" translatable="yes">Use system theme colors</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="xalign">0</property>
-                        <property name="draw_indicator">True</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">3</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="colorbutton_foreground">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="title" translatable="yes">Foreground color</property>
-                        <property name="rgba">rgb(255,255,255)</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">4</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkColorButton" id="colorbutton_background">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="title" translatable="yes">Background color</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">5</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="entry_scrollback_lines">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="max_length">5</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">6</property>
-                        <property name="width">3</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_copy1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Copy</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">7</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_copy2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Host key +</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">7</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_keyboard_copy">
-                        <property name="label">COPY</property>
-                        <property name="width_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="hexpand">False</property>
-                        <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">7</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_paste1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Paste</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">8</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_paste2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Host key +</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">8</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_keyboard_paste">
-                        <property name="label">PASTE</property>
-                        <property name="width_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="hexpand">False</property>
-                        <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">8</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_select_all1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="hexpand">True</property>
-                        <property name="label" translatable="yes">Select All</property>
-                        <property name="xalign">0</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">9</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_keyboard_select_all2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Host key +</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">2</property>
-                        <property name="top_attach">9</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkButton" id="button_keyboard_select_all">
-                        <property name="label">SELECT_ALL</property>
-                        <property name="width_request">100</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="hexpand">False</property>
-                        <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">3</property>
-                        <property name="top_attach">9</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel" id="label_terminal_clipboard3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">9</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
                       </packing>
                     </child>
                   </object>
@@ -1486,6 +1784,9 @@ Author: Antenore Gatta
           </packing>
         </child>
       </object>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -126,7 +126,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Open connection</item>
@@ -155,7 +154,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Nearest</item>
@@ -186,7 +184,6 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="halign">baseline</property>
                         <property name="max_length">3</property>
                       </object>
                       <packing>
@@ -211,7 +208,6 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="max_length">2</property>
                       </object>
@@ -226,7 +222,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_clear_recent" swapped="no"/>
                       </object>
                       <packing>
@@ -265,7 +260,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_on_button_keystrokes_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -291,7 +285,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Choose the directory where you want to save Remmina screenshots.</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="action">select-folder</property>
                         <property name="title" translatable="yes">Select a Directory</property>
@@ -308,7 +301,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_on_button_resolutions_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -393,7 +385,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Automatic</item>
@@ -424,7 +415,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item id="0" translatable="yes">Tab by groups</item>
@@ -457,7 +447,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">This setting will be active after the application restart</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Use system theme preferences</item>
@@ -488,7 +477,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">This setting will be active after the application restart</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Use system theme preferences</item>
@@ -523,7 +511,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_fullscreen_toolbar_visibility">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="active_id">0</property>
                         <items>
                           <item id="0" translatable="yes">Peeking</item>
@@ -699,7 +686,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_host_key">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Host key</property>
                       </object>
                       <packing>
@@ -714,7 +702,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -727,7 +714,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_fullscreen">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Toggle fullscreen mode</property>
                       </object>
                       <packing>
@@ -742,7 +730,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -755,7 +742,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_auto_fit">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Auto-fit window</property>
                       </object>
                       <packing>
@@ -770,7 +758,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -783,7 +770,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_switch_tab">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Switch tab pages</property>
                       </object>
                       <packing>
@@ -798,7 +786,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -813,7 +800,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -825,7 +811,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_scaled">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Toggle scaled mode</property>
                       </object>
                       <packing>
@@ -840,7 +827,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -853,7 +839,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_grab_keyboard">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Grab keyboard</property>
                       </object>
                       <packing>
@@ -868,7 +855,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -881,7 +867,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_minimize">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Minimize window</property>
                       </object>
                       <packing>
@@ -896,7 +883,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <property name="valign">start</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
@@ -910,7 +896,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_disconnect">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Disconnect</property>
                       </object>
                       <packing>
@@ -925,7 +912,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -938,7 +924,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_toolbar">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Show / hide toolbar</property>
                       </object>
                       <packing>
@@ -953,7 +940,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -966,7 +952,8 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_keyboard_screenshot">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
                         <property name="label" translatable="yes">Screenshot</property>
                         <property name="ellipsize">start</property>
                       </object>
@@ -982,7 +969,6 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -1027,7 +1013,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">SSH tunnel local port</property>
                       </object>
                       <packing>
@@ -1039,7 +1025,6 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="max_length">5</property>
                       </object>
@@ -1069,7 +1054,6 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_ssh_loglevel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item id="0" translatable="yes">SSH_LOG_NOLOG</item>
@@ -1089,7 +1073,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_ssh_loglevel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">SSH log level</property>
                       </object>
                       <packing>
@@ -1182,7 +1166,6 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="halign">baseline</property>
                             <property name="font">Sans 12</property>
                             <property name="preview_text"/>
                           </object>
@@ -1250,7 +1233,6 @@ Author: Antenore Gatta
                           <object class="GtkEntry" id="entry_scrollback_lines">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="halign">baseline</property>
                             <property name="max_length">5</property>
                           </object>
                           <packing>
@@ -1292,7 +1274,6 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>
@@ -1334,7 +1315,6 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>
@@ -1376,7 +1356,6 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
-                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -22,7 +22,7 @@ Author: Antenore Gatta
 
 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
+  <requires lib="gtk+" version="3.8"/>
   <!-- interface-license-type gplv2 -->
   <!-- interface-name Remmina Preferences Dialog -->
   <!-- interface-copyright Antenore Gatta & Giovanni Panozzo 2014-2017 -->
@@ -1394,8 +1394,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Foreground color</property>
-                            <property name="rgba">rgb(255,255,255)</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1421,7 +1419,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Background color</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1447,7 +1444,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Cursor Color</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1486,7 +1482,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for black</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1499,7 +1494,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright black</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">1</property>
@@ -1512,7 +1506,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for red</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">2</property>
@@ -1525,7 +1518,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for green</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">3</property>
@@ -1538,7 +1530,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for yellow</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">4</property>
@@ -1551,7 +1542,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for blue</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">5</property>
@@ -1564,7 +1554,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for magenta</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">6</property>
@@ -1577,7 +1566,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for Cyan</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">7</property>
@@ -1590,7 +1578,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for white</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">8</property>
@@ -1603,7 +1590,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright red</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">2</property>
@@ -1616,7 +1602,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright green</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">3</property>
@@ -1629,7 +1614,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright yellow</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">4</property>
@@ -1642,7 +1626,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright blue</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">5</property>
@@ -1655,7 +1638,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright magenta</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">6</property>
@@ -1668,7 +1650,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright Cyan</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">7</property>
@@ -1681,7 +1662,6 @@ Author: Antenore Gatta
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
                             <property name="title" translatable="yes">Pick a color for bright white</property>
-                            <property name="show_editor">True</property>
                           </object>
                           <packing>
                             <property name="left_attach">8</property>
@@ -1811,9 +1791,6 @@ Author: Antenore Gatta
           </packing>
         </child>
       </object>
-    </child>
-    <child>
-      <placeholder/>
     </child>
   </object>
 </interface>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1710,6 +1710,33 @@ Author: Antenore Gatta
                           </packing>
                         </child>
                         <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">start</property>
+                            <property name="hexpand">True</property>
+                            <property name="label" translatable="yes">Load color scheme</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">5</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkFileChooserButton" id="filechooserbutton_terminal_color_scheme">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="tooltip_text" translatable="yes">Chose a color scheme file, than close and reopen the prefernces dialog.</property>
+                            <property name="title" translatable="yes">Terminal Color Scheme file chooser</property>
+                            <signal name="file-set" handler="remmina_pref_on_color_scheme_selected" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">5</property>
+                            <property name="width">8</property>
+                          </packing>
+                        </child>
+                        <child>
                           <placeholder/>
                         </child>
                         <child>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -114,7 +114,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Double-click action</property>
                       </object>
                       <packing>
@@ -126,6 +126,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_double_click">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Open connection</item>
@@ -142,7 +143,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Scale quality</property>
                       </object>
                       <packing>
@@ -154,6 +155,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_scale_quality">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Nearest</item>
@@ -172,7 +174,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Auto scroll step size</property>
                       </object>
                       <packing>
@@ -184,6 +186,7 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_scroll">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="halign">baseline</property>
                         <property name="max_length">3</property>
                       </object>
                       <packing>
@@ -196,7 +199,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Maximum recent items</property>
                       </object>
                       <packing>
@@ -208,6 +211,7 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_recent_items">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="max_length">2</property>
                       </object>
@@ -222,6 +226,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_clear_recent" swapped="no"/>
                       </object>
                       <packing>
@@ -233,7 +238,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_resolutions">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Resolutions</property>
                       </object>
                       <packing>
@@ -245,7 +250,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_keystrokes">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Keystrokes</property>
                         <property name="justify">fill</property>
                       </object>
@@ -260,6 +265,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_on_button_keystrokes_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -272,7 +278,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_options_screenshot_folder">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Screenshots folder</property>
                       </object>
                       <packing>
@@ -285,6 +291,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Choose the directory where you want to save Remmina screenshots.</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="action">select-folder</property>
                         <property name="title" translatable="yes">Select a Directory</property>
@@ -301,6 +308,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_on_button_resolutions_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -373,7 +381,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Default view mode</property>
                       </object>
                       <packing>
@@ -385,6 +393,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_view_mode">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Automatic</item>
@@ -403,7 +412,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Tab interface</property>
                       </object>
                       <packing>
@@ -415,6 +424,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_tab_interface">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item id="0" translatable="yes">Tab by groups</item>
@@ -433,7 +443,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_buttons_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Show buttons icons</property>
                         <property name="justify">fill</property>
                       </object>
@@ -447,6 +457,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">This setting will be active after the application restart</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Use system theme preferences</item>
@@ -464,7 +475,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_appearance_show_menu_icons">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Show menu icons</property>
                       </object>
                       <packing>
@@ -477,6 +488,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">This setting will be active after the application restart</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item translatable="yes">Use system theme preferences</item>
@@ -511,6 +523,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_appearance_fullscreen_toolbar_visibility">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="active_id">0</property>
                         <items>
                           <item id="0" translatable="yes">Peeking</item>
@@ -528,7 +541,7 @@ Author: Antenore Gatta
                       <object class="GtkLabel" id="label_fullscreen_toolbar_visibility">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="halign">end</property>
+                        <property name="halign">start</property>
                         <property name="label" translatable="yes">Fullscreen toolbar visibility</property>
                       </object>
                       <packing>
@@ -701,7 +714,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -729,7 +742,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -757,7 +770,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -785,7 +798,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -800,7 +813,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -827,7 +840,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -855,7 +868,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -883,7 +896,8 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
+                        <property name="valign">start</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -911,7 +925,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -939,7 +953,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -968,7 +982,7 @@ Author: Antenore Gatta
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
-                        <property name="hexpand">True</property>
+                        <property name="halign">baseline</property>
                         <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                       </object>
                       <packing>
@@ -1025,6 +1039,7 @@ Author: Antenore Gatta
                       <object class="GtkEntry" id="entry_options_ssh_port">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <property name="max_length">5</property>
                       </object>
@@ -1054,6 +1069,7 @@ Author: Antenore Gatta
                       <object class="GtkComboBoxText" id="comboboxtext_options_ssh_loglevel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="halign">baseline</property>
                         <property name="hexpand">True</property>
                         <items>
                           <item id="0" translatable="yes">SSH_LOG_NOLOG</item>
@@ -1122,7 +1138,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_font1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Terminal font</property>
                           </object>
@@ -1135,7 +1151,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_scrollback_lines">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Scrollback lines</property>
                           </object>
@@ -1166,6 +1182,7 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
+                            <property name="halign">baseline</property>
                             <property name="font">Sans 12</property>
                             <property name="preview_text"/>
                           </object>
@@ -1233,6 +1250,7 @@ Author: Antenore Gatta
                           <object class="GtkEntry" id="entry_scrollback_lines">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
+                            <property name="halign">baseline</property>
                             <property name="max_length">5</property>
                           </object>
                           <packing>
@@ -1245,7 +1263,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_copy1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Clipboard copy shortcut</property>
                           </object>
@@ -1258,7 +1276,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_copy2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="label" translatable="yes">(Host key +)</property>
                           </object>
                           <packing>
@@ -1274,6 +1292,7 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
+                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>
@@ -1286,7 +1305,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_paste1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Clipboard paste shortcut</property>
                           </object>
@@ -1299,7 +1318,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_paste2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="label" translatable="yes">(Host key +)</property>
                           </object>
                           <packing>
@@ -1315,6 +1334,7 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
+                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>
@@ -1327,7 +1347,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_select_all1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Select all shortcut</property>
                           </object>
@@ -1340,7 +1360,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_keyboard_select_all2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="label" translatable="yes">(Host key +)</property>
                           </object>
                           <packing>
@@ -1356,6 +1376,7 @@ Author: Antenore Gatta
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">True</property>
+                            <property name="halign">baseline</property>
                             <property name="hexpand">True</property>
                             <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
                           </object>
@@ -1379,7 +1400,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_foreground">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Foreground color</property>
                           </object>
@@ -1406,7 +1427,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_background">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Background color</property>
                           </object>
@@ -1432,7 +1453,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_cursor_color">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Cursor color</property>
                           </object>
@@ -1458,7 +1479,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_normal_colors">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Normal colors</property>
                           </object>
@@ -1471,7 +1492,7 @@ Author: Antenore Gatta
                           <object class="GtkLabel" id="label_terminal_bright_colors">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">end</property>
+                            <property name="halign">start</property>
                             <property name="hexpand">True</property>
                             <property name="label" translatable="yes">Bright colors</property>
                           </object>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0 
+<!-- Generated with glade 3.20.0
 
-Remmina Preferences Dialog - 
+Remmina Preferences Dialog -
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2017
 
 This program is free software; you can redistribute it and/or
@@ -1685,7 +1685,7 @@ Author: Antenore Gatta
                           <object class="GtkFileChooserButton" id="filechooserbutton_terminal_color_scheme">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Chose a color scheme file, than close and reopen the prefernces dialog.</property>
+                            <property name="tooltip_text" translatable="yes">Chose a color scheme file, You can download one from https://github.com/mbadolato/iTerm2-Color-Schemes.</property>
                             <property name="title" translatable="yes">Terminal Color Scheme file chooser</property>
                             <signal name="file-set" handler="remmina_pref_on_color_scheme_selected" swapped="no"/>
                           </object>


### PR DESCRIPTION
This PR implement the custom color scheme for SSH as requested in the issue #1235.

A default theme is loaded during the first remmina startup inside the remmina.pref file.

You can set a new scheme in different ways.

1. Using the import widget in the Remmina preferences dialog.

You can download Remmina color scheme files from https://github.com/mbadolato/iTerm2-Color-Schemes

2. Create one using the color editor in the Remmina preferences dialog

3. The geek way, editing the file ~/config/remmina/remmina.colors

With the following syntax:

```
[ssh_colors]
background = #d5ccba
cursor = #45373c
foreground = #45373c
color0 =  #20111b
color1 = #be100e
color2 = #858162
color3 = #eaa549
color4 = #426a79
color5 = #97522c
color6 = #989a9c
color7 = #968c83
color8 = #5e5252
color9 = #be100e
color10 = #858162
color11 = #eaa549
color12 = #426a79
color13 = #97522c
color14 = #989a9c
color15 = #d5ccba
```
Or you can use the rgb colors, like (careful this custom theme it's awful) 

```
[ssh_colors]
background=rgb(156,151,204)
cursor=rgb(112,130,132)
foreground=rgb(250,91,138)
color0=rgb(0,40,49)
color1=rgb(209,28,36)
color2=rgb(115,138,5)
color3=rgb(165,119,6)
color4=rgb(33,118,199)
color5=rgb(198,28,111)
color6=rgb(83,88,55)
color7=rgb(234,227,203)
color8=rgb(0,30,39)
color9=rgb(189,54,19)
color10=rgb(151,255,112)
color11=rgb(83,104,112)
color12=rgb(112,130,132)
color13=rgb(89,86,186)
color14=rgb(129,144,144)
color15=rgb(252,244,220)
```
In the future I will try to add a per profile custom color scheme.

Please test and let me know.