### PR TITLE
Add support for ayatana-appindicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2011 Marc-Andre Moreau
 # Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+# Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/cmake/FindAPPINDICATOR.cmake
+++ b/cmake/FindAPPINDICATOR.cmake
@@ -1,6 +1,8 @@
 # Remmina - The GTK+ Remote Desktop Client
 #
 # Copyright (C) 2011 Marc-Andre Moreau
+# Copyright (C) 2014-2015 Antenore Gatta, Fabio Castelli, Giovanni Panozzo
+# Copyright (C) 2016-2017 Antenore Gatta, Giovanni Panozzo
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -17,21 +19,40 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, 
 # Boston, MA  02110-1301, USA.
 
-pkg_check_modules(PC_APPINDICATOR appindicator3-0.1)
-
-find_path(APPINDICATOR_INCLUDE_DIR NAMES libappindicator/app-indicator.h
-	HINTS ${PC_APPINDICATOR_INCLUDEDIR} ${PC_APPINDICATOR_INCLUDE_DIRS}
-	PATH_SUFFIXES libappindicator-0.1)
-
-find_library(APPINDICATOR_LIBRARY NAMES appindicator3)
-
 include(FindPackageHandleStandardArgs)
 
-find_package_handle_standard_args(APPINDICATOR DEFAULT_MSG APPINDICATOR_LIBRARY APPINDICATOR_INCLUDE_DIR)
+# Try with ayatana-libappindicator
+pkg_check_modules(PC_AYATANA_APPINDICATOR ayatana-appindicator3-0.1)
 
-if(APPINDICATOR_FOUND)
-	set(APPINDICATOR_LIBRARIES ${APPINDICATOR_LIBRARY})
-	set(APPINDICATOR_INCLUDE_DIRS ${APPINDICATOR_INCLUDE_DIR})
+find_path(AYATANA_APPINDICATOR_INCLUDE_DIR NAMES app-indicator.h
+	HINTS ${PC_AYATANA_APPINDICATOR_INCLUDEDIR} ${PC_AYATANA_APPINDICATOR_INCLUDE_DIRS}
+	PATH_SUFFIXES libayatana-appindicator3-0.1/libayatana-appindicator)
+
+find_library(AYATANA_APPINDICATOR_LIBRARY NAMES ayatana-appindicator3)
+
+if (AYATANA_APPINDICATOR_INCLUDE_DIR AND AYATANA_APPINDICATOR_LIBRARY)
+	find_package_handle_standard_args(APPINDICATOR DEFAULT_MSG AYATANA_APPINDICATOR_LIBRARY AYATANA_APPINDICATOR_INCLUDE_DIR)
+endif()
+
+if (APPINDICATOR_FOUND)
+	set(APPINDICATOR_LIBRARIES ${AYATANA_APPINDICATOR_LIBRARY})
+	set(APPINDICATOR_INCLUDE_DIRS ${AYATANA_APPINDICATOR_INCLUDE_DIR})
+else()
+	# Try with normal libappindicator
+	pkg_check_modules(PC_APPINDICATOR appindicator3-0.1)
+
+	find_path(APPINDICATOR_INCLUDE_DIR NAMES app-indicator.h
+		HINTS ${PC_APPINDICATOR_INCLUDEDIR} ${PC_APPINDICATOR_INCLUDE_DIRS}
+		PATH_SUFFIXES libappindicator3-0.1/libappindicator)
+
+	find_library(APPINDICATOR_LIBRARY NAMES appindicator3)
+
+	find_package_handle_standard_args(APPINDICATOR DEFAULT_MSG APPINDICATOR_LIBRARY APPINDICATOR_INCLUDE_DIR)
+
+	if(APPINDICATOR_FOUND)
+		set(APPINDICATOR_LIBRARIES ${APPINDICATOR_LIBRARY})
+		set(APPINDICATOR_INCLUDE_DIRS ${APPINDICATOR_INCLUDE_DIR})
+	endif()
 endif()
 
 mark_as_advanced(APPINDICATOR_INCLUDE_DIR APPINDICATOR_LIBRARY)

--- a/remmina/src/remmina_icon.c
+++ b/remmina/src/remmina_icon.c
@@ -49,7 +49,7 @@
 #include "remmina_sysinfo.h"
 
 #ifdef HAVE_LIBAPPINDICATOR
-#include <libappindicator/app-indicator.h>
+#include <app-indicator.h>
 #endif
 
 typedef struct _RemminaIcon


### PR DESCRIPTION
Canonical's appindicators have been recently forked in a new project, called [ayatana-appindicators](https://sunweavers.net/blog/node/58).
This patch allows cmake to find newest ayatana appindicators. Tested on Debian sid.

