### PR TITLE
Shortcutkey viewonly

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3574,7 +3574,7 @@ static gboolean remmina_connection_window_hostkey_func(RemminaProtocolWidget* gp
 	{
 		remmina_file_set_int(cnnobj->remmina_file, "viewonly",
 				( remmina_file_get_int(cnnobj->remmina_file, "viewonly", 0 )
-				 == 0  ) ? 1 : 0 );     
+				 == 0  ) ? 1 : 0 );
 	}
 	else if (keyval == remmina_pref.shortcutkey_screenshot)
 	{

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -41,6 +41,7 @@
 #include <sys/time.h>
 #include <sys/utsname.h>
 
+#include <glib/gstdio.h>
 #include <gdk/gdkkeysyms.h>
 #include <gtk/gtk.h>
 
@@ -571,6 +572,7 @@ void remmina_pref_init(void)
 	{
 		gkeyfile = g_key_file_new();
 		g_key_file_load_from_file(gkeyfile, remmina_colors_file, G_KEY_FILE_NONE, NULL);
+		g_remove(remmina_colors_file);
 	}
 
 	if (g_key_file_has_key(gkeyfile, "ssh_colors", "background", NULL))

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -537,11 +537,6 @@ void remmina_pref_init(void)
 		                                   NULL);
 	else
 		remmina_pref.vte_allow_bold_text = TRUE;
-	/* Default system theme colors or default vte colors */
-	if (g_key_file_has_key(gkeyfile, "remmina_pref", "vte_system_colors", NULL))
-		remmina_pref.vte_system_colors = g_key_file_get_boolean(gkeyfile, "remmina_pref", "vte_system_colors", NULL);
-	else
-		remmina_pref.vte_system_colors = FALSE;
 
 	if (g_key_file_has_key(gkeyfile, "remmina_pref", "vte_lines", NULL))
 		remmina_pref.vte_lines = g_key_file_get_integer(gkeyfile, "remmina_pref", "vte_lines", NULL);
@@ -766,7 +761,6 @@ void remmina_pref_save(void)
 	g_key_file_set_string(gkeyfile, "remmina_pref", "vte_font", remmina_pref.vte_font ? remmina_pref.vte_font : "");
 	g_key_file_set_boolean(gkeyfile, "remmina_pref", "vte_allow_bold_text", remmina_pref.vte_allow_bold_text);
 	g_key_file_set_integer(gkeyfile, "remmina_pref", "vte_lines", remmina_pref.vte_lines);
-	g_key_file_set_boolean (gkeyfile, "remmina_pref", "vte_system_colors", remmina_pref.vte_system_colors);
 	g_key_file_set_string(gkeyfile, "ssh_colors", "background", remmina_pref.background ? remmina_pref.background : "");
 	g_key_file_set_string(gkeyfile, "ssh_colors", "cursor", remmina_pref.cursor ? remmina_pref.cursor : "");
 	g_key_file_set_string(gkeyfile, "ssh_colors", "foreground", remmina_pref.foreground ? remmina_pref.foreground : "");

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -212,6 +212,7 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 	remmina_pref.shortcutkey_scale = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_scaled));
 	remmina_pref.shortcutkey_grab = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_grab_keyboard));
 	remmina_pref.shortcutkey_screenshot = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_screenshot));
+	remmina_pref.shortcutkey_viewonly = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_viewonly));
 	remmina_pref.shortcutkey_minimize = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_minimize));
 	remmina_pref.shortcutkey_disconnect = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_disconnect));
 	remmina_pref.shortcutkey_toolbar = remmina_key_chooser_get_keyval(gtk_button_get_label(remmina_pref_dialog->button_keyboard_toolbar));
@@ -369,6 +370,7 @@ static void remmina_pref_dialog_init(void)
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_scaled, remmina_pref.shortcutkey_scale);
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_grab_keyboard, remmina_pref.shortcutkey_grab);
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_screenshot, remmina_pref.shortcutkey_screenshot);
+	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_viewonly, remmina_pref.shortcutkey_viewonly);
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_minimize, remmina_pref.shortcutkey_minimize);
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_disconnect, remmina_pref.shortcutkey_disconnect);
 	remmina_pref_dialog_set_button_label(remmina_pref_dialog->button_keyboard_toolbar, remmina_pref.shortcutkey_toolbar);
@@ -507,6 +509,7 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->button_keyboard_scaled = GTK_BUTTON(GET_OBJECT("button_keyboard_scaled"));
 	remmina_pref_dialog->button_keyboard_grab_keyboard = GTK_BUTTON(GET_OBJECT("button_keyboard_grab_keyboard"));
 	remmina_pref_dialog->button_keyboard_screenshot = GTK_BUTTON(GET_OBJECT("button_keyboard_screenshot"));
+	remmina_pref_dialog->button_keyboard_viewonly = GTK_BUTTON(GET_OBJECT("button_keyboard_viewonly"));
 	remmina_pref_dialog->button_keyboard_minimize = GTK_BUTTON(GET_OBJECT("button_keyboard_minimize"));
 	remmina_pref_dialog->button_keyboard_disconnect = GTK_BUTTON(GET_OBJECT("button_keyboard_disconnect"));
 	remmina_pref_dialog->button_keyboard_toolbar = GTK_BUTTON(GET_OBJECT("button_keyboard_toolbar"));

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -226,7 +226,6 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 		remmina_pref.vte_font = g_strdup(gtk_font_button_get_font_name(remmina_pref_dialog->fontbutton_terminal_font));
 	}
 	remmina_pref.vte_allow_bold_text = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_bold));
-	remmina_pref.vte_system_colors = gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors));
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_foreground), &color);
 	remmina_pref.foreground = gdk_rgba_to_string(&color);
 	gtk_color_chooser_get_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_background), &color);
@@ -388,7 +387,6 @@ static void remmina_pref_dialog_init(void)
 		gtk_widget_set_sensitive(GTK_WIDGET(remmina_pref_dialog->fontbutton_terminal_font), FALSE);
 	}
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_bold), remmina_pref.vte_allow_bold_text);
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors), remmina_pref.vte_system_colors);
 
 	/* Foreground color option */
 	gdk_rgba_parse(&color, remmina_pref.foreground);
@@ -432,10 +430,6 @@ static void remmina_pref_dialog_init(void)
 	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color14), &color);
 	gdk_rgba_parse(&color, remmina_pref.color15);
 	gtk_color_chooser_set_rgba(GTK_COLOR_CHOOSER(remmina_pref_dialog->colorbutton_color15), &color);
-
-
-	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(remmina_pref_dialog->checkbutton_terminal_system_colors), remmina_pref.vte_system_colors);
-	remmina_pref_dialog_vte_color_on_toggled(GTK_WIDGET(remmina_pref_dialog->checkbutton_terminal_system_colors), NULL);
 
 	g_snprintf(buf, sizeof(buf), "%i", remmina_pref.vte_lines);
 	gtk_entry_set_text(remmina_pref_dialog->entry_scrollback_lines, buf);
@@ -524,7 +518,6 @@ GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 	remmina_pref_dialog->button_keyboard_copy = GTK_BUTTON(GET_OBJECT("button_keyboard_copy"));
 	remmina_pref_dialog->button_keyboard_paste = GTK_BUTTON(GET_OBJECT("button_keyboard_paste"));
 	remmina_pref_dialog->button_keyboard_select_all = GTK_BUTTON(GET_OBJECT("button_keyboard_select_all"));
-	remmina_pref_dialog->checkbutton_terminal_system_colors = GTK_CHECK_BUTTON(GET_OBJECT("checkbutton_terminal_system_colors"));
 	remmina_pref_dialog->label_terminal_foreground = GTK_LABEL(GET_OBJECT("label_terminal_foreground"));
 	remmina_pref_dialog->colorbutton_foreground = GTK_COLOR_BUTTON(GET_OBJECT("colorbutton_foreground"));
 	remmina_pref_dialog->label_terminal_background = GTK_LABEL(GET_OBJECT("label_terminal_background"));

--- a/remmina/src/remmina_pref_dialog.h
+++ b/remmina/src/remmina_pref_dialog.h
@@ -85,6 +85,7 @@ typedef struct _RemminaPrefDialog
 	GtkButton *button_keyboard_scaled;
 	GtkButton *button_keyboard_grab_keyboard;
 	GtkButton *button_keyboard_screenshot;
+	GtkButton *button_keyboard_viewonly;
 	GtkButton *button_keyboard_minimize;
 	GtkButton *button_keyboard_disconnect;
 	GtkButton *button_keyboard_toolbar;

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -591,10 +591,7 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 			break;
 	}
 		vte_terminal_set_colors (VTE_TERMINAL(vte), &foreground_color, &background_color, remminavte.palette, PALETTE_SIZE);
-		vte_terminal_set_color_foreground (VTE_TERMINAL(vte), &foreground_color);
-		vte_terminal_set_color_background (VTE_TERMINAL(vte), &background_color);
-		vte_terminal_set_cursor_shape (VTE_TERMINAL(vte), VTE_CURSOR_SHAPE_BLOCK);
-		vte_terminal_set_color_cursor (VTE_TERMINAL(vte), &foreground_color);
+		vte_terminal_set_color_cursor (VTE_TERMINAL(vte), &cursor_color);
 #else
 		/* VTE <= 2.90 doesn't support GdkRGBA so we must convert GdkRGBA to GdkColor */
 		foreground_gdkcolor.red = (guint16)(foreground_color.red * 0xFFFF);

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -465,7 +465,6 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	GtkAdjustment *vadjustment;
 	GtkWidget *vscrollbar;
 	GtkWidget *vte;
-	GtkStyleContext *style_context;
 	GdkRGBA foreground_color;
 	GdkRGBA background_color;
 	GdkRGBA cursor_color;
@@ -489,19 +488,6 @@ remmina_plugin_ssh_init (RemminaProtocolWidget *gp)
 	gtk_widget_show(vte);
 	vte_terminal_set_size (VTE_TERMINAL (vte), 80, 25);
 	vte_terminal_set_scroll_on_keystroke (VTE_TERMINAL (vte), TRUE);
-	if (remmina_pref.vte_system_colors)
-	{
-		/* Get default system theme colors */
-		style_context = gtk_widget_get_style_context(GTK_WIDGET (vte));
-		gtk_style_context_get_color(style_context, GTK_STATE_FLAG_NORMAL, &foreground_color);
-		gtk_style_context_get(style_context, GTK_STATE_FLAG_NORMAL, "background-color", &background_color, NULL);
-	}
-	else
-	{
-		/* Get customized colors */
-		gdk_rgba_parse(&foreground_color, remmina_pref.foreground);
-		gdk_rgba_parse(&background_color, remmina_pref.background);
-	}
 	remminafile = remmina_plugin_service->protocol_plugin_get_file (gp);
 
 #if VTE_CHECK_VERSION(0,38,0)

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -977,6 +977,35 @@ Author: Antenore Gatta
                         <property name="width">2</property>
                       </packing>
                     </child>
+                    <child>
+                      <object class="GtkLabel" id="label_keyboard_viewonly">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="hexpand">True</property>
+                        <property name="label" translatable="yes">View-only mode</property>
+                        <property name="ellipsize">start</property>
+                      </object>
+                      <packing>
+                        <property name="left_attach">0</property>
+                        <property name="top_attach">10</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="button_keyboard_viewonly">
+                        <property name="label" translatable="yes">VIEW-ONLY MODE</property>
+                        <property name="width_request">100</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <signal name="clicked" handler="remmina_pref_dialog_on_key_chooser" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left_attach">1</property>
+                        <property name="top_attach">10</property>
+                        <property name="width">2</property>
+                      </packing>
+                    </child>
                   </object>
                 </child>
               </object>

--- a/remmina/ui/remmina_preferences.glade
+++ b/remmina/ui/remmina_preferences.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.20.0
+<!-- Generated with glade 3.20.0 
 
 Remmina Preferences Dialog -
 Copyright (C) Antenore Gatta & Giovanni Panozzo 2014-2017
@@ -1214,22 +1214,6 @@ Author: Antenore Gatta
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkCheckButton" id="checkbutton_terminal_system_colors">
-                            <property name="label" translatable="yes">Use system theme colors</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="halign">start</property>
-                            <property name="hexpand">True</property>
-                            <property name="draw_indicator">True</property>
-                          </object>
-                          <packing>
-                            <property name="left_attach">0</property>
-                            <property name="top_attach">7</property>
-                            <property name="width">4</property>
-                          </packing>
-                        </child>
-                        <child>
                           <object class="GtkEntry" id="entry_scrollback_lines">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
@@ -1791,6 +1775,9 @@ Author: Antenore Gatta
           </packing>
         </child>
       </object>
+    </child>
+    <child>
+      <placeholder/>
     </child>
   </object>
 </interface>


### PR DESCRIPTION
With @remminafan1 we have added a configurable shortcut to set the View-Only mode.

We have also fixed a bug in spice ( #1035 ) that was causing issues with this PR.

The shortcut is configurable from the preferences menu as usual.