### PR TITLE
Server name is notified to the user everytime we enter a tab

### DIFF
--- a/remmina/desktop/CMakeLists.txt
+++ b/remmina/desktop/CMakeLists.txt
@@ -82,7 +82,7 @@ set(REMMINA_BINARY_PATH ${CMAKE_INSTALL_FULL_BINDIR}/remmina)
 set(REMMINA_ICON "remmina")
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/remmina.desktop.in
-    ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop @ONLY)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/remmina.desktop
+    ${CMAKE_CURRENT_BINARY_DIR}/org.Remmina.desktop @ONLY)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/org.Remmina.desktop
     DESTINATION "${REMMINA_DATADIR}/applications")
 install(FILES remmina.appdata.xml DESTINATION "${REMMINA_DATADIR}/appdata")

--- a/remmina/desktop/remmina.appdata.xml
+++ b/remmina/desktop/remmina.appdata.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli (Muflone), Giovanni Panozzo.
   Copyright (C) 2009-2014 Vic Lee
+  Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli (Muflone), Giovanni Panozzo.
+  Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo.
 -->
 <component type="desktop">
-  <id>remmina.desktop</id>
+  <id>org.Remmina.desktop</id>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Remmina</name>

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -1847,7 +1847,7 @@ static void remmina_connection_holder_toolbar_screenshot(GtkWidget* widget, Remm
 	cairo_surface_write_to_png(surface, pngname);
 
 	/* send a desktop notification */
-	remmina_public_send_notification ("remmina-screenshot-is-ready-id", "Screenshot taken", pngname);
+	remmina_public_send_notification ("remmina-screenshot-is-ready-id", _("Screenshot taken"), pngname);
 
 	//Clean up and return.
 	cairo_destroy(cr);
@@ -2874,10 +2874,21 @@ static gboolean remmina_connection_holder_on_switch_page_real(gpointer data)
 {
 	TRACE_CALL("remmina_connection_holder_on_switch_page_real");
 	RemminaConnectionHolder* cnnhld = (RemminaConnectionHolder*) data;
+	RemminaConnectionObject* currentpage_cnnobj;
+	int np;
+	GtkWidget* page;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	if (GTK_IS_WIDGET(cnnhld->cnnwin))
 	{
+
+		np = gtk_notebook_get_current_page(GTK_NOTEBOOK (priv->notebook));
+		page = gtk_notebook_get_nth_page (GTK_NOTEBOOK (priv->notebook), np);
+		currentpage_cnnobj = (RemminaConnectionObject*) g_object_get_data(G_OBJECT(page),"cnnobj");
+		/* send a desktop notification each time we switch to a new tab*/
+		remmina_public_send_notification ("remmina-proto-widget-enter-id",
+				_("Connected to: "),
+				remmina_file_get_string(currentpage_cnnobj->remmina_file, "server"));
 		remmina_connection_holder_update_toolbar(cnnhld);
 		remmina_connection_holder_grab_focus(GTK_NOTEBOOK(priv->notebook));
 		if (cnnhld->cnnwin->priv->view_mode != SCROLLED_WINDOW_MODE)

--- a/remmina/src/remmina_public.c
+++ b/remmina/src/remmina_public.c
@@ -690,7 +690,9 @@ void remmina_public_send_notification (const gchar *notification_id,
 
 	GNotification *notification = g_notification_new (notification_title);
 	g_notification_set_body (notification, notification_message);
+#if GLIB_CHECK_VERSION(2,42,0)
 	g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_NORMAL);
+#endif
 	g_application_send_notification (g_application_get_default (), notification_id, notification);
 	g_object_unref (notification);
 }

--- a/remmina/src/remmina_public.c
+++ b/remmina/src/remmina_public.c
@@ -690,6 +690,7 @@ void remmina_public_send_notification (const gchar *notification_id,
 
 	GNotification *notification = g_notification_new (notification_title);
 	g_notification_set_body (notification, notification_message);
+	g_notification_set_priority (notification, G_NOTIFICATION_PRIORITY_NORMAL);
 	g_application_send_notification (g_application_get_default (), notification_id, notification);
 	g_object_unref (notification);
 }

--- a/snap/CMakeLists.txt
+++ b/snap/CMakeLists.txt
@@ -42,7 +42,8 @@ set(SNAP_SETUP_DIR ${SNAP_BUILD_DIR}/snap)
 set(SNAP_GUI_DIR ${SNAP_SETUP_DIR}/gui)
 
 file(MAKE_DIRECTORY ${SNAP_GUI_DIR})
-file(RELATIVE_PATH CMAKE_SOURCE_DIR_RELATIVE ${SNAP_BUILD_DIR} ${CMAKE_SOURCE_DIR})
+file(RELATIVE_PATH CMAKE_SOURCE_DIR_RELATIVE ${SNAP_BUILD_DIR}
+    ${CMAKE_SOURCE_DIR})
 
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/snapcraft.yaml.in
     ${SNAP_BUILD_DIR}/snapcraft.yaml @ONLY)
@@ -50,7 +51,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/snapcraft.yaml.in
 set(REMMINA_BINARY_PATH "remmina")
 set(REMMINA_ICON "\${SNAP}/meta/gui/icon.svg")
 configure_file(${CMAKE_SOURCE_DIR}/remmina/desktop/remmina.desktop.in
-    ${SNAP_GUI_DIR}/remmina.desktop @ONLY)
+    ${SNAP_GUI_DIR}/org.Remmina.desktop @ONLY)
 
 configure_file(${CMAKE_SOURCE_DIR}/LICENSE
     ${SNAP_SETUP_DIR}/license.txt COPYONLY)


### PR DESCRIPTION
I've a implemented a simple desktop notification that print the server name each time we enter a tab in the remmina connection window

It's not exactly what has been requested by @StuWhitby via #815 , but I think it's much better because it is the standard way advised by the Gnome project to notify the user, moreover the user can configure how, when and for how long the notifications are shown, without making things overcomplicated for Remmina.

@StuWhitby,  @giox069 what do you think? Later I'll add a couple of screenshot. 