### PR TITLE
[snap] Use the new desktop, desktop-legacy and wayland interfaces

### DIFF
--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -45,7 +45,7 @@ parts:
       - libxv-dev
     configflags:
       - -DCMAKE_BUILD_TYPE=@CMAKE_BUILD_TYPE@
-      - -DWITH_WAYLAND=off
+      - -DWITH_WAYLAND=on
       - -DWITH_CLIENT=off
       - -DWITH_SERVER=off
       - -DWITH_PULSE=on
@@ -127,6 +127,8 @@ apps:
     plugs:
       - avahi-observe
       - cups-control
+      - desktop
+      - desktop-legacy
       - gsettings
       - home
       - mount-observe
@@ -134,6 +136,7 @@ apps:
       - network-bind
       - pulseaudio
       - unity7
+      - wayland
 
   winpr-makecert:
     command: winpr-makecert


### PR DESCRIPTION
Use the new desktop, desktop-legacy and wayland interfaces introduced in snapd 2.28.  Also build freerdp with wayland support.  This fixes the
snap to work on Ubuntu Desktop 17.10 with the default session using
wayland.