### PR TITLE
Reverted the notfication for the floating toolbar

### DIFF
--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -3003,12 +3003,17 @@ static gboolean remmina_connection_holder_on_switch_page_real(gpointer data)
 
 	if (GTK_IS_WIDGET(cnnhld->cnnwin))
 	{
+		remmina_connection_holder_floating_toolbar_show (cnnhld, TRUE);
+		if (!priv->hidetb_timer)
+			priv->hidetb_timer = g_timeout_add(TB_HIDE_TIME_TIME, (GSourceFunc)
+					remmina_connection_holder_floating_toolbar_hide, cnnhld);
 		remmina_connection_holder_update_toolbar(cnnhld);
 		remmina_connection_holder_grab_focus(GTK_NOTEBOOK(priv->notebook));
 		if (cnnhld->cnnwin->priv->view_mode != SCROLLED_WINDOW_MODE)
 		{
 			remmina_connection_holder_check_resize(cnnhld);
 		}
+
 	}
 	priv->switch_page_handler = 0;
 	return FALSE;


### PR DESCRIPTION
I've reverted the notification in favor the floating toolbar.

When you are in fullscreen (tabbed mode) and you switch between profiles, the floating toolbar temporary appears.

As there is the server name in the floating toolbar, we always now on which profile we are working on.