### PR TITLE
__func__ keyword must not be quoted

### DIFF
--- a/remmina-plugin-secret/src/glibsecret_plugin.c
+++ b/remmina-plugin-secret/src/glibsecret_plugin.c
@@ -58,7 +58,7 @@ static SecretCollection* defaultcollection;
 
 static void  remmina_plugin_glibsecret_unlock_secret_service()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 #ifdef LIBSECRET_VERSION_0_18
 
@@ -82,7 +82,7 @@ static void  remmina_plugin_glibsecret_unlock_secret_service()
 
 void remmina_plugin_glibsecret_store_password(RemminaFile *remminafile, const gchar *key, const gchar *password)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GError *r = NULL;
 	const gchar *path;
 	gchar *s;
@@ -105,7 +105,7 @@ void remmina_plugin_glibsecret_store_password(RemminaFile *remminafile, const gc
 gchar*
 remmina_plugin_glibsecret_get_password(RemminaFile *remminafile, const gchar *key)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GError *r = NULL;
 	const gchar *path;
 	gchar *password;
@@ -128,7 +128,7 @@ remmina_plugin_glibsecret_get_password(RemminaFile *remminafile, const gchar *ke
 
 void remmina_plugin_glibsecret_delete_password(RemminaFile *remminafile, const gchar *key)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GError *r = NULL;
 	const gchar *path;
 
@@ -151,7 +151,7 @@ static RemminaSecretPlugin remmina_plugin_glibsecret =
 G_MODULE_EXPORT gboolean
 remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	remmina_plugin_service = service;
 

--- a/remmina-plugins/nx/nx_plugin.c
+++ b/remmina-plugins/nx/nx_plugin.c
@@ -80,7 +80,7 @@ struct onMainThread_cb_data {
 
 static gboolean onMainThread_cb(struct onMainThread_cb_data *d)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if ( !d->cancelled ) {
 		switch ( d->func ) {
 		case FUNC_GTK_SOCKET_ADD_ID:
@@ -98,7 +98,7 @@ static gboolean onMainThread_cb(struct onMainThread_cb_data *d)
 
 static void onMainThread_cleanup_handler(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct onMainThread_cb_data *d = data;
 	d->cancelled = TRUE;
 }
@@ -106,7 +106,7 @@ static void onMainThread_cleanup_handler(gpointer data)
 
 static void onMainThread_schedule_callback_and_wait( struct onMainThread_cb_data *d )
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	d->cancelled = FALSE;
 	pthread_cleanup_push( onMainThread_cleanup_handler, d );
 	pthread_mutex_init( &d->mu, NULL );
@@ -122,7 +122,7 @@ static void onMainThread_schedule_callback_and_wait( struct onMainThread_cb_data
 
 static void onMainThread_gtk_socket_add_id( GtkSocket* sk, Window w)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	struct onMainThread_cb_data *d;
 
@@ -142,7 +142,7 @@ static void onMainThread_gtk_socket_add_id( GtkSocket* sk, Window w)
 
 static gboolean remmina_plugin_nx_try_window_id(Window window_id)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	gboolean found = FALSE;
 
@@ -163,7 +163,7 @@ static gboolean remmina_plugin_nx_try_window_id(Window window_id)
 
 static void remmina_plugin_nx_remove_window_id(Window window_id)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	gboolean found = FALSE;
 
@@ -182,19 +182,19 @@ static void remmina_plugin_nx_remove_window_id(Window window_id)
 
 static void remmina_plugin_nx_on_plug_added(GtkSocket *socket, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_nx_service->protocol_plugin_emit_signal(gp, "connect");
 }
 
 static void remmina_plugin_nx_on_plug_removed(GtkSocket *socket, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_nx_service->protocol_plugin_close_connection(gp);
 }
 
 gboolean remmina_plugin_nx_ssh_auth_callback(gchar **passphrase, gpointer userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = (RemminaProtocolWidget*)userdata;
 	gint ret;
 
@@ -210,7 +210,7 @@ gboolean remmina_plugin_nx_ssh_auth_callback(gchar **passphrase, gpointer userda
 
 static void remmina_plugin_nx_on_proxy_exit(GPid pid, gint status, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = (RemminaProtocolWidget*)data;
 
 	remmina_plugin_nx_service->protocol_plugin_close_connection(gp);
@@ -218,13 +218,13 @@ static void remmina_plugin_nx_on_proxy_exit(GPid pid, gint status, gpointer data
 
 static int remmina_plugin_nx_dummy_handler(Display *dsp, XErrorEvent *err)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return 0;
 }
 
 static gboolean remmina_plugin_nx_start_create_notify(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
 	gpdata->display = XOpenDisplay(gdk_display_get_name(gdk_display_get_default()));
@@ -240,7 +240,7 @@ static gboolean remmina_plugin_nx_start_create_notify(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_nx_monitor_create_notify(RemminaProtocolWidget *gp, const gchar *cmd)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata;
 	Atom atom;
 	XEvent xev;
@@ -293,7 +293,7 @@ static gboolean remmina_plugin_nx_monitor_create_notify(RemminaProtocolWidget *g
 
 static gint remmina_plugin_nx_wait_signal(RemminaPluginNxData *gpdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	fd_set set;
 	guchar dummy = 0;
 
@@ -307,7 +307,7 @@ static gint remmina_plugin_nx_wait_signal(RemminaPluginNxData *gpdata)
 
 static gboolean remmina_plugin_nx_start_session(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	RemminaNXSession *nx;
@@ -519,7 +519,7 @@ static gboolean remmina_plugin_nx_start_session(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_nx_main(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	gboolean ret;
 	const gchar *err;
@@ -539,7 +539,7 @@ static gboolean remmina_plugin_nx_main(RemminaProtocolWidget *gp)
 
 static gpointer remmina_plugin_nx_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
 	CANCEL_ASYNC
@@ -551,7 +551,7 @@ static gpointer remmina_plugin_nx_main_thread(gpointer data)
 
 static void remmina_plugin_nx_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata;
 	gint flags;
 
@@ -577,7 +577,7 @@ static void remmina_plugin_nx_init(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_nx_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	const gchar *resolution;
@@ -617,7 +617,7 @@ static gboolean remmina_plugin_nx_open_connection(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_nx_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (gpdata->thread) {
@@ -655,7 +655,7 @@ static gboolean remmina_plugin_nx_close_connection(RemminaProtocolWidget *gp)
 /* Send CTRL+ALT+DEL keys keystrokes to the plugin socket widget */
 static void remmina_plugin_nx_send_ctrlaltdel(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint keys[] = { GDK_KEY_Control_L, GDK_KEY_Alt_L, GDK_KEY_Delete };
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
@@ -665,13 +665,13 @@ static void remmina_plugin_nx_send_ctrlaltdel(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_nx_query_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static void remmina_plugin_nx_call_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (feature->id) {
 	case REMMINA_PLUGIN_NX_FEATURE_TOOL_SENDCTRLALTDEL:
 		remmina_plugin_nx_send_ctrlaltdel(gp);
@@ -764,7 +764,7 @@ static RemminaProtocolPlugin remmina_plugin_nx =
 G_MODULE_EXPORT gboolean
 remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	Display *dpy;
 	XkbRF_VarDefsRec vd;
 	gchar *s;

--- a/remmina-plugins/nx/nx_session.c
+++ b/remmina-plugins/nx/nx_session.c
@@ -48,7 +48,7 @@
 
 static gboolean remmina_get_keytype(const gchar *private_key_file, gint *keytype, gboolean *encrypted)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	FILE *fp;
 	gchar buf1[100], buf2[100];
 
@@ -128,7 +128,7 @@ struct _RemminaNXSession {
 RemminaNXSession*
 remmina_nx_session_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaNXSession *nx;
 
 	nx = g_new0(RemminaNXSession, 1);
@@ -144,7 +144,7 @@ remmina_nx_session_new(void)
 
 void remmina_nx_session_free(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_t thread;
 
 	if (nx->proxy_watch_source) {
@@ -193,7 +193,7 @@ void remmina_nx_session_free(RemminaNXSession *nx)
 
 static void remmina_nx_session_set_error(RemminaNXSession *nx, const gchar *fmt)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar *err;
 
 	if (nx->error)
@@ -204,7 +204,7 @@ static void remmina_nx_session_set_error(RemminaNXSession *nx, const gchar *fmt)
 
 static void remmina_nx_session_set_application_error(RemminaNXSession *nx, const gchar *fmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 
 	if (nx->error) g_free(nx->error);
@@ -215,20 +215,20 @@ static void remmina_nx_session_set_application_error(RemminaNXSession *nx, const
 
 gboolean remmina_nx_session_has_error(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return (nx->error != NULL);
 }
 
 const gchar*
 remmina_nx_session_get_error(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return nx->error;
 }
 
 void remmina_nx_session_clear_error(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (nx->error) {
 		g_free(nx->error);
 		nx->error = NULL;
@@ -237,25 +237,25 @@ void remmina_nx_session_clear_error(RemminaNXSession *nx)
 
 void remmina_nx_session_set_encryption(RemminaNXSession *nx, gint encryption)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	nx->encryption = encryption;
 }
 
 void remmina_nx_session_set_localport(RemminaNXSession *nx, gint localport)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	nx->localport = localport;
 }
 
 void remmina_nx_session_set_log_callback(RemminaNXSession *nx, RemminaNXLogCallback log_callback)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	nx->log_callback = log_callback;
 }
 
 static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct timeval timeout;
 	ssh_channel ch[2];
 	ssh_buffer buffer;
@@ -304,7 +304,7 @@ static gboolean remmina_nx_session_get_response(RemminaNXSession *nx)
 
 static void remmina_nx_session_parse_session_list_line(RemminaNXSession *nx, const gchar *line)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *p1, *p2;
 	gchar *val;
 	gint i;
@@ -360,7 +360,7 @@ static void remmina_nx_session_parse_session_list_line(RemminaNXSession *nx, con
 
 static gint remmina_nx_session_parse_line(RemminaNXSession *nx, const gchar *line, gchar **valueptr)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *s;
 	gchar *ptr;
 	gint status;
@@ -412,7 +412,7 @@ static gint remmina_nx_session_parse_line(RemminaNXSession *nx, const gchar *lin
 static gchar*
 remmina_nx_session_get_line(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *line;
 	gchar *pos, *ptr;
 	gint len;
@@ -440,7 +440,7 @@ remmina_nx_session_get_line(RemminaNXSession *nx)
 
 static gint remmina_nx_session_parse_response(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *line;
 	gchar *pos, *p;
 	gint status = -1;
@@ -496,7 +496,7 @@ static gint remmina_nx_session_parse_response(RemminaNXSession *nx)
 
 static gint remmina_nx_session_expect_status2(RemminaNXSession *nx, gint status, gint status2)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint response;
 
 	while ((response = remmina_nx_session_parse_response(nx)) != status && response != status2) {
@@ -513,13 +513,13 @@ static gint remmina_nx_session_expect_status2(RemminaNXSession *nx, gint status,
 
 static gboolean remmina_nx_session_expect_status(RemminaNXSession *nx, gint status)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return (remmina_nx_session_expect_status2(nx, status, 0) == status);
 }
 
 static void remmina_nx_session_send_command(RemminaNXSession *nx, const gchar *cmdfmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 	gchar *cmd;
 
@@ -536,7 +536,7 @@ static void remmina_nx_session_send_command(RemminaNXSession *nx, const gchar *c
 gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guint port, const gchar *private_key_file,
 				 RemminaNXPassphraseCallback passphrase_func, gpointer userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint ret;
 	ssh_key priv_key;
 	gint keytype;
@@ -617,7 +617,7 @@ gboolean remmina_nx_session_open(RemminaNXSession *nx, const gchar *server, guin
 
 gboolean remmina_nx_session_login(RemminaNXSession *nx, const gchar *username, const gchar *password)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint response;
 
 	/* Login to the NX server */
@@ -640,7 +640,7 @@ gboolean remmina_nx_session_login(RemminaNXSession *nx, const gchar *username, c
 
 void remmina_nx_session_add_parameter(RemminaNXSession *nx, const gchar *name, const gchar *valuefmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 	gchar *value;
 
@@ -652,7 +652,7 @@ void remmina_nx_session_add_parameter(RemminaNXSession *nx, const gchar *name, c
 
 static gboolean remmina_nx_session_send_session_command(RemminaNXSession *nx, const gchar *cmd_type, gint response)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GString *cmd;
 	GHashTableIter iter;
 	gchar *key, *value;
@@ -673,7 +673,7 @@ static gboolean remmina_nx_session_send_session_command(RemminaNXSession *nx, co
 
 gboolean remmina_nx_session_list(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean ret;
 
 	if (nx->session_list == NULL) {
@@ -689,13 +689,13 @@ gboolean remmina_nx_session_list(RemminaNXSession *nx)
 
 void remmina_nx_session_set_tree_view(RemminaNXSession *nx, GtkTreeView *tree)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_tree_view_set_model(tree, GTK_TREE_MODEL(nx->session_list));
 }
 
 gboolean remmina_nx_session_iter_first(RemminaNXSession *nx, GtkTreeIter *iter)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!nx->session_list)
 		return FALSE;
 	return gtk_tree_model_get_iter_first(GTK_TREE_MODEL(nx->session_list), iter);
@@ -703,7 +703,7 @@ gboolean remmina_nx_session_iter_first(RemminaNXSession *nx, GtkTreeIter *iter)
 
 gboolean remmina_nx_session_iter_next(RemminaNXSession *nx, GtkTreeIter *iter)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!nx->session_list)
 		return FALSE;
 	return gtk_tree_model_iter_next(GTK_TREE_MODEL(nx->session_list), iter);
@@ -712,7 +712,7 @@ gboolean remmina_nx_session_iter_next(RemminaNXSession *nx, GtkTreeIter *iter)
 gchar*
 remmina_nx_session_iter_get(RemminaNXSession *nx, GtkTreeIter *iter, gint column)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *val;
 
 	gtk_tree_model_get(GTK_TREE_MODEL(nx->session_list), iter, column, &val, -1);
@@ -721,19 +721,19 @@ remmina_nx_session_iter_get(RemminaNXSession *nx, GtkTreeIter *iter, gint column
 
 void remmina_nx_session_iter_set(RemminaNXSession *nx, GtkTreeIter *iter, gint column, const gchar *data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_list_store_set(nx->session_list, iter, column, data, -1);
 }
 
 gboolean remmina_nx_session_allow_start(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return nx->allow_start;
 }
 
 static void remmina_nx_session_add_common_parameters(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *value;
 
 	/* Add fixed session parameters for startsession */
@@ -752,34 +752,34 @@ static void remmina_nx_session_add_common_parameters(RemminaNXSession *nx)
 
 gboolean remmina_nx_session_start(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_nx_session_add_common_parameters(nx);
 	return remmina_nx_session_send_session_command(nx, "startsession", 105);
 }
 
 gboolean remmina_nx_session_attach(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_nx_session_add_common_parameters(nx);
 	return remmina_nx_session_send_session_command(nx, "attachsession", 105);
 }
 
 gboolean remmina_nx_session_restore(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_nx_session_add_common_parameters(nx);
 	return remmina_nx_session_send_session_command(nx, "restoresession", 105);
 }
 
 gboolean remmina_nx_session_terminate(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_nx_session_send_session_command(nx, "terminate", 105);
 }
 
 static gpointer remmina_nx_session_tunnel_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaNXSession *nx = (RemminaNXSession*)data;
 	gchar *ptr;
 	ssize_t len = 0, lenw = 0;
@@ -893,7 +893,7 @@ static gpointer remmina_nx_session_tunnel_main_thread(gpointer data)
 
 gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint port;
 	gint sock;
 	gint sockopt = 1;
@@ -949,7 +949,7 @@ gboolean remmina_nx_session_tunnel_open(RemminaNXSession *nx)
 static gchar*
 remmina_nx_session_get_proxy_option(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (nx->encryption) {
 		return g_strdup_printf("nx,session=%s,cookie=%s,id=%s,shmem=1,shpix=1,connect=127.0.0.1:%i",
 			(gchar*)g_hash_table_lookup(nx->session_parameters, "session"), nx->proxy_cookie,
@@ -963,7 +963,7 @@ remmina_nx_session_get_proxy_option(RemminaNXSession *nx)
 
 gboolean remmina_nx_session_invoke_proxy(RemminaNXSession *nx, gint display, GChildWatchFunc exit_func, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *argv[50];
 	gint argc;
 	GError *error = NULL;
@@ -1014,7 +1014,7 @@ gboolean remmina_nx_session_invoke_proxy(RemminaNXSession *nx, gint display, GCh
 
 void remmina_nx_session_bye(RemminaNXSession *nx)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_nx_session_send_command(nx, "bye");
 	remmina_nx_session_get_response(nx);
 }

--- a/remmina-plugins/nx/nx_session_manager.c
+++ b/remmina-plugins/nx/nx_session_manager.c
@@ -41,7 +41,7 @@
 
 static void remmina_nx_session_manager_set_sensitive(RemminaProtocolWidget *gp, gboolean sensitive)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (gpdata->attach_session) {
@@ -56,7 +56,7 @@ static void remmina_nx_session_manager_set_sensitive(RemminaProtocolWidget *gp, 
 static gboolean remmina_nx_session_manager_selection_func(GtkTreeSelection *selection, GtkTreeModel *model, GtkTreePath *path,
 							  gboolean path_currently_selected, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = (RemminaProtocolWidget*)user_data;
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
@@ -75,7 +75,7 @@ static gboolean remmina_nx_session_manager_selection_func(GtkTreeSelection *sele
 
 static void remmina_nx_session_manager_send_signal(RemminaPluginNxData *gpdata, gint event_type)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar dummy = (guchar)event_type;
 	/* Signal the NX thread to resume execution */
 	if (write(gpdata->event_pipe[1], &dummy, 1)) {
@@ -84,7 +84,7 @@ static void remmina_nx_session_manager_send_signal(RemminaPluginNxData *gpdata, 
 
 static void remmina_nx_session_manager_on_response(GtkWidget *dialog, gint response_id, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	gint event_type;
 
@@ -111,7 +111,7 @@ static void remmina_nx_session_manager_on_response(GtkWidget *dialog, gint respo
  * Automatically close the dialog using the default response id */
 void remmina_nx_session_manager_on_row_activated(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	remmina_plugin_nx_service->log_printf("[NX] Default response_id %d\n",
 		gpdata->default_response);
@@ -123,7 +123,7 @@ void remmina_nx_session_manager_on_row_activated(GtkTreeView *tree, GtkTreePath 
 
 static gboolean remmina_nx_session_manager_main(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	GtkWidget *dialog;
@@ -234,7 +234,7 @@ static gboolean remmina_nx_session_manager_main(RemminaProtocolWidget *gp)
 
 void remmina_nx_session_manager_start(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginNxData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (gpdata->session_manager_start_handler == 0) {

--- a/remmina-plugins/rdp/rdp_cliprdr.c
+++ b/remmina-plugins/rdp/rdp_cliprdr.c
@@ -47,7 +47,7 @@
 
 UINT32 remmina_rdp_cliprdr_get_format_from_gdkatom(GdkAtom atom)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	UINT32 rc;
 	gchar* name = gdk_atom_name(atom);
 	rc = 0;
@@ -75,7 +75,7 @@ UINT32 remmina_rdp_cliprdr_get_format_from_gdkatom(GdkAtom atom)
 
 void remmina_rdp_cliprdr_get_target_types(UINT32** formats, UINT16* size, GdkAtom* types, int count)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int i;
 	*size = 1;
 	*formats = (UINT32*)malloc(sizeof(UINT32) * (count + 1));
@@ -94,7 +94,7 @@ void remmina_rdp_cliprdr_get_target_types(UINT32** formats, UINT16* size, GdkAto
 
 static UINT8* lf2crlf(UINT8* data, int* size)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	UINT8 c;
 	UINT8* outbuf;
 	UINT8* out;
@@ -126,7 +126,7 @@ static UINT8* lf2crlf(UINT8* data, int* size)
 
 static void crlf2lf(UINT8* data, size_t* size)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	UINT8 c;
 	UINT8* out;
 	UINT8* in;
@@ -147,18 +147,18 @@ static void crlf2lf(UINT8* data, size_t* size)
 
 int remmina_rdp_cliprdr_server_file_contents_request(CliprdrClientContext* context, CLIPRDR_FILE_CONTENTS_REQUEST* fileContentsRequest)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return -1;
 }
 int remmina_rdp_cliprdr_server_file_contents_response(CliprdrClientContext* context, CLIPRDR_FILE_CONTENTS_RESPONSE* fileContentsResponse)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return 1;
 }
 
 void remmina_rdp_cliprdr_send_client_format_list(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	rfClipboard* clipboard;
@@ -184,7 +184,7 @@ void remmina_rdp_cliprdr_send_client_format_list(RemminaProtocolWidget *gp)
 
 static void remmina_rdp_cliprdr_send_client_capabilities(rfClipboard* clipboard)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	CLIPRDR_CAPABILITIES capabilities;
 	CLIPRDR_GENERAL_CAPABILITY_SET generalCapabilitySet;
 
@@ -203,7 +203,7 @@ static void remmina_rdp_cliprdr_send_client_capabilities(rfClipboard* clipboard)
 
 static UINT remmina_rdp_cliprdr_monitor_ready(CliprdrClientContext* context, CLIPRDR_MONITOR_READY* monitorReady)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfClipboard* clipboard = (rfClipboard*)context->custom;
 	RemminaProtocolWidget* gp;
 
@@ -216,14 +216,14 @@ static UINT remmina_rdp_cliprdr_monitor_ready(CliprdrClientContext* context, CLI
 
 static UINT remmina_rdp_cliprdr_server_capabilities(CliprdrClientContext* context, CLIPRDR_CAPABILITIES* capabilities)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return CHANNEL_RC_OK;
 }
 
 
 static UINT remmina_rdp_cliprdr_server_format_list(CliprdrClientContext* context, CLIPRDR_FORMAT_LIST* formatList)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Called when a user do a "Copy" on the server: we collect all formats
 	 * the server send us and then setup the local clipboard with the appropiate
@@ -290,14 +290,14 @@ static UINT remmina_rdp_cliprdr_server_format_list(CliprdrClientContext* context
 
 static UINT remmina_rdp_cliprdr_server_format_list_response(CliprdrClientContext* context, CLIPRDR_FORMAT_LIST_RESPONSE* formatListResponse)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return CHANNEL_RC_OK;
 }
 
 
 static UINT remmina_rdp_cliprdr_server_format_data_request(CliprdrClientContext* context, CLIPRDR_FORMAT_DATA_REQUEST* formatDataRequest)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaPluginRdpUiObject* ui;
 	RemminaProtocolWidget* gp;
@@ -318,7 +318,7 @@ static UINT remmina_rdp_cliprdr_server_format_data_request(CliprdrClientContext*
 
 static UINT remmina_rdp_cliprdr_server_format_data_response(CliprdrClientContext* context, CLIPRDR_FORMAT_DATA_RESPONSE* formatDataResponse)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	UINT8* data;
 	size_t size;
@@ -451,7 +451,7 @@ static UINT remmina_rdp_cliprdr_server_format_data_response(CliprdrClientContext
 
 void remmina_rdp_cliprdr_request_data(GtkClipboard *gtkClipboard, GtkSelectionData *selection_data, guint info, RemminaProtocolWidget* gp )
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Called by GTK when someone press "Paste" on the client side.
 	 * We ask to the server the data we need */
@@ -523,13 +523,13 @@ void remmina_rdp_cliprdr_request_data(GtkClipboard *gtkClipboard, GtkSelectionDa
 
 void remmina_rdp_cliprdr_empty_clipboard(GtkClipboard *gtkClipboard, rfClipboard *clipboard)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* No need to do anything here */
 }
 
 CLIPRDR_FORMAT_LIST *remmina_rdp_cliprdr_get_client_format_list(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkClipboard* gtkClipboard;
 	rfClipboard* clipboard;
@@ -592,14 +592,14 @@ CLIPRDR_FORMAT_LIST *remmina_rdp_cliprdr_get_client_format_list(RemminaProtocolW
 
 static void remmina_rdp_cliprdr_mt_get_format_list(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	ui->retptr = (void*)remmina_rdp_cliprdr_get_client_format_list(gp);
 }
 
 
 void remmina_rdp_cliprdr_get_clipboard_data(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkClipboard* gtkClipboard;
 	rfClipboard* clipboard;
 	UINT8* inbuf = NULL;
@@ -706,7 +706,7 @@ void remmina_rdp_cliprdr_get_clipboard_data(RemminaProtocolWidget* gp, RemminaPl
 
 void remmina_rdp_cliprdr_set_clipboard_content(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkClipboard* gtkClipboard;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
@@ -723,7 +723,7 @@ void remmina_rdp_cliprdr_set_clipboard_content(RemminaProtocolWidget* gp, Remmin
 
 void remmina_rdp_cliprdr_set_clipboard_data(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkClipboard* gtkClipboard;
 	GtkTargetEntry* targets;
 	gint n_targets;
@@ -745,7 +745,7 @@ static void remmina_rdp_cliprdr_detach_owner(RemminaProtocolWidget* gp, RemminaP
 {
 	/* When closing a rdp connection, we should check if gp is a clipboard owner.
 	 * If it's an owner, detach it from the clipboard */
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	GtkClipboard* gtkClipboard;
 
@@ -758,7 +758,7 @@ static void remmina_rdp_cliprdr_detach_owner(RemminaProtocolWidget* gp, RemminaP
 
 void remmina_rdp_event_process_clipboard(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (ui->clipboard.type) {
 
 	case REMMINA_RDP_UI_CLIPBOARD_FORMATLIST:
@@ -786,19 +786,19 @@ void remmina_rdp_event_process_clipboard(RemminaProtocolWidget* gp, RemminaPlugi
 
 void remmina_rdp_clipboard_init(rfContext *rfi)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	// Future: initialize rfi->clipboard
 }
 void remmina_rdp_clipboard_free(rfContext *rfi)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	// Future: deinitialize rfi->clipboard
 }
 
 
 void remmina_rdp_cliprdr_init(rfContext* rfi, CliprdrClientContext* cliprdr)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	rfClipboard* clipboard;
 	clipboard = &(rfi->clipboard);

--- a/remmina-plugins/rdp/rdp_event.c
+++ b/remmina-plugins/rdp/rdp_event.c
@@ -47,7 +47,7 @@
 
 static void remmina_rdp_event_on_focus_in(GtkWidget* widget, GdkEventKey* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	rdpInput* input;
 	GdkModifierType state;
@@ -89,7 +89,7 @@ static void remmina_rdp_event_on_focus_in(GtkWidget* widget, GdkEventKey* event,
 
 void remmina_rdp_event_event_push(RemminaProtocolWidget* gp, const RemminaPluginRdpEvent* e)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpEvent* event;
 
@@ -109,7 +109,7 @@ void remmina_rdp_event_event_push(RemminaProtocolWidget* gp, const RemminaPlugin
 
 static void remmina_rdp_event_release_all_keys(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpEvent rdp_event = { 0 };
 	int i;
@@ -130,7 +130,7 @@ static void remmina_rdp_event_release_all_keys(RemminaProtocolWidget* gp)
 
 static void remmina_rdp_event_release_key(RemminaProtocolWidget* gp, RemminaPluginRdpEvent rdp_event)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpEvent rdp_event_2 = { 0 };
@@ -156,7 +156,7 @@ static void remmina_rdp_event_release_key(RemminaProtocolWidget* gp, RemminaPlug
 
 static void keypress_list_add(RemminaProtocolWidget *gp, RemminaPluginRdpEvent rdp_event)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	if (!rdp_event.key_event.key_code)
 		return;
@@ -172,7 +172,7 @@ static void keypress_list_add(RemminaProtocolWidget *gp, RemminaPluginRdpEvent r
 
 static void remmina_rdp_event_scale_area(RemminaProtocolWidget* gp, gint* x, gint* y, gint* w, gint* h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint width, height;
 	gint sx, sy, sw, sh;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
@@ -217,7 +217,7 @@ static void remmina_rdp_event_scale_area(RemminaProtocolWidget* gp, gint* x, gin
 
 void remmina_rdp_event_update_region(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	gint x, y, w, h;
 
@@ -234,7 +234,7 @@ void remmina_rdp_event_update_region(RemminaProtocolWidget* gp, RemminaPluginRdp
 
 void remmina_rdp_event_update_rect(RemminaProtocolWidget* gp, gint x, gint y, gint w, gint h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	if (rfi->scale == REMMINA_PROTOCOL_WIDGET_SCALE_MODE_SCALED)
@@ -245,7 +245,7 @@ void remmina_rdp_event_update_rect(RemminaProtocolWidget* gp, gint x, gint y, gi
 
 static void remmina_rdp_event_update_scale_factor(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkAllocation a;
 	gint rdwidth, rdheight;
 	gint gpwidth, gpheight;
@@ -280,7 +280,7 @@ static void remmina_rdp_event_update_scale_factor(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_event_on_draw(GtkWidget* widget, cairo_t* context, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	guint width, height;
 	gchar *msg;
@@ -331,7 +331,7 @@ static gboolean remmina_rdp_event_on_draw(GtkWidget* widget, cairo_t* context, R
 
 static gboolean remmina_rdp_event_delayed_monitor_layout(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpEvent rdp_event = { 0 };
 	GtkAllocation a;
@@ -377,7 +377,7 @@ static gboolean remmina_rdp_event_delayed_monitor_layout(RemminaProtocolWidget* 
 
 void remmina_rdp_event_send_delayed_monitor_layout(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	if (!rfi || !rfi->connected || rfi->is_reconnecting)
 		return;
@@ -393,7 +393,7 @@ void remmina_rdp_event_send_delayed_monitor_layout(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_event_on_configure(GtkWidget* widget, GdkEventConfigure* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Called when gp changes its size or position */
 
@@ -412,7 +412,7 @@ static gboolean remmina_rdp_event_on_configure(GtkWidget* widget, GdkEventConfig
 
 static void remmina_rdp_event_translate_pos(RemminaProtocolWidget* gp, int ix, int iy, UINT16* ox, UINT16* oy)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	/*
@@ -434,7 +434,7 @@ static void remmina_rdp_event_translate_pos(RemminaProtocolWidget* gp, int ix, i
 
 static void remmina_rdp_event_reverse_translate_pos_reverse(RemminaProtocolWidget* gp, int ix, int iy, int* ox, int* oy)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	/*
@@ -456,7 +456,7 @@ static void remmina_rdp_event_reverse_translate_pos_reverse(RemminaProtocolWidge
 
 static gboolean remmina_rdp_event_on_motion(GtkWidget* widget, GdkEventMotion* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpEvent rdp_event = { 0 };
 
 	rdp_event.type = REMMINA_RDP_EVENT_TYPE_MOUSE;
@@ -471,7 +471,7 @@ static gboolean remmina_rdp_event_on_motion(GtkWidget* widget, GdkEventMotion* e
 
 static gboolean remmina_rdp_event_on_button(GtkWidget* widget, GdkEventButton* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint flag;
 	gboolean extended = FALSE;
 	RemminaPluginRdpEvent rdp_event = { 0 };
@@ -527,7 +527,7 @@ static gboolean remmina_rdp_event_on_button(GtkWidget* widget, GdkEventButton* e
 
 static gboolean remmina_rdp_event_on_scroll(GtkWidget* widget, GdkEventScroll* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint flag;
 	RemminaPluginRdpEvent rdp_event = { 0 };
 
@@ -568,7 +568,7 @@ static gboolean remmina_rdp_event_on_scroll(GtkWidget* widget, GdkEventScroll* e
 
 static gboolean remmina_rdp_event_on_key(GtkWidget* widget, GdkEventKey* event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkDisplay* display;
 	guint32 unicode_keyval;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
@@ -658,7 +658,7 @@ static gboolean remmina_rdp_event_on_key(GtkWidget* widget, GdkEventKey* event, 
 gboolean remmina_rdp_event_on_clipboard(GtkClipboard *gtkClipboard, GdkEvent *event, RemminaProtocolWidget *gp)
 {
 	/* Signal handler for GTK clipboard owner-change */
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpEvent rdp_event = { 0 };
 	CLIPRDR_FORMAT_LIST* pFormatList;
 
@@ -678,7 +678,7 @@ gboolean remmina_rdp_event_on_clipboard(GtkClipboard *gtkClipboard, GdkEvent *ev
 
 void remmina_rdp_event_init(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 	gint flags;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
@@ -754,7 +754,7 @@ void remmina_rdp_event_init(RemminaProtocolWidget* gp)
 
 void remmina_rdp_event_free_event(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* obj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	switch (obj->type) {
@@ -776,7 +776,7 @@ void remmina_rdp_event_free_event(RemminaProtocolWidget* gp, RemminaPluginRdpUiO
 
 void remmina_rdp_event_uninit(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpUiObject* ui;
 
@@ -835,7 +835,7 @@ static void remmina_rdp_event_create_cairo_surface(rfContext* rfi)
 
 void remmina_rdp_event_update_scale(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint width, height;
 	RemminaFile* remminafile;
 	rdpGdi* gdi;
@@ -879,7 +879,7 @@ void remmina_rdp_event_update_scale(RemminaProtocolWidget* gp)
 
 static void remmina_rdp_event_connected(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	remmina_plugin_service->protocol_plugin_emit_signal(gp, "connect");
@@ -893,14 +893,14 @@ static void remmina_rdp_event_connected(RemminaProtocolWidget* gp, RemminaPlugin
 
 static void remmina_rdp_event_reconnect_progress(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	gdk_window_invalidate_rect(gtk_widget_get_window(rfi->drawing_area), NULL, TRUE);
 }
 
 static BOOL remmina_rdp_event_create_cursor(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkPixbuf* pixbuf;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	rdpPointer* pointer = (rdpPointer*)ui->cursor.pointer;
@@ -929,14 +929,14 @@ static BOOL remmina_rdp_event_create_cursor(RemminaProtocolWidget* gp, RemminaPl
 
 static void remmina_rdp_event_free_cursor(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_object_unref(ui->cursor.pointer->cursor);
 	ui->cursor.pointer->cursor = NULL;
 }
 
 static BOOL remmina_rdp_event_set_pointer_position(RemminaProtocolWidget *gp, gint x, gint y)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkWindow *w, *nw;
 	gint nx, ny, wx, wy;
 #if GTK_CHECK_VERSION(3, 20, 0)
@@ -973,7 +973,7 @@ static BOOL remmina_rdp_event_set_pointer_position(RemminaProtocolWidget *gp, gi
 
 static void remmina_rdp_event_cursor(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	switch (ui->cursor.type) {
@@ -1010,19 +1010,19 @@ static void remmina_rdp_event_cursor(RemminaProtocolWidget* gp, RemminaPluginRdp
 
 static void remmina_rdp_ui_event_update_scale(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_rdp_event_update_scale(gp);
 }
 
 void remmina_rdp_event_unfocus(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_rdp_event_release_all_keys(gp);
 }
 
 static void remmina_rdp_event_process_event(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (ui->event.type) {
 	case REMMINA_RDP_UI_EVENT_UPDATE_SCALE:
 		remmina_rdp_ui_event_update_scale(gp, ui);
@@ -1032,7 +1032,7 @@ static void remmina_rdp_event_process_event(RemminaProtocolWidget* gp, RemminaPl
 
 static void remmina_rdp_event_process_ui_event(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (ui->type) {
 	case REMMINA_RDP_UI_UPDATE_REGION:
 		remmina_rdp_event_update_region(gp, ui);
@@ -1065,7 +1065,7 @@ static void remmina_rdp_event_process_ui_event(RemminaProtocolWidget* gp, Remmin
 
 static gboolean remmina_rdp_event_process_ui_queue(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	RemminaPluginRdpUiObject* ui;
@@ -1098,7 +1098,7 @@ static gboolean remmina_rdp_event_process_ui_queue(RemminaProtocolWidget* gp)
 
 static void remmina_rdp_event_queue_ui(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	gboolean ui_sync_save;
 	int oldcanceltype;
@@ -1155,7 +1155,7 @@ void remmina_rdp_event_queue_ui_async(RemminaProtocolWidget* gp, RemminaPluginRd
 
 int remmina_rdp_event_queue_ui_sync_retint(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int retval;
 	ui->sync = TRUE;
 	remmina_rdp_event_queue_ui(gp, ui);
@@ -1166,7 +1166,7 @@ int remmina_rdp_event_queue_ui_sync_retint(RemminaProtocolWidget* gp, RemminaPlu
 
 void *remmina_rdp_event_queue_ui_sync_retptr(RemminaProtocolWidget* gp, RemminaPluginRdpUiObject* ui)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	void *rp;
 	ui->sync = TRUE;
 	remmina_rdp_event_queue_ui(gp, ui);

--- a/remmina-plugins/rdp/rdp_file.c
+++ b/remmina-plugins/rdp/rdp_file.c
@@ -40,7 +40,7 @@
 
 gboolean remmina_rdp_file_import_test(const gchar* from_file)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* ext;
 
 	ext = strrchr(from_file, '.');
@@ -61,7 +61,7 @@ gboolean remmina_rdp_file_import_test(const gchar* from_file)
 
 static void remmina_rdp_file_import_field(RemminaFile* remminafile, const gchar* key, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (g_strcmp0(key, "desktopwidth") == 0) {
 		remmina_plugin_service->file_set_string(remminafile, "resolution_width", value);
 	}else if (g_strcmp0(key, "desktopheight") == 0) {
@@ -118,7 +118,7 @@ static void remmina_rdp_file_import_field(RemminaFile* remminafile, const gchar*
 
 static RemminaFile* remmina_rdp_file_import_channel(GIOChannel* channel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* p;
 	const gchar* enc;
 	gchar* line = NULL;
@@ -186,7 +186,7 @@ static RemminaFile* remmina_rdp_file_import_channel(GIOChannel* channel)
 
 RemminaFile* remmina_rdp_file_import(const gchar* from_file)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GIOChannel* channel;
 	GError* error = NULL;
 	RemminaFile* remminafile;
@@ -206,7 +206,7 @@ RemminaFile* remmina_rdp_file_import(const gchar* from_file)
 
 gboolean remmina_rdp_file_export_test(RemminaFile* remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (g_strcmp0(remmina_plugin_service->file_get_string(remminafile, "protocol"), "RDP") == 0)
 		return TRUE;
 
@@ -215,7 +215,7 @@ gboolean remmina_rdp_file_export_test(RemminaFile* remminafile)
 
 gboolean remmina_rdp_file_export_channel(RemminaFile* remminafile, FILE* fp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 	gchar* p;
 	const gchar* cs;
@@ -283,7 +283,7 @@ gboolean remmina_rdp_file_export_channel(RemminaFile* remminafile, FILE* fp)
 
 gboolean remmina_rdp_file_export(RemminaFile* remminafile, const gchar* to_file)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	FILE* fp;
 	gchar* p;
 	gboolean ret;

--- a/remmina-plugins/rdp/rdp_graphics.c
+++ b/remmina-plugins/rdp/rdp_graphics.c
@@ -51,7 +51,7 @@
 
 BOOL rf_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_BITMAP
 	UINT8* data;
 	Pixmap pixmap;
@@ -89,7 +89,7 @@ BOOL rf_Bitmap_New(rdpContext* context, rdpBitmap* bitmap)
 
 void rf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_BITMAP
 	rfContext* rfi = (rfContext*)context;
 
@@ -102,7 +102,7 @@ void rf_Bitmap_Free(rdpContext* context, rdpBitmap* bitmap)
 
 BOOL rf_Bitmap_Paint(rdpContext* context, rdpBitmap* bitmap)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_BITMAP
 	XImage* image;
 	int width, height;
@@ -134,7 +134,7 @@ BOOL rf_Bitmap_Paint(rdpContext* context, rdpBitmap* bitmap)
 BOOL rf_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 			  const BYTE* data, UINT32 width, UINT32 height, UINT32 bpp, UINT32 length, BOOL compressed, UINT32 codec_id)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_BITMAP
 	UINT16 size;
 
@@ -168,7 +168,7 @@ BOOL rf_Bitmap_Decompress(rdpContext* context, rdpBitmap* bitmap,
 
 BOOL rf_Bitmap_SetSurface(rdpContext* context, rdpBitmap* bitmap, BOOL primary)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_BITMAP
 	rfContext* rfi = (rfContext*)context;
 
@@ -184,7 +184,7 @@ BOOL rf_Bitmap_SetSurface(rdpContext* context, rdpBitmap* bitmap, BOOL primary)
 
 BOOL rf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 
@@ -201,7 +201,7 @@ BOOL rf_Pointer_New(rdpContext* context, rdpPointer* pointer)
 
 void rf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 
@@ -222,7 +222,7 @@ void rf_Pointer_Free(rdpContext* context, rdpPointer* pointer)
 
 BOOL rf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 
@@ -237,7 +237,7 @@ BOOL rf_Pointer_Set(rdpContext* context, const rdpPointer* pointer)
 
 BOOL rf_Pointer_SetNull(rdpContext* context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 
@@ -250,7 +250,7 @@ BOOL rf_Pointer_SetNull(rdpContext* context)
 
 BOOL rf_Pointer_SetDefault(rdpContext* context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 
@@ -263,7 +263,7 @@ BOOL rf_Pointer_SetDefault(rdpContext* context)
 
 BOOL rf_Pointer_SetPosition(rdpContext* context, UINT32 x, UINT32 y)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginRdpUiObject* ui;
 	rfContext* rfi = (rfContext*)context;
 	ui = g_new0(RemminaPluginRdpUiObject, 1);
@@ -279,7 +279,7 @@ BOOL rf_Pointer_SetPosition(rdpContext* context, UINT32 x, UINT32 y)
 
 BOOL rf_Glyph_New(rdpContext* context, const rdpGlyph* glyph)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_GLYPH
 	int scanline;
 	XImage* image;
@@ -308,7 +308,7 @@ BOOL rf_Glyph_New(rdpContext* context, const rdpGlyph* glyph)
 
 void rf_Glyph_Free(rdpContext* context, rdpGlyph* glyph)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_GLYPH
 	rfContext* rfi = (rfContext*)context;
 
@@ -321,7 +321,7 @@ static BOOL rf_Glyph_Draw(rdpContext* context, const rdpGlyph* glyph, UINT32 x,
 			  UINT32 y, UINT32 w, UINT32 h, UINT32 sx, UINT32 sy,
 			  BOOL fOpRedundant)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_GLYPH
 	rfGlyph* rf_glyph;
 	rfContext* rfi = (rfContext*)context;
@@ -340,7 +340,7 @@ static BOOL rf_Glyph_BeginDraw(rdpContext* context, UINT32 x, UINT32 y,
 			       UINT32 width, UINT32 height, UINT32 bgcolor,
 			       UINT32 fgcolor, BOOL fOpRedundant)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_GLYPH
 	rfContext* rfi = (rfContext*)context;
 
@@ -368,7 +368,7 @@ static BOOL rf_Glyph_EndDraw(rdpContext* context, UINT32 x, UINT32 y,
 			     UINT32 width, UINT32 height,
 			     UINT32 bgcolor, UINT32 fgcolor)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef RF_GLYPH
 	rfContext* rfi = (rfContext*)context;
 
@@ -384,7 +384,7 @@ static BOOL rf_Glyph_EndDraw(rdpContext* context, UINT32 x, UINT32 y,
 
 void rf_register_graphics(rdpGraphics* graphics)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rdpBitmap* bitmap;
 	rdpPointer* pointer;
 	rdpGlyph* glyph;

--- a/remmina-plugins/rdp/rdp_plugin.c
+++ b/remmina-plugins/rdp/rdp_plugin.c
@@ -68,7 +68,7 @@ static char remmina_rdp_plugin_default_drive_name[] = "RemminaDisk";
 
 static BOOL rf_process_event_queue(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	UINT16 flags;
 	rdpInput* input;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
@@ -145,7 +145,7 @@ static BOOL rf_process_event_queue(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_tunnel_init(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Opens the optional SSH tunnel if needed.
 	 * Used also when reopening the same tunnel for a freerdp reconnect.
@@ -209,7 +209,7 @@ static gboolean remmina_rdp_tunnel_init(RemminaProtocolWidget* gp)
 
 BOOL rf_auto_reconnect(rfContext* rfi)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rdpSettings* settings = rfi->instance->settings;
 	RemminaPluginRdpUiObject* ui;
 	time_t treconn;
@@ -289,7 +289,7 @@ BOOL rf_auto_reconnect(rfContext* rfi)
 
 BOOL rf_begin_paint(rdpContext* context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rdpGdi* gdi = context->gdi;
 	gdi->primary->hdc->hwnd->invalid->null = 1;
 	gdi->primary->hdc->hwnd->ninvalid = 0;
@@ -298,7 +298,7 @@ BOOL rf_begin_paint(rdpContext* context)
 
 BOOL rf_end_paint(rdpContext* context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	INT32 x, y;
 	UINT32 w, h;
 	rdpGdi* gdi;
@@ -332,7 +332,7 @@ BOOL rf_end_paint(rdpContext* context)
 
 static BOOL rf_desktop_resize(rdpContext* context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi;
 	RemminaProtocolWidget* gp;
 	RemminaPluginRdpUiObject* ui;
@@ -357,7 +357,7 @@ static BOOL rf_desktop_resize(rdpContext* context)
 
 static BOOL remmina_rdp_pre_connect(freerdp* instance)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi;
 	ALIGN64 rdpSettings* settings;
 	RemminaProtocolWidget* gp;
@@ -445,7 +445,7 @@ static UINT32 rf_get_local_color_format(rfContext* rfi, BOOL aligned)
 
 static BOOL remmina_rdp_post_connect(freerdp* instance)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi;
 	RemminaProtocolWidget* gp;
 	RemminaPluginRdpUiObject* ui;
@@ -514,7 +514,7 @@ static BOOL remmina_rdp_post_connect(freerdp* instance)
 
 static BOOL remmina_rdp_authenticate(freerdp* instance, char** username, char** password, char** domain)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *s_username, *s_password, *s_domain;
 	gint ret;
 	rfContext* rfi;
@@ -567,7 +567,7 @@ static BOOL remmina_rdp_authenticate(freerdp* instance, char** username, char** 
 static DWORD remmina_rdp_verify_certificate(freerdp* instance, const char *common_name, const char* subject,
 					    const char* issuer, const char* fingerprint, BOOL host_mismatch)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint status;
 	rfContext* rfi;
 	RemminaProtocolWidget* gp;
@@ -586,7 +586,7 @@ static DWORD remmina_rdp_verify_changed_certificate(freerdp* instance,
 						    const char* common_name, const char* subject, const char* issuer,
 						    const char* new_fingerprint, const char* old_subject, const char* old_issuer, const char* old_fingerprint)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint status;
 	rfContext* rfi;
 	RemminaProtocolWidget* gp;
@@ -604,7 +604,7 @@ static DWORD remmina_rdp_verify_changed_certificate(freerdp* instance,
 
 static void remmina_rdp_main_loop(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DWORD nCount;
 	DWORD status;
 	HANDLE handles[64];
@@ -652,7 +652,7 @@ static void remmina_rdp_main_loop(RemminaProtocolWidget* gp)
 
 int remmina_rdp_load_static_channel_addin(rdpChannels* channels, rdpSettings* settings, char* name, void* data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	void* entry;
 
 	entry = freerdp_load_channel_addin_entry(name, NULL, NULL, FREERDP_ADDIN_CHANNEL_STATIC);
@@ -669,7 +669,7 @@ int remmina_rdp_load_static_channel_addin(rdpChannels* channels, rdpSettings* se
 /* Send CTRL+ALT+DEL keys keystrokes to the plugin drawing_area widget */
 static void remmina_rdp_send_ctrlaltdel(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint keys[] = { GDK_KEY_Control_L, GDK_KEY_Alt_L, GDK_KEY_Delete };
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
@@ -679,7 +679,7 @@ static void remmina_rdp_send_ctrlaltdel(RemminaProtocolWidget *gp)
 
 static gboolean remmina_rdp_main(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar* s;
 	gchar *sm;
 	gchar* value;
@@ -1044,7 +1044,7 @@ static gboolean remmina_rdp_main(RemminaProtocolWidget* gp)
 
 static gpointer remmina_rdp_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget* gp;
 	rfContext* rfi;
 
@@ -1066,7 +1066,7 @@ static gpointer remmina_rdp_main_thread(gpointer data)
 
 static void remmina_rdp_init(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	freerdp* instance;
 	rfContext* rfi;
 
@@ -1096,7 +1096,7 @@ static void remmina_rdp_init(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_open_connection(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
 	rfi->scale = remmina_plugin_service->remmina_protocol_widget_get_current_scale_mode(gp);
@@ -1115,7 +1115,7 @@ static gboolean remmina_rdp_open_connection(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_close_connection(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	freerdp* instance;
 	RemminaPluginRdpUiObject* ui;
@@ -1183,13 +1183,13 @@ static gboolean remmina_rdp_close_connection(RemminaProtocolWidget* gp)
 
 static gboolean remmina_rdp_query_feature(RemminaProtocolWidget* gp, const RemminaProtocolFeature* feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static void remmina_rdp_call_feature(RemminaProtocolWidget* gp, const RemminaProtocolFeature* feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 
@@ -1226,7 +1226,7 @@ static void remmina_rdp_call_feature(RemminaProtocolWidget* gp, const RemminaPro
 /* Send a keystroke to the plugin window */
 static void remmina_rdp_keystroke(RemminaProtocolWidget *gp, const guint keystrokes[], const gint keylen)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfContext* rfi = GET_PLUGIN_DATA(gp);
 	remmina_plugin_service->protocol_plugin_send_keys_signals(rfi->drawing_area,
 		keystrokes, keylen, GDK_KEY_PRESS | GDK_KEY_RELEASE);
@@ -1439,7 +1439,7 @@ G_MODULE_EXPORT gboolean remmina_plugin_entry(RemminaPluginService* service)
 {
 	int vermaj, vermin, verrev;
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service = service;
 
 	/* Check that we are linked to the correct version of libfreerdp */

--- a/remmina-plugins/rdp/rdp_settings.c
+++ b/remmina-plugins/rdp/rdp_settings.c
@@ -43,13 +43,13 @@ static guint rdp_keyboard_layout = 0;
 
 static void remmina_rdp_settings_kbd_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	keyboard_layout = freerdp_keyboard_init(rdp_keyboard_layout);
 }
 
 void remmina_rdp_settings_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* value;
 
 	value = remmina_plugin_service->pref_get_value("rdp_keyboard_layout");
@@ -64,7 +64,7 @@ void remmina_rdp_settings_init(void)
 
 guint remmina_rdp_settings_get_keyboard_layout(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return keyboard_layout;
 }
 
@@ -116,12 +116,12 @@ G_DEFINE_TYPE(RemminaPluginRdpsetGrid, remmina_rdp_settings_grid, GTK_TYPE_GRID)
 
 static void remmina_rdp_settings_grid_class_init(RemminaPluginRdpsetGridClass* klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_rdp_settings_grid_destroy(GtkWidget* widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 	guint new_layout;
 	GtkTreeIter iter;
@@ -189,7 +189,7 @@ static void remmina_rdp_settings_grid_destroy(GtkWidget* widget, gpointer data)
 
 static void remmina_rdp_settings_grid_load_layout(RemminaPluginRdpsetGrid* grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	gchar* s;
 	GtkTreeIter iter;
@@ -225,7 +225,7 @@ static void remmina_rdp_settings_grid_load_layout(RemminaPluginRdpsetGrid* grid)
 
 static void remmina_rdp_settings_grid_load_devicescalefactor_combo(RemminaPluginRdpsetGrid* grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 
 	gtk_list_store_append(grid->device_scale_factor_store, &iter);
@@ -241,7 +241,7 @@ static void remmina_rdp_settings_grid_load_devicescalefactor_combo(RemminaPlugin
 
 static void remmina_rdp_settings_grid_load_desktoporientation_combo(RemminaPluginRdpsetGrid* grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 
 	gtk_list_store_append(grid->desktop_orientation_store, &iter);
@@ -258,7 +258,7 @@ static void remmina_rdp_settings_grid_load_desktoporientation_combo(RemminaPlugi
 
 static void remmina_rdp_settings_grid_load_quality(RemminaPluginRdpsetGrid* grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* value;
 	GtkTreeIter iter;
 
@@ -294,7 +294,7 @@ static void remmina_rdp_settings_grid_load_quality(RemminaPluginRdpsetGrid* grid
 
 static void remmina_rdp_settings_appscale_on_changed(GtkComboBox *widget, RemminaPluginRdpsetGrid *grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	guint i = 0;
 
@@ -314,7 +314,7 @@ static void remmina_rdp_settings_appscale_on_changed(GtkComboBox *widget, Remmin
 
 static void remmina_rdp_settings_quality_on_changed(GtkComboBox *widget, RemminaPluginRdpsetGrid *grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint v;
 	guint i = 0;
 	GtkTreeIter iter;
@@ -352,7 +352,7 @@ static void remmina_rdp_settings_quality_on_changed(GtkComboBox *widget, Remmina
 
 static void remmina_rdp_settings_quality_option_on_toggled(GtkToggleButton* togglebutton, RemminaPluginRdpsetGrid* grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint v;
 	guint i = 0;
 	GtkTreeIter iter;
@@ -399,7 +399,7 @@ static void remmina_rdp_settings_set_combo_active_item(GtkComboBox* combo, int i
 
 static void remmina_rdp_settings_grid_init(RemminaPluginRdpsetGrid *grid)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 	GtkWidget* widget;
 	GtkCellRenderer* renderer;
@@ -595,7 +595,7 @@ static void remmina_rdp_settings_grid_init(RemminaPluginRdpsetGrid *grid)
 
 GtkWidget* remmina_rdp_settings_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 
 	widget = GTK_WIDGET(g_object_new(REMMINA_TYPE_PLUGIN_RDPSET_GRID, NULL));
@@ -606,7 +606,7 @@ GtkWidget* remmina_rdp_settings_new(void)
 
 void remmina_rdp_settings_get_orientation_scale_prefs(int *desktopOrientation, int *desktopScaleFactor, int *deviceScaleFactor)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* See https://msdn.microsoft.com/en-us/library/cc240510.aspx */
 

--- a/remmina-plugins/telepathy/telepathy_channel_handler.c
+++ b/remmina-plugins/telepathy/telepathy_channel_handler.c
@@ -70,7 +70,7 @@ typedef struct _RemminaTpChannelHandler {
 
 static void remmina_tp_channel_handler_free(RemminaTpChannelHandler *chandler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (chandler->disconnect_handler) {
 		g_signal_handler_disconnect(chandler->proto_widget, chandler->disconnect_handler);
 		chandler->disconnect_handler = 0;
@@ -104,7 +104,7 @@ static void remmina_tp_channel_handler_free(RemminaTpChannelHandler *chandler)
 
 static void remmina_tp_channel_handler_channel_closed(TpChannel *channel, gpointer user_data, GObject *self)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 
 	g_print("remmina_tp_channel_handler_channel_closed: %s\n", chandler->channel_path);
@@ -113,7 +113,7 @@ static void remmina_tp_channel_handler_channel_closed(TpChannel *channel, gpoint
 
 static void remmina_tp_channel_handler_on_disconnect(GtkWidget *widget, RemminaTpChannelHandler *chandler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_print("remmina_tp_channel_handler_on_disconnect: %s\n", chandler->channel_path);
 	g_signal_handler_disconnect(widget, chandler->disconnect_handler);
 	chandler->disconnect_handler = 0;
@@ -122,7 +122,7 @@ static void remmina_tp_channel_handler_on_disconnect(GtkWidget *widget, RemminaT
 
 static void remmina_tp_channel_handler_connect(RemminaTpChannelHandler *chandler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 	gchar *s;
 
@@ -146,7 +146,7 @@ static void remmina_tp_channel_handler_connect(RemminaTpChannelHandler *chandler
 static void remmina_tp_channel_handler_get_service(TpProxy *channel, const GValue *service, const GError *error,
 						   gpointer user_data, GObject *weak_object)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 	const gchar *svc;
 
@@ -169,7 +169,7 @@ static void remmina_tp_channel_handler_get_service(TpProxy *channel, const GValu
 static void remmina_tp_channel_handler_accept(TpChannel *channel, const GValue *address, const GError *error,
 					      gpointer user_data, GObject *weak_object)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 
 	if (error != NULL) {
@@ -186,7 +186,7 @@ static void remmina_tp_channel_handler_accept(TpChannel *channel, const GValue *
 
 static void remmina_tp_channel_handler_on_response(GtkDialog *dialog, gint response_id, RemminaTpChannelHandler *chandler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GValue noop =
 	{ 0 };
 	GError *error;
@@ -209,7 +209,7 @@ static void remmina_tp_channel_handler_on_response(GtkDialog *dialog, gint respo
 static void remmina_tp_channel_handler_get_contacts(TpConnection *connection, guint n_contacts, TpContact * const *contacts,
 						    guint n_failed, const TpHandle *failed, const GError *error, gpointer user_data, GObject *weak_object)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 	TpContact *contact;
 	gchar *token;
@@ -268,7 +268,7 @@ static void remmina_tp_channel_handler_get_contacts(TpConnection *connection, gu
 
 static void remmina_tp_channel_handler_channel_ready(TpChannel *channel, const GError *channel_error, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 	TpHandle handle;
 	GError *error = NULL;
@@ -297,7 +297,7 @@ static void remmina_tp_channel_handler_channel_ready(TpChannel *channel, const G
 static void remmina_tp_channel_handler_connection_ready(TpConnection *connection, const GError *connection_error,
 							gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 	GError *error = NULL;
 
@@ -319,7 +319,7 @@ static void remmina_tp_channel_handler_connection_ready(TpConnection *connection
 
 static void remmina_tp_channel_handler_account_ready(GObject *account, GAsyncResult *res, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpChannelHandler *chandler = (RemminaTpChannelHandler*)user_data;
 	GError *error = NULL;
 
@@ -341,7 +341,7 @@ static void remmina_tp_channel_handler_account_ready(GObject *account, GAsyncRes
 void remmina_tp_channel_handler_new(const gchar *account_path, const gchar *connection_path, const gchar *channel_path,
 				    GHashTable *channel_properties, DBusGMethodInvocation *context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	TpDBusDaemon *bus;
 	TpAccount *account;
 	GError *error = NULL;

--- a/remmina-plugins/telepathy/telepathy_handler.c
+++ b/remmina-plugins/telepathy/telepathy_handler.c
@@ -55,19 +55,19 @@ G_DEFINE_TYPE_WITH_CODE(RemminaTpHandler, remmina_tp_handler, G_TYPE_OBJECT,
 
 static void remmina_tp_handler_class_init(RemminaTpHandlerClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_tp_handler_init(RemminaTpHandler *handler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_tp_handler_handle_channels(TpSvcClientHandler *handler, const char *account_path,
 					       const char *connection_path, const GPtrArray *channels, const GPtrArray *requests_satisfied,
 					       guint64 user_action_time, GHashTable *handler_info, DBusGMethodInvocation *context)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	GValueArray *array;
 
@@ -81,7 +81,7 @@ static void remmina_tp_handler_handle_channels(TpSvcClientHandler *handler, cons
 
 static void remmina_tp_handler_iface_init(gpointer g_iface, gpointer iface_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	TpSvcClientHandlerClass *klass = (TpSvcClientHandlerClass*)g_iface;
 
 #define IMPLEMENT(x) tp_svc_client_handler_implement_ ## x(klass, remmina_tp_handler_ ## x)
@@ -91,7 +91,7 @@ static void remmina_tp_handler_iface_init(gpointer g_iface, gpointer iface_data)
 
 static gboolean remmina_tp_handler_register(RemminaTpHandler *handler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	TpDBusDaemon *bus;
 	GError *error = NULL;
 
@@ -117,7 +117,7 @@ static gboolean remmina_tp_handler_register(RemminaTpHandler *handler)
 RemminaTpHandler*
 remmina_tp_handler_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaTpHandler *handler;
 
 	handler = REMMINA_TP_HANDLER(g_object_new(REMMINA_TYPE_TP_HANDLER, NULL));

--- a/remmina-plugins/telepathy/telepathy_plugin.c
+++ b/remmina-plugins/telepathy/telepathy_plugin.c
@@ -43,7 +43,7 @@ static RemminaTpHandler *remmina_tp_handler = NULL;
 
 void remmina_plugin_telepathy_entry(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (remmina_tp_handler == NULL) {
 		remmina_tp_handler = remmina_tp_handler_new();
 	}
@@ -63,7 +63,7 @@ static RemminaEntryPlugin remmina_plugin_telepathy =
 G_MODULE_EXPORT gboolean
 remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_telepathy_service = service;
 
 	bindtextdomain(GETTEXT_PACKAGE, REMMINA_RUNTIME_LOCALEDIR);

--- a/remmina-plugins/tool_hello_world/plugin.c
+++ b/remmina-plugins/tool_hello_world/plugin.c
@@ -47,13 +47,13 @@ static RemminaPluginService *remmina_plugin_service = NULL;
 
 static void remmina_plugin_tool_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service->log_printf("[%s] Plugin init\n", PLUGIN_NAME);
 }
 
 static gboolean remmina_plugin_tool_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service->log_printf("[%s] Plugin open connection\n", PLUGIN_NAME);
 
 	GtkDialog *dialog;
@@ -66,7 +66,7 @@ static gboolean remmina_plugin_tool_open_connection(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_tool_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service->log_printf("[%s] Plugin close connection\n", PLUGIN_NAME);
 	remmina_plugin_service->protocol_plugin_emit_signal(gp, "disconnect");
 	return FALSE;
@@ -109,7 +109,7 @@ static RemminaProtocolPlugin remmina_plugin = {
 
 G_MODULE_EXPORT gboolean remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service = service;
 
 	bindtextdomain(GETTEXT_PACKAGE, REMMINA_RUNTIME_LOCALEDIR);

--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -149,7 +149,7 @@ struct onMainThread_cb_data {
 
 static gboolean onMainThread_cb(struct onMainThread_cb_data *d)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if ( !d->cancelled ) {
 		switch ( d->func ) {
 		case FUNC_UPDATE_SCALE:
@@ -167,7 +167,7 @@ static gboolean onMainThread_cb(struct onMainThread_cb_data *d)
 
 static void onMainThread_cleanup_handler( gpointer data )
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct onMainThread_cb_data *d = data;
 	d->cancelled = TRUE;
 }
@@ -175,7 +175,7 @@ static void onMainThread_cleanup_handler( gpointer data )
 
 static void onMainThread_schedule_callback_and_wait( struct onMainThread_cb_data *d )
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	d->cancelled = FALSE;
 	pthread_cleanup_push( onMainThread_cleanup_handler, d );
 	pthread_mutex_init( &d->mu, NULL );
@@ -191,7 +191,7 @@ static void onMainThread_schedule_callback_and_wait( struct onMainThread_cb_data
 
 static void remmina_plugin_vnc_event_push(RemminaProtocolWidget *gp, gint event_type, gpointer p1, gpointer p2, gpointer p3)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaPluginVncEvent *event;
 
@@ -226,7 +226,7 @@ static void remmina_plugin_vnc_event_push(RemminaProtocolWidget *gp, gint event_
 
 static void remmina_plugin_vnc_event_free(RemminaPluginVncEvent *event)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (event->event_type) {
 	case REMMINA_PLUGIN_VNC_EVENT_CUTTEXT:
 	case REMMINA_PLUGIN_VNC_EVENT_CHAT_SEND:
@@ -240,7 +240,7 @@ static void remmina_plugin_vnc_event_free(RemminaPluginVncEvent *event)
 
 static void remmina_plugin_vnc_event_free_all(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaPluginVncEvent *event;
 
@@ -253,7 +253,7 @@ static void remmina_plugin_vnc_event_free_all(RemminaProtocolWidget *gp)
 
 static void remmina_plugin_vnc_scale_area(RemminaProtocolWidget *gp, gint *x, gint *y, gint *w, gint *h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	GtkAllocation widget_allocation;
 	gint width, height;
@@ -284,7 +284,7 @@ static void remmina_plugin_vnc_scale_area(RemminaProtocolWidget *gp, gint *x, gi
 
 static void remmina_plugin_vnc_update_scale(RemminaProtocolWidget *gp, gboolean scale)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* This function can be called from a non main thread */
 
 	RemminaPluginVncData *gpdata;
@@ -318,7 +318,7 @@ static void remmina_plugin_vnc_update_scale(RemminaProtocolWidget *gp, gboolean 
 
 gboolean remmina_plugin_vnc_setcursor(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	GdkCursor *cur;
 
@@ -342,7 +342,7 @@ gboolean remmina_plugin_vnc_setcursor(RemminaProtocolWidget *gp)
 
 static void remmina_plugin_vnc_queuecursor(RemminaProtocolWidget *gp, cairo_surface_t *surface, gint x, gint y)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (gpdata->queuecursor_surface) {
@@ -384,7 +384,7 @@ static RemminaPluginVncEvent *remmina_plugin_vnc_event_queue_pop_head(RemminaPlu
 
 static void remmina_plugin_vnc_process_vnc_event(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncEvent *event;
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	rfbClient *cl;
@@ -431,7 +431,7 @@ typedef struct _RemminaPluginVncCuttextParam {
 
 static void remmina_plugin_vnc_update_quality(rfbClient *cl, gint quality)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (quality) {
 	case 9:
 		cl->appData.useBGR233 = 0;
@@ -463,7 +463,7 @@ static void remmina_plugin_vnc_update_quality(rfbClient *cl, gint quality)
 
 static void remmina_plugin_vnc_update_colordepth(rfbClient *cl, gint colordepth)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	cl->format.depth = colordepth;
 	cl->format.bigEndian = 0;
 	cl->appData.requestedDepth = colordepth;
@@ -516,7 +516,7 @@ static void remmina_plugin_vnc_update_colordepth(rfbClient *cl, gint colordepth)
 
 static rfbBool remmina_plugin_vnc_rfb_allocfb(rfbClient *cl)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = rfbClientGetClientData(cl, NULL);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	gint width, height, depth, size;
@@ -565,7 +565,7 @@ static rfbBool remmina_plugin_vnc_rfb_allocfb(rfbClient *cl)
 
 static gint remmina_plugin_vnc_bits(gint n)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint b = 0;
 	while (n) {
 		b++;
@@ -576,7 +576,7 @@ static gint remmina_plugin_vnc_bits(gint n)
 
 static gboolean remmina_plugin_vnc_queue_draw_area_real(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	gint x, y, w, h;
 
@@ -596,7 +596,7 @@ static gboolean remmina_plugin_vnc_queue_draw_area_real(RemminaProtocolWidget *g
 
 static void remmina_plugin_vnc_queue_draw_area(RemminaProtocolWidget *gp, gint x, gint y, gint w, gint h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	gint nx2, ny2, ox2, oy2;
 
@@ -623,7 +623,7 @@ static void remmina_plugin_vnc_queue_draw_area(RemminaProtocolWidget *gp, gint x
 static void remmina_plugin_vnc_rfb_fill_buffer(rfbClient* cl, guchar *dest, gint dest_rowstride, guchar *src,
 					       gint src_rowstride, guchar *mask, gint w, gint h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar *srcptr;
 	gint bytesPerPixel;
 	guint32 src_pixel;
@@ -708,7 +708,7 @@ static void remmina_plugin_vnc_rfb_fill_buffer(rfbClient* cl, guchar *dest, gint
 
 static void remmina_plugin_vnc_rfb_updatefb(rfbClient* cl, int x, int y, int w, int h)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = rfbClientGetClientData(cl, NULL);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	gint bytesPerPixel;
@@ -739,7 +739,7 @@ static void remmina_plugin_vnc_rfb_updatefb(rfbClient* cl, int x, int y, int w, 
 
 static gboolean remmina_plugin_vnc_queue_cuttext(RemminaPluginVncCuttextParam *param)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = param->gp;
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	GTimeVal t;
@@ -769,7 +769,7 @@ static gboolean remmina_plugin_vnc_queue_cuttext(RemminaPluginVncCuttextParam *p
 
 static void remmina_plugin_vnc_rfb_cuttext(rfbClient* cl, const char *text, int textlen)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncCuttextParam *param;
 
 	param = g_new(RemminaPluginVncCuttextParam, 1);
@@ -783,7 +783,7 @@ static void remmina_plugin_vnc_rfb_cuttext(rfbClient* cl, const char *text, int 
 static char*
 remmina_plugin_vnc_rfb_password(rfbClient *cl)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = rfbClientGetClientData(cl, NULL);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
@@ -813,7 +813,7 @@ remmina_plugin_vnc_rfb_password(rfbClient *cl)
 static rfbCredential*
 remmina_plugin_vnc_rfb_credential(rfbClient *cl, int credentialType)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	rfbCredential *cred;
 	RemminaProtocolWidget *gp = rfbClientGetClientData(cl, NULL);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
@@ -891,7 +891,7 @@ remmina_plugin_vnc_rfb_credential(rfbClient *cl, int credentialType)
 
 static void remmina_plugin_vnc_rfb_cursor_shape(rfbClient *cl, int xhot, int yhot, int width, int height, int bytesPerPixel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = rfbClientGetClientData(cl, NULL);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	int stride;
@@ -924,7 +924,7 @@ static void remmina_plugin_vnc_rfb_cursor_shape(rfbClient *cl, int xhot, int yho
 
 static void remmina_plugin_vnc_rfb_bell(rfbClient *cl)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp;
 	GdkWindow *window;
 
@@ -949,7 +949,7 @@ static gboolean vnc_encryption_disable_requested;
 
 static void remmina_plugin_vnc_rfb_output(const char *format, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 	va_start(args, format);
 	gchar *f, *p, *ff;
@@ -983,7 +983,7 @@ static void remmina_plugin_vnc_rfb_output(const char *format, ...)
 
 static void remmina_plugin_vnc_chat_on_send(RemminaProtocolWidget *gp, const gchar *text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *ptr;
 
 	/* Need to add a line-feed for UltraVNC */
@@ -994,14 +994,14 @@ static void remmina_plugin_vnc_chat_on_send(RemminaProtocolWidget *gp, const gch
 
 static void remmina_plugin_vnc_chat_on_destroy(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_vnc_event_push(gp, REMMINA_PLUGIN_VNC_EVENT_CHAT_CLOSE, NULL, NULL, NULL);
 }
 
 /* Send CTRL+ALT+DEL keys keystrokes to the plugin drawing_area widget */
 static void remmina_plugin_vnc_send_ctrlaltdel(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint keys[] = { GDK_KEY_Control_L, GDK_KEY_Alt_L, GDK_KEY_Delete };
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 
@@ -1011,14 +1011,14 @@ static void remmina_plugin_vnc_send_ctrlaltdel(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_vnc_close_chat(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service->protocol_plugin_chat_close(gp);
 	return FALSE;
 }
 
 static gboolean remmina_plugin_vnc_open_chat(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	rfbClient *cl;
 
@@ -1032,7 +1032,7 @@ static gboolean remmina_plugin_vnc_open_chat(RemminaProtocolWidget *gp)
 
 static void remmina_plugin_vnc_rfb_chat(rfbClient* cl, int value, char *text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp;
 
 	gp = (RemminaProtocolWidget*)(rfbClientGetClientData(cl, NULL));
@@ -1055,7 +1055,7 @@ static void remmina_plugin_vnc_rfb_chat(rfbClient* cl, int value, char *text)
 
 static gboolean remmina_plugin_vnc_incoming_connection(RemminaProtocolWidget *gp, rfbClient *cl)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	fd_set fds;
 
@@ -1089,7 +1089,7 @@ static gboolean remmina_plugin_vnc_incoming_connection(RemminaProtocolWidget *gp
 
 static gboolean remmina_plugin_vnc_main_loop(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	gint ret;
 	gint i;
@@ -1137,7 +1137,7 @@ static gboolean remmina_plugin_vnc_main_loop(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_vnc_main(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	rfbClient *cl = NULL;
@@ -1288,7 +1288,7 @@ static gboolean remmina_plugin_vnc_main(RemminaProtocolWidget *gp)
 static gpointer
 remmina_plugin_vnc_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
 	CANCEL_ASYNC
@@ -1316,7 +1316,7 @@ static RemminaPluginVncCoordinates remmina_plugin_vnc_scale_coordinates(GtkWidge
 
 static gboolean remmina_plugin_vnc_on_motion(GtkWidget *widget, GdkEventMotion *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	RemminaPluginVncCoordinates coordinates;
@@ -1335,7 +1335,7 @@ static gboolean remmina_plugin_vnc_on_motion(GtkWidget *widget, GdkEventMotion *
 
 static gboolean remmina_plugin_vnc_on_button(GtkWidget *widget, GdkEventButton *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	RemminaPluginVncCoordinates coordinates;
@@ -1366,7 +1366,7 @@ static gboolean remmina_plugin_vnc_on_button(GtkWidget *widget, GdkEventButton *
 
 static gboolean remmina_plugin_vnc_on_scroll(GtkWidget *widget, GdkEventScroll *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	RemminaPluginVncCoordinates coordinates;
@@ -1420,7 +1420,7 @@ static gboolean remmina_plugin_vnc_on_scroll(GtkWidget *widget, GdkEventScroll *
 
 static void remmina_plugin_vnc_release_key(RemminaProtocolWidget *gp, guint16 keycode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaKeyVal *k;
 	gint i;
@@ -1449,7 +1449,7 @@ static void remmina_plugin_vnc_release_key(RemminaProtocolWidget *gp, guint16 ke
 
 static gboolean remmina_plugin_vnc_on_key(GtkWidget *widget, GdkEventKey *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	RemminaKeyVal *k;
@@ -1497,7 +1497,7 @@ static gboolean remmina_plugin_vnc_on_key(GtkWidget *widget, GdkEventKey *event,
 
 static void remmina_plugin_vnc_on_cuttext_request(GtkClipboard *clipboard, const gchar *text, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	GTimeVal t;
 	glong diff;
@@ -1525,7 +1525,7 @@ static void remmina_plugin_vnc_on_cuttext_request(GtkClipboard *clipboard, const
 
 static void remmina_plugin_vnc_on_cuttext(GtkClipboard *clipboard, GdkEvent *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -1540,7 +1540,7 @@ static void remmina_plugin_vnc_on_cuttext(GtkClipboard *clipboard, GdkEvent *eve
 
 static void remmina_plugin_vnc_on_realize(RemminaProtocolWidget *gp, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 	GdkCursor *cursor;
 	GdkPixbuf *pixbuf;
@@ -1561,7 +1561,7 @@ static void remmina_plugin_vnc_on_realize(RemminaProtocolWidget *gp, gpointer da
 
 static gboolean remmina_plugin_vnc_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -1597,7 +1597,7 @@ static gboolean remmina_plugin_vnc_open_connection(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_vnc_close_connection_timeout(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 
 	/* wait until the running attribute is set to false by the VNC thread */
@@ -1656,7 +1656,7 @@ static gboolean remmina_plugin_vnc_close_connection_timeout(RemminaProtocolWidge
 
 static gboolean remmina_plugin_vnc_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 
 	gpdata->connected = FALSE;
@@ -1675,7 +1675,7 @@ static gboolean remmina_plugin_vnc_close_connection(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_vnc_query_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 
 	switch (feature->id) {
@@ -1690,7 +1690,7 @@ static gboolean remmina_plugin_vnc_query_feature(RemminaProtocolWidget *gp, cons
 
 static void remmina_plugin_vnc_call_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -1734,7 +1734,7 @@ static void remmina_plugin_vnc_call_feature(RemminaProtocolWidget *gp, const Rem
 /* Send a keystroke to the plugin window */
 static void remmina_plugin_vnc_keystroke(RemminaProtocolWidget *gp, const guint keystrokes[], const gint keylen)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	remmina_plugin_service->protocol_plugin_send_keys_signals(gpdata->drawing_area,
 		keystrokes, keylen, GDK_KEY_PRESS | GDK_KEY_RELEASE);
@@ -1743,7 +1743,7 @@ static void remmina_plugin_vnc_keystroke(RemminaProtocolWidget *gp, const guint 
 
 static gboolean remmina_plugin_vnc_on_draw(GtkWidget *widget, cairo_t *context, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata = GET_PLUGIN_DATA(gp);
 	cairo_surface_t *surface;
 	gint width, height;
@@ -1777,7 +1777,7 @@ static gboolean remmina_plugin_vnc_on_draw(GtkWidget *widget, cairo_t *context, 
 
 static void remmina_plugin_vnc_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginVncData *gpdata;
 	gint flags;
 
@@ -1962,7 +1962,7 @@ static RemminaProtocolPlugin remmina_plugin_vnci =
 G_MODULE_EXPORT gboolean
 remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service = service;
 
 	bindtextdomain(GETTEXT_PACKAGE, REMMINA_RUNTIME_LOCALEDIR);

--- a/remmina-plugins/xdmcp/xdmcp_plugin.c
+++ b/remmina-plugins/xdmcp/xdmcp_plugin.c
@@ -66,7 +66,7 @@ static RemminaPluginService *remmina_plugin_service = NULL;
 
 static void remmina_plugin_xdmcp_on_plug_added(GtkSocket *socket, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 
 	remmina_plugin_service->protocol_plugin_emit_signal(gp, "connect");
@@ -75,13 +75,13 @@ static void remmina_plugin_xdmcp_on_plug_added(GtkSocket *socket, RemminaProtoco
 
 static void remmina_plugin_xdmcp_on_plug_removed(GtkSocket *socket, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service->protocol_plugin_close_connection(gp);
 }
 
 static gboolean remmina_plugin_xdmcp_start_xephyr(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	gchar *argv[50];
@@ -175,7 +175,7 @@ static gboolean remmina_plugin_xdmcp_start_xephyr(RemminaProtocolWidget *gp)
 static gboolean remmina_plugin_xdmcp_tunnel_init_callback(RemminaProtocolWidget *gp, gint remotedisplay, const gchar *server,
 							  gint port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -199,7 +199,7 @@ static gboolean remmina_plugin_xdmcp_tunnel_init_callback(RemminaProtocolWidget 
 
 static gboolean remmina_plugin_xdmcp_main(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -224,7 +224,7 @@ static gboolean remmina_plugin_xdmcp_main(RemminaProtocolWidget *gp)
 static gpointer
 remmina_plugin_xdmcp_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
 
 	CANCEL_ASYNC
@@ -236,7 +236,7 @@ remmina_plugin_xdmcp_main_thread(gpointer data)
 
 static void remmina_plugin_xdmcp_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata;
 
 	gpdata = g_new0(RemminaPluginXdmcpData, 1);
@@ -255,7 +255,7 @@ static void remmina_plugin_xdmcp_init(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_xdmcp_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 	gint width, height;
@@ -294,7 +294,7 @@ static gboolean remmina_plugin_xdmcp_open_connection(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_xdmcp_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (gpdata->thread) {
@@ -316,7 +316,7 @@ static gboolean remmina_plugin_xdmcp_close_connection(RemminaProtocolWidget *gp)
 /* Send CTRL+ALT+DEL keys keystrokes to the plugin socket widget */
 static void remmina_plugin_xdmcp_send_ctrlaltdel(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint keys[] = { GDK_KEY_Control_L, GDK_KEY_Alt_L, GDK_KEY_Delete };
 	RemminaPluginXdmcpData *gpdata = GET_PLUGIN_DATA(gp);
 
@@ -326,13 +326,13 @@ static void remmina_plugin_xdmcp_send_ctrlaltdel(RemminaProtocolWidget *gp)
 
 static gboolean remmina_plugin_xdmcp_query_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static void remmina_plugin_xdmcp_call_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	remminafile = remmina_plugin_service->protocol_plugin_get_file(gp);
@@ -411,7 +411,7 @@ static RemminaProtocolPlugin remmina_plugin_xdmcp =
 G_MODULE_EXPORT gboolean
 remmina_plugin_entry(RemminaPluginService *service)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service = service;
 
 	bindtextdomain(GETTEXT_PACKAGE, REMMINA_RUNTIME_LOCALEDIR);

--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -103,7 +103,7 @@ _gpg_error_to_errno(gcry_error_t e)
 
 static gint remmina_on_command_line(GApplication *app, GApplicationCommandLine *cmdline)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	gint status = 0;
 	gboolean executed = FALSE;
@@ -186,7 +186,7 @@ static gint remmina_on_command_line(GApplication *app, GApplicationCommandLine *
 
 static void remmina_on_startup(GApplication *app)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_file_manager_init();
 	remmina_pref_init();
 	remmina_plugin_manager_init();
@@ -205,7 +205,7 @@ static void remmina_on_startup(GApplication *app)
 
 static gint remmina_on_local_cmdline(GApplication *app, GVariantDict *options, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	int status = -1;
 
@@ -217,7 +217,7 @@ static gint remmina_on_local_cmdline(GApplication *app, GVariantDict *options, g
 
 int main(int argc, char* argv[])
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkApplication *app;
 	const gchar *app_id;
 	int status;

--- a/remmina/src/remmina_about.c
+++ b/remmina/src/remmina_about.c
@@ -44,7 +44,7 @@
 /* Show the about dialog from the file ui/remmina_about.glade */
 void remmina_about_open(GtkWindow *parent)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	static gchar version[32];
 
 	g_snprintf(version, sizeof(version), "%s (git %s)", VERSION, REMMINA_GIT_REVISION);

--- a/remmina/src/remmina_applet_menu.c
+++ b/remmina/src/remmina_applet_menu.c
@@ -61,13 +61,13 @@ static guint remmina_applet_menu_signals[LAST_SIGNAL] =
 
 static void remmina_applet_menu_destroy(RemminaAppletMenu *menu, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_free(menu->priv);
 }
 
 static void remmina_applet_menu_class_init(RemminaAppletMenuClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_applet_menu_signals[LAUNCH_ITEM_SIGNAL] = g_signal_new("launch-item", G_TYPE_FROM_CLASS(klass),
 		G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(RemminaAppletMenuClass, launch_item), NULL, NULL,
 		g_cclosure_marshal_VOID__OBJECT, G_TYPE_NONE, 1, G_TYPE_OBJECT);
@@ -78,7 +78,7 @@ static void remmina_applet_menu_class_init(RemminaAppletMenuClass *klass)
 
 static void remmina_applet_menu_init(RemminaAppletMenu *menu)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	menu->priv = g_new0(RemminaAppletMenuPriv, 1);
 
 	g_signal_connect(G_OBJECT(menu), "destroy", G_CALLBACK(remmina_applet_menu_destroy), NULL);
@@ -86,7 +86,7 @@ static void remmina_applet_menu_init(RemminaAppletMenu *menu)
 
 static void remmina_applet_menu_on_item_activate(RemminaAppletMenuItem *menuitem, RemminaAppletMenu *menu)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_signal_emit(G_OBJECT(menu), remmina_applet_menu_signals[LAUNCH_ITEM_SIGNAL], 0, menuitem);
 }
 
@@ -94,7 +94,7 @@ static GtkWidget*
 remmina_applet_menu_add_group(GtkWidget *menu, const gchar *group, gint position, RemminaAppletMenuItem *menuitem,
 			      GtkWidget **groupmenuitem)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	GtkWidget *submenu;
 
@@ -121,7 +121,7 @@ remmina_applet_menu_add_group(GtkWidget *menu, const gchar *group, gint position
 
 static void remmina_applet_menu_increase_group_count(GtkWidget *widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint cnt;
 	gchar *s;
 
@@ -134,13 +134,13 @@ static void remmina_applet_menu_increase_group_count(GtkWidget *widget)
 
 void remmina_applet_menu_register_item(RemminaAppletMenu *menu, RemminaAppletMenuItem *menuitem)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_signal_connect(G_OBJECT(menuitem), "activate", G_CALLBACK(remmina_applet_menu_on_item_activate), menu);
 }
 
 void remmina_applet_menu_add_item(RemminaAppletMenu *menu, RemminaAppletMenuItem *menuitem)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *submenu;
 	GtkWidget *groupmenuitem;
 	GtkMenuItem *submenuitem;
@@ -226,7 +226,7 @@ void remmina_applet_menu_add_item(RemminaAppletMenu *menu, RemminaAppletMenuItem
 GtkWidget*
 remmina_applet_menu_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaAppletMenu *menu;
 
 	menu = REMMINA_APPLET_MENU(g_object_new(REMMINA_TYPE_APPLET_MENU, NULL));
@@ -236,13 +236,13 @@ remmina_applet_menu_new(void)
 
 void remmina_applet_menu_set_hide_count(RemminaAppletMenu *menu, gboolean hide_count)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	menu->priv->hide_count = hide_count;
 }
 
 void remmina_applet_menu_populate(RemminaAppletMenu *menu)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menuitem;
 	gchar filename[MAX_PATH_LEN];
 	GDir *dir;

--- a/remmina/src/remmina_applet_menu_item.c
+++ b/remmina/src/remmina_applet_menu_item.c
@@ -48,7 +48,7 @@ G_DEFINE_TYPE( RemminaAppletMenuItem, remmina_applet_menu_item, GTK_TYPE_MENU_IT
 
 static void remmina_applet_menu_item_destroy(RemminaAppletMenuItem* item, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_free(item->filename);
 	g_free(item->name);
 	g_free(item->group);
@@ -58,12 +58,12 @@ static void remmina_applet_menu_item_destroy(RemminaAppletMenuItem* item, gpoint
 
 static void remmina_applet_menu_item_class_init(RemminaAppletMenuItemClass* klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_applet_menu_item_init(RemminaAppletMenuItem* item)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	item->filename = NULL;
 	item->name = NULL;
 	item->group = NULL;
@@ -75,7 +75,7 @@ static void remmina_applet_menu_item_init(RemminaAppletMenuItem* item)
 
 GtkWidget* remmina_applet_menu_item_new(RemminaAppletMenuItemType item_type, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list ap;
 	RemminaAppletMenuItem* item;
 	GKeyFile* gkeyfile;
@@ -145,7 +145,7 @@ GtkWidget* remmina_applet_menu_item_new(RemminaAppletMenuItemType item_type, ...
 
 gint remmina_applet_menu_item_compare(gconstpointer a, gconstpointer b, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint cmp;
 	RemminaAppletMenuItem* itema;
 	RemminaAppletMenuItem* itemb;

--- a/remmina/src/remmina_avahi.c
+++ b/remmina/src/remmina_avahi.c
@@ -71,7 +71,7 @@ remmina_avahi_resolve_callback(
 	AvahiLookupResultFlags flags,
 	AVAHI_GCC_UNUSED void* userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* key;
 	gchar* value;
 	RemminaAvahi* ga = (RemminaAvahi*)userdata;
@@ -116,7 +116,7 @@ remmina_avahi_browse_callback(
 	AVAHI_GCC_UNUSED AvahiLookupResultFlags flags,
 	void* userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* key;
 	RemminaAvahi* ga = (RemminaAvahi*)userdata;
 
@@ -162,7 +162,7 @@ remmina_avahi_browse_callback(
 
 static void remmina_avahi_client_callback(AvahiClient* c, AvahiClientState state, AVAHI_GCC_UNUSED void * userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaAvahi* ga = (RemminaAvahi*)userdata;
 
 	ga->priv->has_event = TRUE;
@@ -174,7 +174,7 @@ static void remmina_avahi_client_callback(AvahiClient* c, AvahiClientState state
 
 static gboolean remmina_avahi_iterate(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	while (TRUE) {
 		/* Call the iteration until no further events */
 		ga->priv->has_event = FALSE;
@@ -188,7 +188,7 @@ static gboolean remmina_avahi_iterate(RemminaAvahi* ga)
 
 RemminaAvahi* remmina_avahi_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaAvahi* ga;
 
 	ga = g_new(RemminaAvahi, 1);
@@ -206,7 +206,7 @@ RemminaAvahi* remmina_avahi_new(void)
 
 void remmina_avahi_start(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int error;
 
 	if (ga->started)
@@ -240,7 +240,7 @@ void remmina_avahi_start(RemminaAvahi* ga)
 
 void remmina_avahi_stop(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_hash_table_remove_all(ga->discovered_services);
 	if (ga->priv->iterate_handler) {
 		g_source_remove(ga->priv->iterate_handler);
@@ -263,7 +263,7 @@ void remmina_avahi_stop(RemminaAvahi* ga)
 
 void remmina_avahi_free(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (ga == NULL)
 		return;
 
@@ -278,23 +278,23 @@ void remmina_avahi_free(RemminaAvahi* ga)
 
 RemminaAvahi* remmina_avahi_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return NULL;
 }
 
 void remmina_avahi_start(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 void remmina_avahi_stop(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 void remmina_avahi_free(RemminaAvahi* ga)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 #endif

--- a/remmina/src/remmina_chat_window.c
+++ b/remmina/src/remmina_chat_window.c
@@ -51,7 +51,7 @@ static guint remmina_chat_window_signals[LAST_SIGNAL] = { 0 };
 
 static void remmina_chat_window_class_init(RemminaChatWindowClass* klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_chat_window_signals[SEND_SIGNAL] = g_signal_new("send", G_TYPE_FROM_CLASS(klass),
 		G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(RemminaChatWindowClass, send), NULL, NULL,
 		g_cclosure_marshal_VOID__STRING, G_TYPE_NONE, 1, G_TYPE_STRING);
@@ -59,14 +59,14 @@ static void remmina_chat_window_class_init(RemminaChatWindowClass* klass)
 
 static void remmina_chat_window_init(RemminaChatWindow* window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	window->history_text = NULL;
 	window->send_text = NULL;
 }
 
 static void remmina_chat_window_clear_send_text(GtkWidget* widget, RemminaChatWindow* window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextBuffer* buffer;
 
 	buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(window->send_text));
@@ -76,7 +76,7 @@ static void remmina_chat_window_clear_send_text(GtkWidget* widget, RemminaChatWi
 
 static gboolean remmina_chat_window_scroll_proc(RemminaChatWindow* window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextBuffer* buffer;
 	GtkTextIter iter;
 
@@ -90,7 +90,7 @@ static gboolean remmina_chat_window_scroll_proc(RemminaChatWindow* window)
 static void remmina_chat_window_append_text(RemminaChatWindow* window, const gchar* name, const gchar* tagname,
 					    const gchar* text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextBuffer* buffer;
 	GtkTextIter iter;
 	gchar* ptr;
@@ -125,7 +125,7 @@ static void remmina_chat_window_append_text(RemminaChatWindow* window, const gch
 
 static void remmina_chat_window_send(GtkWidget* widget, RemminaChatWindow* window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextBuffer* buffer;
 	GtkTextIter start, end;
 	gchar* text;
@@ -148,7 +148,7 @@ static void remmina_chat_window_send(GtkWidget* widget, RemminaChatWindow* windo
 
 static gboolean remmina_chat_window_send_text_on_key(GtkWidget* widget, GdkEventKey* event, RemminaChatWindow* window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (event->keyval == GDK_KEY_Return) {
 		remmina_chat_window_send(widget, window);
 		return TRUE;
@@ -159,7 +159,7 @@ static gboolean remmina_chat_window_send_text_on_key(GtkWidget* widget, GdkEvent
 GtkWidget*
 remmina_chat_window_new(GtkWindow* parent, const gchar* chat_with)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaChatWindow* window;
 	gchar buf[100];
 	GtkWidget* grid;
@@ -250,7 +250,7 @@ remmina_chat_window_new(GtkWindow* parent, const gchar* chat_with)
 
 void remmina_chat_window_receive(RemminaChatWindow* window, const gchar* name, const gchar* text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_chat_window_append_text(window, name, "receiver-foreground", text);
 }
 

--- a/remmina/src/remmina_connection_window.c
+++ b/remmina/src/remmina_connection_window.c
@@ -224,7 +224,7 @@ static const GtkTargetEntry dnd_targets_tb[] =
 
 static void remmina_connection_window_class_init(RemminaConnectionWindowClass* klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkCssProvider  *provider;
 
 	provider = gtk_css_provider_new();
@@ -391,7 +391,7 @@ static RemminaScaleMode get_current_allowed_scale_mode(RemminaConnectionObject* 
 
 static void remmina_connection_holder_disconnect_current_page(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 
 	/* Disconnects the connection which is currently in view in the notebook */
@@ -401,7 +401,7 @@ static void remmina_connection_holder_disconnect_current_page(RemminaConnectionH
 
 static void remmina_connection_holder_keyboard_ungrab(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkDisplay *display;
 #if GTK_CHECK_VERSION(3, 20, 0)
 	GdkSeat *seat;
@@ -444,7 +444,7 @@ static void remmina_connection_holder_keyboard_ungrab(RemminaConnectionHolder* c
 
 static void remmina_connection_holder_keyboard_grab(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	GdkDisplay *display;
 #if GTK_CHECK_VERSION(3, 20, 0)
@@ -515,7 +515,7 @@ static void remmina_connection_window_close_all_connections(RemminaConnectionWin
 
 gboolean remmina_connection_window_delete(RemminaConnectionWindow* cnnwin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnwin->priv;
 	RemminaConnectionHolder *cnnhld = cnnwin->priv->cnnhld;
 	GtkNotebook* notebook = GTK_NOTEBOOK(priv->notebook);
@@ -551,14 +551,14 @@ gboolean remmina_connection_window_delete(RemminaConnectionWindow* cnnwin)
 
 static gboolean remmina_connection_window_delete_event(GtkWidget* widget, GdkEvent* event, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_connection_window_delete(REMMINA_CONNECTION_WINDOW(widget));
 	return TRUE;
 }
 
 static void remmina_connection_window_destroy(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = REMMINA_CONNECTION_WINDOW(widget)->priv;
 
 	if (priv->kbcaptured)
@@ -606,7 +606,7 @@ static void remmina_connection_window_destroy(GtkWidget* widget, RemminaConnecti
 
 gboolean remmina_connection_window_notify_widget_toolbar_placement(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GType rcwtype;
 	rcwtype = remmina_connection_window_get_type();
 	if (G_TYPE_CHECK_INSTANCE_TYPE(widget, rcwtype)) {
@@ -619,7 +619,7 @@ gboolean remmina_connection_window_notify_widget_toolbar_placement(GtkWidget *wi
 static gboolean remmina_connection_window_tb_drag_failed(GtkWidget *widget, GdkDragContext *context,
 							 GtkDragResult result, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionHolder* cnnhld;
 	RemminaConnectionWindowPriv* priv;
 
@@ -635,7 +635,7 @@ static gboolean remmina_connection_window_tb_drag_failed(GtkWidget *widget, GdkD
 static gboolean remmina_connection_window_tb_drag_drop(GtkWidget *widget, GdkDragContext *context,
 						       gint x, gint y, guint time, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkAllocation wa;
 	gint new_toolbar_placement;
 	RemminaConnectionHolder* cnnhld;
@@ -678,7 +678,7 @@ static gboolean remmina_connection_window_tb_drag_drop(GtkWidget *widget, GdkDra
 
 static void remmina_connection_window_tb_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaConnectionHolder* cnnhld;
 	RemminaConnectionWindowPriv* priv;
@@ -709,7 +709,7 @@ static void remmina_connection_window_tb_drag_begin(GtkWidget *widget, GdkDragCo
 
 static void remmina_connection_holder_update_toolbar_opacity(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
@@ -734,7 +734,7 @@ static void remmina_connection_holder_update_toolbar_opacity(RemminaConnectionHo
 #if !FLOATING_TOOLBAR_WIDGET
 static gboolean remmina_connection_holder_floating_toolbar_motion(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
@@ -788,7 +788,7 @@ static gboolean remmina_connection_holder_floating_toolbar_motion(RemminaConnect
 
 static void remmina_connection_holder_floating_toolbar_update(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	if (priv->floating_toolbar_motion_show || priv->floating_toolbar_motion_visible) {
@@ -808,7 +808,7 @@ static void remmina_connection_holder_floating_toolbar_update(RemminaConnectionH
 #if FLOATING_TOOLBAR_WIDGET
 static gboolean remmina_connection_holder_floating_toolbar_make_invisible(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = (RemminaConnectionWindowPriv*)data;
 	gtk_widget_set_opacity(GTK_WIDGET(priv->overlay_ftb_overlay), 0.0);
 	priv->ftb_hide_eventsource = 0;
@@ -818,7 +818,7 @@ static gboolean remmina_connection_holder_floating_toolbar_make_invisible(gpoint
 
 static void remmina_connection_holder_floating_toolbar_show(RemminaConnectionHolder* cnnhld, gboolean show)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 #if FLOATING_TOOLBAR_WIDGET
@@ -856,7 +856,7 @@ static void remmina_connection_holder_floating_toolbar_show(RemminaConnectionHol
 
 static void remmina_connection_holder_floating_toolbar_visible(RemminaConnectionHolder* cnnhld, gboolean visible)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #if !FLOATING_TOOLBAR_WIDGET
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
@@ -871,7 +871,7 @@ static void remmina_connection_holder_floating_toolbar_visible(RemminaConnection
 
 static void remmina_connection_holder_get_desktop_size(RemminaConnectionHolder* cnnhld, gint* width, gint* height)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaProtocolWidget* gp = REMMINA_PROTOCOL_WIDGET(cnnobj->proto);
 
@@ -882,7 +882,7 @@ static void remmina_connection_holder_get_desktop_size(RemminaConnectionHolder* 
 
 static void remmina_connection_object_set_scrolled_policy(RemminaConnectionObject* cnnobj, GtkScrolledWindow* scrolled_window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaScaleMode scalemode;
 	scalemode = get_current_allowed_scale_mode(cnnobj, NULL, NULL);
 	gtk_scrolled_window_set_policy(scrolled_window,
@@ -892,7 +892,7 @@ static void remmina_connection_object_set_scrolled_policy(RemminaConnectionObjec
 
 static gboolean remmina_connection_holder_toolbar_autofit_restore(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ_WITH_RETURN(FALSE)
 	RemminaConnectionWindowPriv * priv = cnnhld->cnnwin->priv;
 	gint dwidth, dheight;
@@ -921,7 +921,7 @@ static gboolean remmina_connection_holder_toolbar_autofit_restore(RemminaConnect
 
 static void remmina_connection_holder_toolbar_autofit(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 
 	if (GTK_IS_SCROLLED_WINDOW(cnnobj->scrolled_container)) {
@@ -943,7 +943,7 @@ static void remmina_connection_holder_toolbar_autofit(GtkWidget* widget, Remmina
 
 static void remmina_connection_holder_check_resize(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	gboolean scroll_required = FALSE;
 
@@ -1027,7 +1027,7 @@ static void remmina_connection_holder_check_resize(RemminaConnectionHolder* cnnh
 
 static void remmina_connection_holder_set_tooltip(GtkWidget* item, const gchar* tip, guint key1, guint key2)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s1;
 	gchar* s2;
 
@@ -1052,7 +1052,7 @@ static void remmina_connection_holder_set_tooltip(GtkWidget* item, const gchar* 
 
 static void remmina_protocol_widget_update_alignment(RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaScaleMode scalemode;
 	gboolean scaledexpandedmode;
 	int rdwidth, rdheight;
@@ -1126,7 +1126,7 @@ static void remmina_protocol_widget_update_alignment(RemminaConnectionObject* cn
 
 static void remmina_connection_holder_toolbar_fullscreen(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gtk_toggle_tool_button_get_active(GTK_TOGGLE_TOOL_BUTTON(widget))) {
 		remmina_connection_holder_create_fullscreen(cnnhld, NULL, cnnhld->fullscreen_view_mode);
 	}else  {
@@ -1136,7 +1136,7 @@ static void remmina_connection_holder_toolbar_fullscreen(GtkWidget* widget, Remm
 
 static void remmina_connection_holder_viewport_fullscreen_mode(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
 		return;
 	cnnhld->fullscreen_view_mode = VIEWPORT_FULLSCREEN_MODE;
@@ -1145,7 +1145,7 @@ static void remmina_connection_holder_viewport_fullscreen_mode(GtkWidget* widget
 
 static void remmina_connection_holder_scrolled_fullscreen_mode(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
 		return;
 	cnnhld->fullscreen_view_mode = SCROLLED_FULLSCREEN_MODE;
@@ -1154,7 +1154,7 @@ static void remmina_connection_holder_scrolled_fullscreen_mode(GtkWidget* widget
 
 static void remmina_connection_holder_fullscreen_option_popdown(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	priv->sticky = FALSE;
@@ -1165,7 +1165,7 @@ static void remmina_connection_holder_fullscreen_option_popdown(GtkWidget* widge
 
 static void remmina_connection_holder_toolbar_fullscreen_option(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkWidget* menu;
 	GtkWidget* menuitem;
@@ -1209,7 +1209,7 @@ static void remmina_connection_holder_toolbar_fullscreen_option(GtkWidget* widge
 
 static void remmina_connection_holder_scaler_option_popdown(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	priv->sticky = FALSE;
 	gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(priv->scaler_option_button), FALSE);
@@ -1218,7 +1218,7 @@ static void remmina_connection_holder_scaler_option_popdown(GtkWidget* widget, R
 
 static void remmina_connection_holder_scaler_expand(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
 		return;
@@ -1228,7 +1228,7 @@ static void remmina_connection_holder_scaler_expand(GtkWidget* widget, RemminaCo
 }
 static void remmina_connection_holder_scaler_keep_aspect(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	if (!gtk_check_menu_item_get_active(GTK_CHECK_MENU_ITEM(widget)))
 		return;
@@ -1239,7 +1239,7 @@ static void remmina_connection_holder_scaler_keep_aspect(GtkWidget* widget, Remm
 
 static void remmina_connection_holder_toolbar_scaler_option(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkWidget* menu;
@@ -1286,7 +1286,7 @@ static void remmina_connection_holder_toolbar_scaler_option(GtkWidget* widget, R
 
 static void remmina_connection_holder_switch_page_activate(GtkMenuItem* menuitem, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	gint page_num;
 
@@ -1296,7 +1296,7 @@ static void remmina_connection_holder_switch_page_activate(GtkMenuItem* menuitem
 
 static void remmina_connection_holder_toolbar_switch_page_popdown(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	priv->sticky = FALSE;
@@ -1307,7 +1307,7 @@ static void remmina_connection_holder_toolbar_switch_page_popdown(GtkWidget* wid
 
 static void remmina_connection_holder_toolbar_switch_page(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionObject* cnnobj;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkWidget* menu;
@@ -1359,7 +1359,7 @@ static void remmina_connection_holder_toolbar_switch_page(GtkWidget* widget, Rem
 
 static void remmina_connection_holder_update_toolbar_autofit_button(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkToolItem* toolitem;
@@ -1413,7 +1413,7 @@ static void remmina_connection_holder_change_scalemode(RemminaConnectionHolder* 
 
 static void remmina_connection_holder_toolbar_dynres(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean bdyn, bscale;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
@@ -1431,7 +1431,7 @@ static void remmina_connection_holder_toolbar_dynres(GtkWidget* widget, RemminaC
 
 static void remmina_connection_holder_toolbar_scaled_mode(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean bdyn, bscale;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
@@ -1448,7 +1448,7 @@ static void remmina_connection_holder_toolbar_scaled_mode(GtkWidget* widget, Rem
 
 static void remmina_connection_holder_toolbar_preferences_popdown(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	priv->sticky = FALSE;
@@ -1459,7 +1459,7 @@ static void remmina_connection_holder_toolbar_preferences_popdown(GtkWidget* wid
 
 static void remmina_connection_holder_toolbar_tools_popdown(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	priv->sticky = FALSE;
@@ -1470,7 +1470,7 @@ static void remmina_connection_holder_toolbar_tools_popdown(GtkWidget* widget, R
 
 static void remmina_connection_holder_call_protocol_feature_radio(GtkMenuItem* menuitem, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaProtocolFeature* feature;
 	gpointer value;
@@ -1486,7 +1486,7 @@ static void remmina_connection_holder_call_protocol_feature_radio(GtkMenuItem* m
 
 static void remmina_connection_holder_call_protocol_feature_check(GtkMenuItem* menuitem, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaProtocolFeature* feature;
 	gboolean value;
@@ -1499,7 +1499,7 @@ static void remmina_connection_holder_call_protocol_feature_check(GtkMenuItem* m
 
 static void remmina_connection_holder_call_protocol_feature_activate(GtkMenuItem* menuitem, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaProtocolFeature* feature;
 
@@ -1510,7 +1510,7 @@ static void remmina_connection_holder_call_protocol_feature_activate(GtkMenuItem
 static void remmina_connection_holder_toolbar_preferences_radio(RemminaConnectionHolder* cnnhld, RemminaFile* remminafile,
 								GtkWidget* menu, const RemminaProtocolFeature* feature, const gchar* domain, gboolean enabled)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* menuitem;
 	GSList* group;
 	gint i;
@@ -1545,7 +1545,7 @@ static void remmina_connection_holder_toolbar_preferences_radio(RemminaConnectio
 static void remmina_connection_holder_toolbar_preferences_check(RemminaConnectionHolder* cnnhld, RemminaFile* remminafile,
 								GtkWidget* menu, const RemminaProtocolFeature* feature, const gchar* domain, gboolean enabled)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* menuitem;
 
 	menuitem = gtk_check_menu_item_new_with_label(g_dgettext(domain, (const gchar*)feature->opt3));
@@ -1567,7 +1567,7 @@ static void remmina_connection_holder_toolbar_preferences_check(RemminaConnectio
 
 static void remmina_connection_holder_toolbar_preferences(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	const RemminaProtocolFeature* feature;
@@ -1625,7 +1625,7 @@ static void remmina_connection_holder_toolbar_preferences(GtkWidget* widget, Rem
 
 static void remmina_connection_holder_toolbar_tools(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	const RemminaProtocolFeature* feature;
@@ -1713,7 +1713,7 @@ static void remmina_connection_holder_toolbar_tools(GtkWidget* widget, RemminaCo
 
 static void remmina_connection_holder_toolbar_screenshot(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GdkPixbuf *screenshot;
 	GdkWindow *active_window;
@@ -1834,20 +1834,20 @@ static void remmina_connection_holder_toolbar_screenshot(GtkWidget* widget, Remm
 
 static void remmina_connection_holder_toolbar_minimize(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_connection_holder_floating_toolbar_show(cnnhld, FALSE);
 	gtk_window_iconify(GTK_WINDOW(cnnhld->cnnwin));
 }
 
 static void remmina_connection_holder_toolbar_disconnect(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_connection_holder_disconnect_current_page(cnnhld);
 }
 
 static void remmina_connection_holder_toolbar_grab(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	gboolean capture;
 
@@ -1865,7 +1865,7 @@ static void remmina_connection_holder_toolbar_grab(GtkWidget* widget, RemminaCon
 static GtkWidget*
 remmina_connection_holder_create_toolbar(RemminaConnectionHolder* cnnhld, gint mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkWidget* toolbar;
 	GtkToolItem* toolitem;
@@ -2084,7 +2084,7 @@ static void remmina_connection_holder_place_toolbar(GtkToolbar *toolbar, GtkGrid
 
 static void remmina_connection_holder_update_toolbar(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	GtkToolItem* toolitem;
@@ -2150,7 +2150,7 @@ static void remmina_connection_holder_update_toolbar(RemminaConnectionHolder* cn
 
 static void remmina_connection_holder_showhide_toolbar(RemminaConnectionHolder* cnnhld, gboolean resize)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	/* Here we should threat the resize flag, but we don't */
@@ -2166,7 +2166,7 @@ static void remmina_connection_holder_showhide_toolbar(RemminaConnectionHolder* 
 static gboolean remmina_connection_holder_floating_toolbar_on_enter(GtkWidget* widget, GdkEventCrossing* event,
 								    RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_connection_holder_floating_toolbar_show(cnnhld, TRUE);
 	return TRUE;
 }
@@ -2174,7 +2174,7 @@ static gboolean remmina_connection_holder_floating_toolbar_on_enter(GtkWidget* w
 static gboolean remmina_connection_object_enter_protocol_widget(GtkWidget* widget, GdkEventCrossing* event,
 								RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionHolder* cnnhld = cnnobj->cnnhld;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	if (!priv->sticky && event->mode == GDK_CROSSING_NORMAL) {
@@ -2186,7 +2186,7 @@ static gboolean remmina_connection_object_enter_protocol_widget(GtkWidget* widge
 
 static void remmina_connection_window_focus_in(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 #if !FLOATING_TOOLBAR_WIDGET
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
@@ -2201,7 +2201,7 @@ static void remmina_connection_window_focus_in(GtkWidget* widget, RemminaConnect
 
 static void remmina_connection_window_focus_out(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 
 #if !FLOATING_TOOLBAR_WIDGET
@@ -2226,7 +2226,7 @@ static void remmina_connection_window_focus_out(GtkWidget* widget, RemminaConnec
 
 static gboolean remmina_connection_window_focus_out_event(GtkWidget* widget, GdkEvent* event, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #if DEBUG_KB_GRABBING
 	printf("DEBUG_KB_GRABBING: focus out and mouse_pointer_entered is %s\n", cnnhld->cnnwin->priv->mouse_pointer_entered ? "true" : "false");
 #endif
@@ -2236,7 +2236,7 @@ static gboolean remmina_connection_window_focus_out_event(GtkWidget* widget, Gdk
 
 static gboolean remmina_connection_window_focus_in_event(GtkWidget* widget, GdkEvent* event, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #if DEBUG_KB_GRABBING
 	printf("DEBUG_KB_GRABBING: focus in and mouse_pointer_entered is %s\n", cnnhld->cnnwin->priv->mouse_pointer_entered ? "true" : "false");
 #endif
@@ -2246,7 +2246,7 @@ static gboolean remmina_connection_window_focus_in_event(GtkWidget* widget, GdkE
 
 static gboolean remmina_connection_window_on_enter(GtkWidget* widget, GdkEventCrossing* event, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	cnnhld->cnnwin->priv->mouse_pointer_entered = TRUE;
 #if DEBUG_KB_GRABBING
 	printf("DEBUG_KB_GRABBING: enter detail=");
@@ -2269,7 +2269,7 @@ static gboolean remmina_connection_window_on_enter(GtkWidget* widget, GdkEventCr
 
 static gboolean remmina_connection_window_on_leave(GtkWidget* widget, GdkEventCrossing* event, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #if DEBUG_KB_GRABBING
 	printf("DEBUG_KB_GRABBING: leave detail=");
 	switch (event->detail) {
@@ -2300,7 +2300,7 @@ static gboolean remmina_connection_window_on_leave(GtkWidget* widget, GdkEventCr
 static gboolean
 remmina_connection_holder_floating_toolbar_hide(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	priv->hidetb_timer = 0;
 	remmina_connection_holder_floating_toolbar_show(cnnhld, FALSE);
@@ -2310,7 +2310,7 @@ remmina_connection_holder_floating_toolbar_hide(RemminaConnectionHolder* cnnhld)
 static gboolean remmina_connection_holder_floating_toolbar_on_scroll(GtkWidget* widget, GdkEventScroll* event,
 								     RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ_WITH_RETURN(FALSE)
 	int opacity;
 
@@ -2352,7 +2352,7 @@ static gboolean remmina_connection_holder_floating_toolbar_on_scroll(GtkWidget* 
 
 static gboolean remmina_connection_window_after_configure_scrolled(gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint width, height;
 	GdkWindowState s;
 	gint ipg, npages;
@@ -2389,7 +2389,7 @@ static gboolean remmina_connection_window_after_configure_scrolled(gpointer user
 static gboolean remmina_connection_window_on_configure(GtkWidget* widget, GdkEventConfigure* event,
 						       RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ_WITH_RETURN(FALSE)
 #if !FLOATING_TOOLBAR_WIDGET
 	RemminaConnectionWindowPriv * priv = cnnhld->cnnwin->priv;
@@ -2430,7 +2430,7 @@ static gboolean remmina_connection_window_on_configure(GtkWidget* widget, GdkEve
 
 static void remmina_connection_holder_update_pin(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (cnnhld->cnnwin->priv->pin_down) {
 		gtk_button_set_image(GTK_BUTTON(cnnhld->cnnwin->priv->pin_button),
 			gtk_image_new_from_icon_name("remmina-pin-down", GTK_ICON_SIZE_MENU));
@@ -2442,7 +2442,7 @@ static void remmina_connection_holder_update_pin(RemminaConnectionHolder* cnnhld
 
 static void remmina_connection_holder_toolbar_pin(GtkWidget* widget, RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_pref.toolbar_pin_down = cnnhld->cnnwin->priv->pin_down = !cnnhld->cnnwin->priv->pin_down;
 	remmina_pref_save();
 	remmina_connection_holder_update_pin(cnnhld);
@@ -2450,7 +2450,7 @@ static void remmina_connection_holder_toolbar_pin(GtkWidget* widget, RemminaConn
 
 static void remmina_connection_holder_create_floating_toolbar(RemminaConnectionHolder* cnnhld, gint mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 #if FLOATING_TOOLBAR_WIDGET
@@ -2564,7 +2564,7 @@ static void remmina_connection_holder_create_floating_toolbar(RemminaConnectionH
 
 static void remmina_connection_window_toolbar_place_signal(RemminaConnectionWindow* cnnwin, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv;
 
 	priv = cnnwin->priv;
@@ -2580,7 +2580,7 @@ static void remmina_connection_window_toolbar_place_signal(RemminaConnectionWind
 
 static void remmina_connection_window_init(RemminaConnectionWindow* cnnwin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv;
 
 	priv = g_new0(RemminaConnectionWindowPriv, 1);
@@ -2600,7 +2600,7 @@ static void remmina_connection_window_init(RemminaConnectionWindow* cnnwin)
 
 static gboolean remmina_connection_window_state_event(GtkWidget* widget, GdkEventWindowState* event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	if (event->changed_mask & GDK_WINDOW_STATE_FOCUSED) {
 		if (event->new_window_state & GDK_WINDOW_STATE_FOCUSED)
@@ -2628,7 +2628,7 @@ static gboolean remmina_connection_window_state_event(GtkWidget* widget, GdkEven
 static GtkWidget*
 remmina_connection_window_new_from_holder(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindow* cnnwin;
 
 	cnnwin = REMMINA_CONNECTION_WINDOW(g_object_new(REMMINA_TYPE_CONNECTION_WINDOW, NULL));
@@ -2658,7 +2658,7 @@ remmina_connection_window_new_from_holder(RemminaConnectionHolder* cnnhld)
  */
 static void remmina_connection_window_update_tag(RemminaConnectionWindow* cnnwin, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* tag;
 
 	switch (remmina_pref.tab_mode) {
@@ -2677,7 +2677,7 @@ static void remmina_connection_window_update_tag(RemminaConnectionWindow* cnnwin
 
 static void remmina_connection_object_create_scrolled_container(RemminaConnectionObject* cnnobj, gint view_mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* container;
 
 	if (view_mode == VIEWPORT_FULLSCREEN_MODE) {
@@ -2701,7 +2701,7 @@ static void remmina_connection_object_create_scrolled_container(RemminaConnectio
 
 static void remmina_connection_holder_grab_focus(GtkNotebook *notebook)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionObject* cnnobj;
 	GtkWidget* child;
 
@@ -2714,7 +2714,7 @@ static void remmina_connection_holder_grab_focus(GtkNotebook *notebook)
 
 static void remmina_connection_object_on_close_button_clicked(GtkButton* button, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (REMMINA_IS_PROTOCOL_WIDGET(cnnobj->proto)) {
 		remmina_protocol_widget_close_connection(REMMINA_PROTOCOL_WIDGET(cnnobj->proto));
 	}
@@ -2722,7 +2722,7 @@ static void remmina_connection_object_on_close_button_clicked(GtkButton* button,
 
 static GtkWidget* remmina_connection_object_create_tab(RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* hbox;
 	GtkWidget* widget;
 	GtkWidget* button;
@@ -2766,7 +2766,7 @@ static GtkWidget* remmina_connection_object_create_tab(RemminaConnectionObject* 
 static gint remmina_connection_object_append_page(RemminaConnectionObject* cnnobj, GtkNotebook* notebook, GtkWidget* tab,
 						  gint view_mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 
 	remmina_connection_object_create_scrolled_container(cnnobj, view_mode);
@@ -2781,7 +2781,7 @@ static gint remmina_connection_object_append_page(RemminaConnectionObject* cnnob
 static void remmina_connection_window_initialize_notebook(GtkNotebook* to, GtkNotebook* from, RemminaConnectionObject* cnnobj,
 							  gint view_mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i, n, c;
 	GtkWidget* tab;
 	GtkWidget* widget;
@@ -2842,7 +2842,7 @@ static void remmina_connection_window_initialize_notebook(GtkNotebook* to, GtkNo
 
 static void remmina_connection_holder_update_notebook(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkNotebook* notebook;
 	gint n;
 
@@ -2866,7 +2866,7 @@ static void remmina_connection_holder_update_notebook(RemminaConnectionHolder* c
 
 static gboolean remmina_connection_holder_on_switch_page_real(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionHolder* cnnhld = (RemminaConnectionHolder*)data;
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
@@ -2889,7 +2889,7 @@ static gboolean remmina_connection_holder_on_switch_page_real(gpointer data)
 static void remmina_connection_holder_on_switch_page(GtkNotebook* notebook, GtkWidget* page, guint page_num,
 						     RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 
 	if (!priv->switch_page_handler) {
@@ -2907,7 +2907,7 @@ static void remmina_connection_holder_on_page_added(GtkNotebook* notebook, GtkWi
 static void remmina_connection_holder_on_page_removed(GtkNotebook* notebook, GtkWidget* child, guint page_num,
 						      RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	if (!cnnhld->cnnwin)
 		return;
@@ -2924,7 +2924,7 @@ remmina_connection_holder_on_notebook_create_window(GtkNotebook* notebook, GtkWi
 {
 	/* This signal callback is called by GTK when a detachable tab is dropped on the root window */
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindow* srccnnwin;
 	RemminaConnectionWindow* dstcnnwin;
 	RemminaConnectionObject* cnnobj;
@@ -2980,7 +2980,7 @@ remmina_connection_holder_on_notebook_create_window(GtkNotebook* notebook, GtkWi
 static GtkWidget*
 remmina_connection_holder_create_notebook(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* notebook;
 
 	notebook = gtk_notebook_new();
@@ -3001,7 +3001,7 @@ remmina_connection_holder_create_notebook(RemminaConnectionHolder* cnnhld)
 /* Create a scrolled window container */
 static void remmina_connection_holder_create_scrolled(RemminaConnectionHolder* cnnhld, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* window;
 	GtkWidget* oldwindow;
 	GtkWidget* grid;
@@ -3111,7 +3111,7 @@ static void remmina_connection_holder_create_scrolled(RemminaConnectionHolder* c
 
 static gboolean remmina_connection_window_go_fullscreen(GtkWidget *widget, GdkEvent *event, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionHolder* cnnhld;
 	RemminaConnectionWindowPriv* priv;
 
@@ -3140,7 +3140,7 @@ static gboolean remmina_connection_window_go_fullscreen(GtkWidget *widget, GdkEv
 
 static void remmina_connection_holder_create_overlay_ftb_overlay(RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget* revealer;
 	RemminaConnectionWindowPriv* priv;
@@ -3222,7 +3222,7 @@ static void remmina_connection_holder_create_overlay_ftb_overlay(RemminaConnecti
 static gboolean remmina_connection_window_ftb_drag_drop(GtkWidget *widget, GdkDragContext *context,
 							gint x, gint y, guint time, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkAllocation wa;
 	gint new_floating_toolbar_placement;
 	RemminaConnectionHolder* cnnhld;
@@ -3255,7 +3255,7 @@ static gboolean remmina_connection_window_ftb_drag_drop(GtkWidget *widget, GdkDr
 
 static void remmina_connection_window_ftb_drag_begin(GtkWidget *widget, GdkDragContext *context, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaConnectionHolder* cnnhld;
 	RemminaConnectionWindowPriv* priv;
@@ -3288,7 +3288,7 @@ static void remmina_connection_window_ftb_drag_begin(GtkWidget *widget, GdkDragC
 static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder* cnnhld, RemminaConnectionObject* cnnobj,
 							gint view_mode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* window;
 	GtkWidget* oldwindow;
 	GtkWidget* notebook;
@@ -3367,7 +3367,7 @@ static void remmina_connection_holder_create_fullscreen(RemminaConnectionHolder*
 static gboolean remmina_connection_window_hostkey_func(RemminaProtocolWidget* gp, guint keyval, gboolean release,
 						       RemminaConnectionHolder* cnnhld)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	DECLARE_CNNOBJ_WITH_RETURN(FALSE);
 	RemminaConnectionWindowPriv* priv = cnnhld->cnnwin->priv;
 	const RemminaProtocolFeature* feature;
@@ -3554,7 +3554,7 @@ static gboolean remmina_connection_window_hostkey_func(RemminaProtocolWidget* gp
 
 static RemminaConnectionWindow* remmina_connection_window_find(RemminaFile* remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar* tag;
 
 	switch (remmina_pref.tab_mode) {
@@ -3576,7 +3576,7 @@ static RemminaConnectionWindow* remmina_connection_window_find(RemminaFile* remm
 
 static void remmina_connection_object_on_connect(RemminaProtocolWidget* gp, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindow* cnnwin;
 	RemminaConnectionHolder* cnnhld;
 	GtkWidget* tab;
@@ -3655,7 +3655,7 @@ static void cb_autoclose_widget(GtkWidget *widget)
 
 static void remmina_connection_object_on_disconnect(RemminaProtocolWidget* gp, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionHolder* cnnhld = cnnobj->cnnhld;
 	GtkWidget* dialog;
 	GtkWidget* pparent;
@@ -3702,7 +3702,7 @@ static void remmina_connection_object_on_disconnect(RemminaProtocolWidget* gp, R
 
 static void remmina_connection_object_on_desktop_resize(RemminaProtocolWidget* gp, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (cnnobj->cnnhld && cnnobj->cnnhld->cnnwin && cnnobj->cnnhld->cnnwin->priv->view_mode != SCROLLED_WINDOW_MODE) {
 		remmina_connection_holder_check_resize(cnnobj->cnnhld);
 	}
@@ -3710,20 +3710,20 @@ static void remmina_connection_object_on_desktop_resize(RemminaProtocolWidget* g
 
 static void remmina_connection_object_on_update_align(RemminaProtocolWidget* gp, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_protocol_widget_update_alignment(cnnobj);
 }
 
 static void remmina_connection_object_on_unlock_dynres(RemminaProtocolWidget* gp, RemminaConnectionObject* cnnobj)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	cnnobj->dynres_unlocked = TRUE;
 	remmina_connection_holder_update_toolbar(cnnobj->cnnhld);
 }
 
 gboolean remmina_connection_window_open_from_filename(const gchar* filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 	GtkWidget* dialog;
 
@@ -3743,13 +3743,13 @@ gboolean remmina_connection_window_open_from_filename(const gchar* filename)
 
 void remmina_connection_window_open_from_file(RemminaFile* remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_connection_window_open_from_file_full(remminafile, NULL, NULL, NULL);
 }
 
 GtkWidget* remmina_connection_window_open_from_file_full(RemminaFile* remminafile, GCallback disconnect_cb, gpointer data, guint* handler)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionObject* cnnobj;
 	GtkWidget* protocolwidget;
 

--- a/remmina/src/remmina_crypt.c
+++ b/remmina/src/remmina_crypt.c
@@ -47,7 +47,7 @@
 
 static gboolean remmina_crypt_init(gcry_cipher_hd_t *phd)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar* secret;
 	gcry_error_t err;
 	gsize secret_len;
@@ -93,7 +93,7 @@ static gboolean remmina_crypt_init(gcry_cipher_hd_t *phd)
 
 gchar* remmina_crypt_encrypt(const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar* buf;
 	gint buf_len;
 	gchar* result;
@@ -132,7 +132,7 @@ gchar* remmina_crypt_encrypt(const gchar *str)
 
 gchar* remmina_crypt_decrypt(const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar* buf;
 	gsize buf_len;
 	gcry_error_t err;
@@ -167,13 +167,13 @@ gchar* remmina_crypt_decrypt(const gchar *str)
 
 gchar* remmina_crypt_encrypt(const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return NULL;
 }
 
 gchar* remmina_crypt_decrypt(const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return NULL;
 }
 

--- a/remmina/src/remmina_exec.c
+++ b/remmina/src/remmina_exec.c
@@ -54,7 +54,7 @@
 
 static gboolean cb_closewidget(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* The correct way to close a remmina_connection_window is to send
 	 * it a "delete-event" signal. Simply destroying it will not close
 	 * all network connections */
@@ -65,7 +65,7 @@ static gboolean cb_closewidget(GtkWidget *widget, gpointer data)
 
 void remmina_exec_exitremmina()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Save main window state/position */
 	remmina_main_save_before_destroy();
@@ -82,7 +82,7 @@ void remmina_exec_exitremmina()
 
 static gboolean disable_remmina_connection_window_delete_confirm_cb(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaConnectionWindow *rcw;
 
 	if (REMMINA_IS_CONNECTION_WINDOW(widget)) {
@@ -94,7 +94,7 @@ static gboolean disable_remmina_connection_window_delete_confirm_cb(GtkWidget *w
 
 void remmina_application_condexit(RemminaCondExitType why)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Exit remmina only if there are no interesting windows left:
 	 * no main window, no systray menu, no connection window.
@@ -122,7 +122,7 @@ void remmina_application_condexit(RemminaCondExitType why)
 
 void remmina_exec_command(RemminaCommandType command, const gchar* data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s1;
 	gchar* s2;
 	GtkWidget* widget;

--- a/remmina/src/remmina_external_tools.c
+++ b/remmina/src/remmina_external_tools.c
@@ -45,7 +45,7 @@ static gboolean remmina_external_tools_launcher(const gchar* filename, const gch
 
 static void view_popup_menu_onDoSomething(GtkWidget *menuitem, gpointer userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *remminafilename = g_object_get_data(G_OBJECT(menuitem), "remminafilename");
 	gchar *scriptfilename = g_object_get_data(G_OBJECT(menuitem), "scriptfilename");
 	gchar *scriptshortname = g_object_get_data(G_OBJECT(menuitem), "scriptshortname");
@@ -55,7 +55,7 @@ static void view_popup_menu_onDoSomething(GtkWidget *menuitem, gpointer userdata
 
 gboolean remmina_external_tools_from_filename(RemminaMain *remminamain, gchar* remminafilename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menu, *menuitem;
 	gchar dirname[MAX_PATH_LEN];
 	gchar filename[MAX_PATH_LEN];
@@ -100,7 +100,7 @@ gboolean remmina_external_tools_from_filename(RemminaMain *remminamain, gchar* r
 
 static gboolean remmina_external_tools_launcher(const gchar* filename, const gchar* scriptname, const gchar* shortname)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 	const char *env_format = "%s=%s";
 	char *env;

--- a/remmina/src/remmina_file.c
+++ b/remmina/src/remmina_file.c
@@ -70,7 +70,7 @@ static struct timespec times[2];
 static RemminaFile*
 remmina_file_new_empty(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	remminafile = g_new0(RemminaFile, 1);
@@ -86,7 +86,7 @@ remmina_file_new_empty(void)
 RemminaFile*
 remmina_file_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	/* Try to load from the preference file for default settings first */
@@ -104,7 +104,7 @@ remmina_file_new(void)
 
 void remmina_file_generate_filename(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GTimeVal gtime;
 	GDir *dir;
 
@@ -122,7 +122,7 @@ void remmina_file_generate_filename(RemminaFile *remminafile)
 
 void remmina_file_set_filename(RemminaFile *remminafile, const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_free(remminafile->filename);
 	remminafile->filename = g_strdup(filename);
 }
@@ -130,14 +130,14 @@ void remmina_file_set_filename(RemminaFile *remminafile, const gchar *filename)
 const gchar*
 remmina_file_get_filename(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remminafile->filename;
 }
 
 RemminaFile*
 remmina_file_copy(const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	remminafile = remmina_file_load(filename);
@@ -148,7 +148,7 @@ remmina_file_copy(const gchar *filename)
 
 static const RemminaProtocolSetting* find_protocol_setting(const gchar *name, RemminaProtocolPlugin* protocol_plugin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const RemminaProtocolSetting* setting_iter;
 
 	if (protocol_plugin == NULL)
@@ -178,7 +178,7 @@ static const RemminaProtocolSetting* find_protocol_setting(const gchar *name, Re
 
 static gboolean is_encrypted_setting(const RemminaProtocolSetting* setting)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (setting != NULL &&
 	    (setting->type == REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD) ) {
 		return TRUE;
@@ -188,7 +188,7 @@ static gboolean is_encrypted_setting(const RemminaProtocolSetting* setting)
 
 static gboolean is_encrypted_setting_by_name(const gchar *setting_name, RemminaProtocolPlugin* protocol_plugin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const RemminaProtocolSetting* setting;
 
 	if (strcmp(setting_name, "ssh_password") == 0) {
@@ -205,7 +205,7 @@ static gboolean is_encrypted_setting_by_name(const gchar *setting_name, RemminaP
 RemminaFile*
 remmina_file_load(const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	RemminaFile *remminafile;
 	gchar *proto;
@@ -290,13 +290,13 @@ remmina_file_load(const gchar *filename)
 
 void remmina_file_set_string(RemminaFile *remminafile, const gchar *setting, const gchar *value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_file_set_string_ref(remminafile, setting, g_strdup(value));
 }
 
 void remmina_file_set_string_ref(RemminaFile *remminafile, const gchar *setting, gchar *value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar* message;
 
 	if (value) {
@@ -316,7 +316,7 @@ void remmina_file_set_string_ref(RemminaFile *remminafile, const gchar *setting,
 const gchar*
 remmina_file_get_string(RemminaFile *remminafile, const gchar *setting)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *value;
 	const gchar* message;
 
@@ -351,7 +351,7 @@ remmina_file_get_string(RemminaFile *remminafile, const gchar *setting)
 gchar*
 remmina_file_get_secret(RemminaFile *remminafile, const gchar *setting)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* This function is in the RemminaPluginService table, we cannot remove it
 	 * without breaking plugin API */
@@ -361,13 +361,13 @@ remmina_file_get_secret(RemminaFile *remminafile, const gchar *setting)
 
 void remmina_file_set_int(RemminaFile *remminafile, const gchar *setting, gint value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_hash_table_insert(remminafile->settings, g_strdup(setting), g_strdup_printf("%i", value));
 }
 
 gint remmina_file_get_int(RemminaFile *remminafile, const gchar *setting, gint default_value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *value;
 
 	value = g_hash_table_lookup(remminafile->settings, setting);
@@ -377,7 +377,7 @@ gint remmina_file_get_int(RemminaFile *remminafile, const gchar *setting, gint d
 static GKeyFile*
 remmina_file_get_keyfile(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 
 	if (remminafile->filename == NULL)
@@ -391,7 +391,7 @@ remmina_file_get_keyfile(RemminaFile *remminafile)
 
 void remmina_file_free(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (remminafile == NULL)
 		return;
 
@@ -404,7 +404,7 @@ void remmina_file_free(RemminaFile *remminafile)
 
 void remmina_file_save(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSecretPlugin *secret_plugin;
 	RemminaProtocolPlugin* protocol_plugin;
 	GHashTableIter iter;
@@ -474,7 +474,7 @@ void remmina_file_save(RemminaFile *remminafile)
 
 void remmina_file_store_secret_plugin_password(RemminaFile *remminafile, const gchar* key, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Only change the password in the keyring. This function
 	 * is a shortcut which avoids updating of date/time of .pref file
@@ -493,7 +493,7 @@ void remmina_file_store_secret_plugin_password(RemminaFile *remminafile, const g
 RemminaFile*
 remmina_file_dup(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *dupfile;
 	GHashTableIter iter;
 	const gchar *key, *value;
@@ -512,7 +512,7 @@ remmina_file_dup(RemminaFile *remminafile)
 const gchar*
 remmina_file_get_icon_name(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolPlugin *plugin;
 
 	plugin = (RemminaProtocolPlugin*)remmina_plugin_manager_get_plugin(REMMINA_PLUGIN_TYPE_PROTOCOL,
@@ -526,7 +526,7 @@ remmina_file_get_icon_name(RemminaFile *remminafile)
 RemminaFile*
 remmina_file_dup_temp_protocol(RemminaFile *remminafile, const gchar *new_protocol)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *tmp;
 
 	tmp = remmina_file_dup(remminafile);
@@ -538,7 +538,7 @@ remmina_file_dup_temp_protocol(RemminaFile *remminafile, const gchar *new_protoc
 
 void remmina_file_delete(const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	remminafile = remmina_file_load(filename);
@@ -553,7 +553,7 @@ void remmina_file_unsave_password(RemminaFile *remminafile)
 {
 	/* Delete all saved secrets for this profile */
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const RemminaProtocolSetting* setting_iter;
 	RemminaProtocolPlugin* protocol_plugin;
 	gchar *proto;
@@ -591,7 +591,7 @@ void remmina_file_unsave_password(RemminaFile *remminafile)
 gchar*
 remmina_file_get_datetime(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GFile *file;
 	GFileInfo *info;
@@ -636,7 +636,7 @@ remmina_file_get_datetime(RemminaFile *remminafile)
 void
 remmina_file_touch(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int fd;
 	struct stat st;
 	int r;

--- a/remmina/src/remmina_file_editor.c
+++ b/remmina/src/remmina_file_editor.c
@@ -129,14 +129,14 @@ struct _RemminaFileEditorPriv {
 
 static void remmina_file_editor_class_init(RemminaFileEditorClass* klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 #ifdef HAVE_LIBAVAHI_UI
 
 static void remmina_file_editor_browse_avahi(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* dialog;
 	gchar* host;
 
@@ -170,7 +170,7 @@ static void remmina_file_editor_browse_avahi(GtkWidget* button, RemminaFileEdito
 
 static void remmina_file_editor_on_realize(GtkWidget* widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditor* gfe;
 	GtkWidget* defaultwidget;
 
@@ -188,7 +188,7 @@ static void remmina_file_editor_on_realize(GtkWidget* widget, gpointer user_data
 
 static void remmina_file_editor_destroy(GtkWidget* widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_file_free(REMMINA_FILE_EDITOR(widget)->priv->remmina_file);
 	g_hash_table_destroy(REMMINA_FILE_EDITOR(widget)->priv->setting_widgets);
 	g_free(REMMINA_FILE_EDITOR(widget)->priv);
@@ -196,13 +196,13 @@ static void remmina_file_editor_destroy(GtkWidget* widget, gpointer data)
 
 static void remmina_file_editor_button_on_toggled(GtkToggleButton* togglebutton, GtkWidget* widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_set_sensitive(widget, gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(togglebutton)));
 }
 
 static void remmina_file_editor_create_notebook_container(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* Create the notebook */
 	gfe->priv->config_container = gtk_notebook_new();
 	gfe->priv->config_viewport = gtk_viewport_new(NULL, NULL);
@@ -225,7 +225,7 @@ static void remmina_file_editor_create_notebook_container(RemminaFileEditor* gfe
 static GtkWidget* remmina_file_editor_create_notebook_tab(RemminaFileEditor* gfe,
 							  const gchar* stock_id, const gchar* label, gint rows, gint cols)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* tablabel;
 	GtkWidget* tabbody;
 	GtkWidget* grid;
@@ -260,7 +260,7 @@ static GtkWidget* remmina_file_editor_create_notebook_tab(RemminaFileEditor* gfe
 
 static void remmina_file_editor_ssh_server_custom_radio_on_toggled(GtkToggleButton* togglebutton, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_set_sensitive(gfe->priv->ssh_server_entry,
 		gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(gfe->priv->ssh_enabled_check)) &&
 		(gfe->priv->ssh_server_custom_radio == NULL ||
@@ -270,7 +270,7 @@ static void remmina_file_editor_ssh_server_custom_radio_on_toggled(GtkToggleButt
 
 static void remmina_file_editor_ssh_auth_publickey_radio_on_toggled(GtkToggleButton* togglebutton, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean b;
 	const gchar* s;
 
@@ -287,7 +287,7 @@ static void remmina_file_editor_ssh_auth_publickey_radio_on_toggled(GtkToggleBut
 static void remmina_file_editor_ssh_enabled_check_on_toggled(GtkToggleButton* togglebutton,
 							     RemminaFileEditor* gfe, RemminaProtocolSSHSetting ssh_setting)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	gboolean enabled = TRUE;
 	gchar* p;
@@ -323,7 +323,7 @@ static void remmina_file_editor_ssh_enabled_check_on_toggled(GtkToggleButton* to
 
 static void remmina_file_editor_create_ssh_privatekey(RemminaFileEditor* gfe, GtkWidget* grid, gint row, gint column)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 	GtkWidget* widget;
 	GtkWidget* dialog;
@@ -371,7 +371,7 @@ static void remmina_file_editor_create_ssh_privatekey(RemminaFileEditor* gfe, Gt
 static void remmina_file_editor_create_server(RemminaFileEditor* gfe, const RemminaProtocolSetting* setting, GtkWidget* grid,
 					      gint row)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolPlugin* plugin = gfe->priv->plugin;
 	GtkWidget* widget;
 #ifdef HAVE_LIBAVAHI_UI
@@ -421,7 +421,7 @@ static void remmina_file_editor_create_server(RemminaFileEditor* gfe, const Remm
 static GtkWidget* remmina_file_editor_create_password(RemminaFileEditor* gfe, GtkWidget* grid,
 						      gint row, gint col, const gchar* label, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 
 	widget = gtk_label_new(label);
@@ -451,7 +451,7 @@ static GtkWidget* remmina_file_editor_create_password(RemminaFileEditor* gfe, Gt
 
 static void remmina_file_editor_update_resolution(GtkWidget* widget, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* res_str;
 	res_str = g_strdup_printf("%dx%d",
 		remmina_file_get_int(gfe->priv->remmina_file, "resolution_width", 0),
@@ -464,7 +464,7 @@ static void remmina_file_editor_update_resolution(GtkWidget* widget, RemminaFile
 
 static void remmina_file_editor_browse_resolution(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkDialog *dialog = remmina_string_list_new(FALSE, NULL);
 	remmina_string_list_set_validation_func(remmina_public_resolution_validation_func);
@@ -482,7 +482,7 @@ static void remmina_file_editor_browse_resolution(GtkWidget* button, RemminaFile
 static void remmina_file_editor_create_resolution(RemminaFileEditor* gfe, const RemminaProtocolSetting* setting,
 						  GtkWidget* grid, gint row)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 	GtkWidget* hbox;
 	const gchar *resolution_w, *resolution_h;
@@ -541,7 +541,7 @@ static void remmina_file_editor_create_resolution(RemminaFileEditor* gfe, const 
 static GtkWidget* remmina_file_editor_create_text(RemminaFileEditor* gfe, GtkWidget* grid,
 						  gint row, gint col, const gchar* label, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 
 	widget = gtk_label_new(label);
@@ -570,7 +570,7 @@ static GtkWidget* remmina_file_editor_create_text(RemminaFileEditor* gfe, GtkWid
 static GtkWidget* remmina_file_editor_create_select(RemminaFileEditor* gfe, GtkWidget* grid,
 						    gint row, gint col, const gchar* label, const gpointer* list, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 
 	widget = gtk_label_new(label);
@@ -589,7 +589,7 @@ static GtkWidget* remmina_file_editor_create_select(RemminaFileEditor* gfe, GtkW
 static GtkWidget* remmina_file_editor_create_combo(RemminaFileEditor* gfe, GtkWidget* grid,
 						   gint row, gint col, const gchar* label, const gchar* list, const gchar* value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 
 	widget = gtk_label_new(label);
@@ -609,7 +609,7 @@ static GtkWidget* remmina_file_editor_create_combo(RemminaFileEditor* gfe, GtkWi
 static GtkWidget* remmina_file_editor_create_check(RemminaFileEditor* gfe, GtkWidget* grid,
 						   gint row, gint top, const gchar* label, gboolean value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* widget;
 	widget = gtk_check_button_new_with_label(label);
 	gtk_widget_show(widget);
@@ -626,7 +626,7 @@ static GtkWidget*
 remmina_file_editor_create_chooser(RemminaFileEditor* gfe, GtkWidget* grid, gint row, gint col, const gchar* label,
 				   const gchar* value, gint type)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* check;
 	GtkWidget* widget;
 	GtkWidget* hbox;
@@ -662,7 +662,7 @@ remmina_file_editor_create_chooser(RemminaFileEditor* gfe, GtkWidget* grid, gint
 static void remmina_file_editor_create_settings(RemminaFileEditor* gfe, GtkWidget* grid,
 						const RemminaProtocolSetting* settings)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	GtkWidget* widget;
 	gint grid_row = 0;
@@ -769,7 +769,7 @@ static void remmina_file_editor_create_settings(RemminaFileEditor* gfe, GtkWidge
 
 static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaProtocolSSHSetting ssh_setting)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	RemminaFileEditorPriv* priv = gfe->priv;
 	GtkWidget* grid;
@@ -944,7 +944,7 @@ static void remmina_file_editor_create_ssh_tab(RemminaFileEditor* gfe, RemminaPr
 
 static void remmina_file_editor_create_all_settings(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	GtkWidget* grid;
 
@@ -968,7 +968,7 @@ static void remmina_file_editor_create_all_settings(RemminaFileEditor* gfe)
 
 static void remmina_file_editor_protocol_combo_on_changed(GtkComboBox* combo, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	gchar* protocol;
 
@@ -1013,7 +1013,7 @@ static void remmina_file_editor_protocol_combo_on_changed(GtkComboBox* combo, Re
 
 static void remmina_file_editor_update_ssh(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	gboolean ssh_enabled;
 
@@ -1064,7 +1064,7 @@ static void remmina_file_editor_update_ssh(RemminaFileEditor* gfe)
 
 static void remmina_file_editor_update_settings(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv = gfe->priv;
 	GHashTableIter iter;
 	gpointer key, value;
@@ -1092,7 +1092,7 @@ static void remmina_file_editor_update_settings(RemminaFileEditor* gfe)
 
 static void remmina_file_editor_update(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *custom_resolution, *res_w, *res_h;
 	int w, h;
 
@@ -1142,7 +1142,7 @@ static void remmina_file_editor_update(RemminaFileEditor* gfe)
 
 static void remmina_file_editor_on_default(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* gf;
 	GtkWidget* dialog;
 
@@ -1170,7 +1170,7 @@ static void remmina_file_editor_on_default(GtkWidget* button, RemminaFileEditor*
 
 static void remmina_file_editor_on_save(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	remmina_file_editor_update(gfe);
 
@@ -1182,7 +1182,7 @@ static void remmina_file_editor_on_save(GtkWidget* button, RemminaFileEditor* gf
 
 static void remmina_file_editor_on_connect(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* gf;
 
 	remmina_file_editor_update(gfe);
@@ -1199,7 +1199,7 @@ static void remmina_file_editor_on_connect(GtkWidget* button, RemminaFileEditor*
 
 static void remmina_file_editor_on_save_connect(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* TODO: Call remmina_file_editor_on_save */
 	RemminaFile* gf;
 
@@ -1219,13 +1219,13 @@ static void remmina_file_editor_on_save_connect(GtkWidget* button, RemminaFileEd
 
 static void remmina_file_editor_on_cancel(GtkWidget* button, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_destroy(GTK_WIDGET(gfe));
 }
 
 static void remmina_file_editor_init(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv;
 	GtkWidget* widget;
 
@@ -1271,7 +1271,7 @@ static void remmina_file_editor_init(RemminaFileEditor* gfe)
 
 static gboolean remmina_file_editor_iterate_protocol(gchar* protocol, RemminaPlugin* plugin, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditor* gfe = REMMINA_FILE_EDITOR(data);
 	GtkListStore* store;
 	GtkTreeIter iter;
@@ -1294,7 +1294,7 @@ static gboolean remmina_file_editor_iterate_protocol(gchar* protocol, RemminaPlu
 
 static void remmina_file_editor_check_profile(RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv;
 
 	priv = gfe->priv;
@@ -1306,7 +1306,7 @@ static void remmina_file_editor_check_profile(RemminaFileEditor* gfe)
 
 static void remmina_file_editor_name_on_changed(GtkEditable* editable, RemminaFileEditor* gfe)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditorPriv* priv;
 
 	priv = gfe->priv;
@@ -1318,7 +1318,7 @@ static void remmina_file_editor_name_on_changed(GtkEditable* editable, RemminaFi
 
 GtkWidget* remmina_file_editor_new_from_file(RemminaFile* remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFileEditor* gfe;
 	RemminaFileEditorPriv* priv;
 	GtkWidget* grid;
@@ -1459,13 +1459,13 @@ GtkWidget* remmina_file_editor_new_from_file(RemminaFile* remminafile)
 
 GtkWidget* remmina_file_editor_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_file_editor_new_full(NULL, NULL);
 }
 
 GtkWidget* remmina_file_editor_new_full(const gchar* server, const gchar* protocol)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 
 	remminafile = remmina_file_new();
@@ -1479,7 +1479,7 @@ GtkWidget* remmina_file_editor_new_full(const gchar* server, const gchar* protoc
 
 GtkWidget* remmina_file_editor_new_copy(const gchar* filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 	GtkWidget* dialog;
 
@@ -1497,7 +1497,7 @@ GtkWidget* remmina_file_editor_new_copy(const gchar* filename)
 
 GtkWidget* remmina_file_editor_new_from_filename(const gchar* filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 	GtkWidget* dialog;
 

--- a/remmina/src/remmina_file_manager.c
+++ b/remmina/src/remmina_file_manager.c
@@ -52,7 +52,7 @@ static gchar *cachedir;
  * The returned string must be freed by the caller with g_free */
 gchar *remmina_file_get_datadir(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *dir = g_strdup_printf(".%s", g_get_prgname());
 	int i;
 	/* Legacy ~/.remmina */
@@ -95,7 +95,7 @@ static gboolean remmina_file_manager_do_copy(const char *src_path, const char *d
 
 void remmina_file_manager_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GDir *dir;
 	gchar *legacy = g_strdup_printf(".%s", g_get_prgname());
 	const gchar *filename;
@@ -144,7 +144,7 @@ void remmina_file_manager_init(void)
 
 gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar filename[MAX_PATH_LEN];
 	GDir* dir;
 	const gchar* name;
@@ -176,7 +176,7 @@ gint remmina_file_manager_iterate(GFunc func, gpointer user_data)
 
 gchar* remmina_file_manager_get_groups(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar filename[MAX_PATH_LEN];
 	GDir* dir;
 	const gchar* name;
@@ -214,7 +214,7 @@ gchar* remmina_file_manager_get_groups(void)
 
 static void remmina_file_manager_add_group(GNode* node, const gchar* group)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint cmp;
 	gchar* p1;
 	gchar* p2;
@@ -271,7 +271,7 @@ static void remmina_file_manager_add_group(GNode* node, const gchar* group)
 
 GNode* remmina_file_manager_get_group_tree(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar filename[MAX_PATH_LEN];
 	GDir* dir;
 	const gchar* name;
@@ -300,7 +300,7 @@ GNode* remmina_file_manager_get_group_tree(void)
 
 void remmina_file_manager_free_group_tree(GNode* node)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaGroupData* data;
 	GNode* child;
 
@@ -321,7 +321,7 @@ void remmina_file_manager_free_group_tree(GNode* node)
 
 RemminaFile* remmina_file_manager_load_file(const gchar* filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile = NULL;
 	RemminaFilePlugin* plugin;
 	gchar* p;

--- a/remmina/src/remmina_ftp_client.c
+++ b/remmina/src/remmina_ftp_client.c
@@ -83,14 +83,14 @@ static gboolean remmina_cell_renderer_pixbuf_activate(GtkCellRenderer *renderer,
 						      const gchar *path, const GdkRectangle *background_area, const GdkRectangle *cell_area,
 						      GtkCellRendererState flags)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_signal_emit(G_OBJECT(renderer), remmina_cell_renderer_pixbuf_signals[0], 0, path);
 	return TRUE;
 }
 
 static void remmina_cell_renderer_pixbuf_class_init(RemminaCellRendererPixbufClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkCellRendererClass *renderer_class = GTK_CELL_RENDERER_CLASS(klass);
 
 	renderer_class->activate = remmina_cell_renderer_pixbuf_activate;
@@ -102,14 +102,14 @@ static void remmina_cell_renderer_pixbuf_class_init(RemminaCellRendererPixbufCla
 
 static void remmina_cell_renderer_pixbuf_init(RemminaCellRendererPixbuf *renderer)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_object_set(G_OBJECT(renderer), "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE, NULL);
 }
 
 static GtkCellRenderer*
 remmina_cell_renderer_pixbuf_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkCellRenderer *renderer;
 
 	renderer = GTK_CELL_RENDERER(g_object_new(REMMINA_TYPE_CELL_RENDERER_PIXBUF, NULL));
@@ -164,7 +164,7 @@ static guint remmina_ftp_client_signals[LAST_SIGNAL] =
 
 static void remmina_ftp_client_class_init(RemminaFTPClientClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_ftp_client_signals[OPEN_DIR_SIGNAL] = g_signal_new("open-dir", G_TYPE_FROM_CLASS(klass),
 		G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(RemminaFTPClientClass, open_dir), NULL, NULL,
 		g_cclosure_marshal_VOID__STRING, G_TYPE_NONE, 1, G_TYPE_STRING);
@@ -181,7 +181,7 @@ static void remmina_ftp_client_class_init(RemminaFTPClientClass *klass)
 
 static void remmina_ftp_client_destroy(RemminaFTPClient *client, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	g_free(priv->current_directory);
 	g_free(priv->working_directory);
@@ -191,7 +191,7 @@ static void remmina_ftp_client_destroy(RemminaFTPClient *client, gpointer data)
 static void remmina_ftp_client_cell_data_filetype_pixbuf(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 							 GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint type;
 
 	/* Same as REMMINA_FTP_TASK_COLUMN_TYPE */
@@ -210,7 +210,7 @@ static void remmina_ftp_client_cell_data_filetype_pixbuf(GtkTreeViewColumn *col,
 static void remmina_ftp_client_cell_data_progress_pixbuf(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 							 GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint tasktype, status;
 
 	gtk_tree_model_get(model, iter, REMMINA_FTP_TASK_COLUMN_TASKTYPE, &tasktype, REMMINA_FTP_TASK_COLUMN_STATUS, &status,
@@ -236,7 +236,7 @@ static void remmina_ftp_client_cell_data_progress_pixbuf(GtkTreeViewColumn *col,
 static gchar*
 remmina_ftp_client_size_to_str(gfloat size)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *str;
 
 	if (size < 1024.0) {
@@ -254,7 +254,7 @@ remmina_ftp_client_size_to_str(gfloat size)
 static void remmina_ftp_client_cell_data_size(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 					      GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gfloat size;
 	gchar *str;
 
@@ -269,7 +269,7 @@ static void remmina_ftp_client_cell_data_size(GtkTreeViewColumn *col, GtkCellRen
 static void remmina_ftp_client_cell_data_permission(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 						    GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint permission;
 	gchar buf[11];
 
@@ -293,7 +293,7 @@ static void remmina_ftp_client_cell_data_permission(GtkTreeViewColumn *col, GtkC
 static void remmina_ftp_client_cell_data_size_progress(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 						       GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint status;
 	gfloat size, donesize;
 	gchar *strsize, *strdonesize, *str;
@@ -319,7 +319,7 @@ static void remmina_ftp_client_cell_data_size_progress(GtkTreeViewColumn *col, G
 static void remmina_ftp_client_cell_data_progress(GtkTreeViewColumn *col, GtkCellRenderer *renderer, GtkTreeModel *model,
 						  GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint status;
 	gfloat size, donesize;
 	gint progress;
@@ -342,7 +342,7 @@ static void remmina_ftp_client_cell_data_progress(GtkTreeViewColumn *col, GtkCel
 
 static void remmina_ftp_client_open_dir(RemminaFTPClient *client, const gchar *dir)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	BUSY_CURSOR
 	g_signal_emit(G_OBJECT(client), remmina_ftp_client_signals[OPEN_DIR_SIGNAL], 0, dir);
 	NORMAL_CURSOR
@@ -350,13 +350,13 @@ static void remmina_ftp_client_open_dir(RemminaFTPClient *client, const gchar *d
 
 static void remmina_ftp_client_dir_on_activate(GtkWidget *widget, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_ftp_client_open_dir(client, gtk_entry_get_text(GTK_ENTRY(widget)));
 }
 
 static void remmina_ftp_client_dir_on_changed(GtkWidget *widget, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *entry = gtk_bin_get_child(GTK_BIN(widget));
 
 	if (!gtk_widget_is_focus(entry)) {
@@ -369,7 +369,7 @@ static void remmina_ftp_client_dir_on_changed(GtkWidget *widget, RemminaFTPClien
 
 static void remmina_ftp_client_set_file_action_sensitive(RemminaFTPClient *client, gboolean sensitive)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	for (i = 0; client->priv->file_action_widgets[i]; i++) {
 		gtk_widget_set_sensitive(client->priv->file_action_widgets[i], sensitive);
@@ -379,7 +379,7 @@ static void remmina_ftp_client_set_file_action_sensitive(RemminaFTPClient *clien
 
 static void remmina_ftp_client_file_selection_on_changed(GtkTreeSelection *selection, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GList *list;
 
 	list = gtk_tree_selection_get_selected_rows(selection, NULL);
@@ -390,7 +390,7 @@ static void remmina_ftp_client_file_selection_on_changed(GtkTreeSelection *selec
 static gchar*
 remmina_ftp_client_get_download_dir(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkWidget *dialog;
 	gchar *localdir = NULL;
@@ -412,7 +412,7 @@ remmina_ftp_client_get_download_dir(RemminaFTPClient *client)
 
 static void remmina_ftp_client_download(RemminaFTPClient *client, GtkTreeIter *piter, const gchar *localdir)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkListStore *store = GTK_LIST_STORE(priv->task_list_model);
 	GtkTreeIter iter;
@@ -439,7 +439,7 @@ static void remmina_ftp_client_download(RemminaFTPClient *client, GtkTreeIter *p
 static gboolean remmina_ftp_client_task_list_on_query_tooltip(GtkWidget *widget, gint x, gint y, gboolean keyboard_tip,
 							      GtkTooltip *tooltip, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkTreeIter iter;
 	GtkTreePath *path = NULL;
@@ -465,25 +465,25 @@ static gboolean remmina_ftp_client_task_list_on_query_tooltip(GtkWidget *widget,
 
 static void remmina_ftp_client_action_parent(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_ftp_client_open_dir(client, "..");
 }
 
 static void remmina_ftp_client_action_home(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_ftp_client_open_dir(client, NULL);
 }
 
 static void remmina_ftp_client_action_refresh(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_ftp_client_open_dir(client, ".");
 }
 
 static void remmina_ftp_client_action_download(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkTreeSelection *selection;
 	gchar *localdir;
@@ -515,7 +515,7 @@ static void remmina_ftp_client_action_download(GObject *object, RemminaFTPClient
 
 static void remmina_ftp_client_action_delete(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkWidget *dialog;
 	GtkTreeSelection *selection;
@@ -570,7 +570,7 @@ static void remmina_ftp_client_action_delete(GObject *object, RemminaFTPClient *
 
 static void remmina_ftp_client_upload_folder_on_toggled(GtkToggleButton *togglebutton, GtkWidget *widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_file_chooser_set_action(
 		GTK_FILE_CHOOSER(widget),
 		gtk_toggle_button_get_active(togglebutton) ?
@@ -579,7 +579,7 @@ static void remmina_ftp_client_upload_folder_on_toggled(GtkToggleButton *toggleb
 
 static void remmina_ftp_client_action_upload(GObject *object, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkListStore *store = GTK_LIST_STORE(priv->task_list_model);
 	GtkTreeIter iter;
@@ -648,7 +648,7 @@ static void remmina_ftp_client_action_upload(GObject *object, RemminaFTPClient *
 
 static void remmina_ftp_client_popup_menu(RemminaFTPClient *client, GdkEventButton *event)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menu;
 	GtkWidget *menuitem;
 	GtkWidget *image;
@@ -683,7 +683,7 @@ static void remmina_ftp_client_popup_menu(RemminaFTPClient *client, GdkEventButt
 
 static gboolean remmina_ftp_client_file_list_on_button_press(GtkWidget *widget, GdkEventButton *event, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GList *list;
 	GtkTreeIter iter;
@@ -723,7 +723,7 @@ static gboolean remmina_ftp_client_file_list_on_button_press(GtkWidget *widget, 
 
 static void remmina_ftp_client_task_list_cell_on_activate(GtkCellRenderer *renderer, gchar *path, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkTreeIter iter;
 	GtkTreePath *treepath;
@@ -745,7 +745,7 @@ static void remmina_ftp_client_task_list_cell_on_activate(GtkCellRenderer *rende
 
 static GtkWidget* remmina_ftp_client_create_toolbar(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *box;
 	GtkWidget *button;
 	GtkWidget *image;
@@ -811,14 +811,14 @@ static GtkWidget* remmina_ftp_client_create_toolbar(RemminaFTPClient *client)
 
 void remmina_ftp_client_set_show_hidden(RemminaFTPClient *client, gboolean show_hidden)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	client->priv->file_list_show_hidden = show_hidden;
 	gtk_tree_model_filter_refilter(GTK_TREE_MODEL_FILTER(client->priv->file_list_filter));
 }
 
 static gboolean remmina_ftp_client_filter_visible_func(GtkTreeModel *model, GtkTreeIter *iter, RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *name;
 	gboolean result = TRUE;
 
@@ -836,20 +836,20 @@ static gboolean remmina_ftp_client_filter_visible_func(GtkTreeModel *model, GtkT
 /* Set the overwrite_all status */
 void remmina_ftp_client_set_overwrite_status(RemminaFTPClient *client, gboolean status)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	client->priv->overwrite_all = status;
 }
 
 /* Get the overwrite_all status */
 gboolean remmina_ftp_client_get_overwrite_status(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return client->priv->overwrite_all;
 }
 
 static void remmina_ftp_client_init(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv;
 	GtkWidget *vpaned;
 	GtkWidget *toolbar;
@@ -1051,7 +1051,7 @@ static void remmina_ftp_client_init(RemminaFTPClient *client)
 GtkWidget*
 remmina_ftp_client_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClient *client;
 
 	client = REMMINA_FTP_CLIENT(g_object_new(REMMINA_TYPE_FTP_CLIENT, NULL));
@@ -1061,7 +1061,7 @@ remmina_ftp_client_new(void)
 
 void remmina_ftp_client_save_state(RemminaFTPClient *client, RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint pos;
 
 	pos = gtk_paned_get_position(GTK_PANED(client->priv->vpaned));
@@ -1070,7 +1070,7 @@ void remmina_ftp_client_save_state(RemminaFTPClient *client, RemminaFile *remmin
 
 void remmina_ftp_client_load_state(RemminaFTPClient *client, RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint pos;
 	GtkAllocation a;
 
@@ -1086,7 +1086,7 @@ void remmina_ftp_client_load_state(RemminaFTPClient *client, RemminaFile *remmin
 
 void remmina_ftp_client_clear_file_list(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 
 	gtk_list_store_clear(GTK_LIST_STORE(priv->file_list_model));
@@ -1095,7 +1095,7 @@ void remmina_ftp_client_clear_file_list(RemminaFTPClient *client)
 
 void remmina_ftp_client_add_file(RemminaFTPClient *client, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkListStore *store = GTK_LIST_STORE(priv->file_list_model);
 	GtkTreeIter iter;
@@ -1122,7 +1122,7 @@ void remmina_ftp_client_add_file(RemminaFTPClient *client, ...)
 
 void remmina_ftp_client_set_dir(RemminaFTPClient *client, const gchar *dir)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkTreeModel *model;
 	GtkTreeIter iter;
@@ -1153,7 +1153,7 @@ void remmina_ftp_client_set_dir(RemminaFTPClient *client, const gchar *dir)
 gchar*
 remmina_ftp_client_get_dir(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 
 	return g_strdup(priv->current_directory);
@@ -1162,7 +1162,7 @@ remmina_ftp_client_get_dir(RemminaFTPClient *client)
 RemminaFTPTask*
 remmina_ftp_client_get_waiting_task(RemminaFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkTreePath *path;
 	GtkTreeIter iter;
@@ -1206,7 +1206,7 @@ remmina_ftp_client_get_waiting_task(RemminaFTPClient *client)
 
 void remmina_ftp_client_update_task(RemminaFTPClient *client, RemminaFTPTask* task)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPClientPriv *priv = (RemminaFTPClientPriv*)client->priv;
 	GtkListStore *store = GTK_LIST_STORE(priv->task_list_model);
 	GtkTreePath *path;
@@ -1237,7 +1237,7 @@ void remmina_ftp_client_update_task(RemminaFTPClient *client, RemminaFTPTask* ta
 
 void remmina_ftp_task_free(RemminaFTPTask *task)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (task) {
 		g_free(task->name);
 		g_free(task->remotedir);

--- a/remmina/src/remmina_icon.c
+++ b/remmina/src/remmina_icon.c
@@ -69,7 +69,7 @@ static RemminaIcon remmina_icon =
 
 void remmina_icon_destroy(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (remmina_icon.icon) {
 #ifdef HAVE_LIBAPPINDICATOR
 		app_indicator_set_status(remmina_icon.icon, APP_INDICATOR_STATUS_PASSIVE);
@@ -94,25 +94,25 @@ void remmina_icon_destroy(void)
 
 static void remmina_icon_main(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_exec_command(REMMINA_COMMAND_MAIN, NULL);
 }
 
 static void remmina_icon_preferences(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_exec_command(REMMINA_COMMAND_PREF, "2");
 }
 
 static void remmina_icon_about(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_exec_command(REMMINA_COMMAND_ABOUT, NULL);
 }
 
 static void remmina_icon_enable_avahi(GtkCheckMenuItem *checkmenuitem, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!remmina_icon.avahi)
 		return;
 
@@ -129,7 +129,7 @@ static void remmina_icon_enable_avahi(GtkCheckMenuItem *checkmenuitem, gpointer 
 
 static void remmina_icon_populate_additional_menu_item(GtkWidget *menu)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menuitem;
 
 	menuitem = gtk_menu_item_new_with_label(_("Open Main Window"));
@@ -173,7 +173,7 @@ static void remmina_icon_populate_additional_menu_item(GtkWidget *menu)
 
 static void remmina_icon_on_launch_item(RemminaAppletMenu *menu, RemminaAppletMenuItem *menuitem, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *s;
 
 	switch (menuitem->item_type) {
@@ -193,7 +193,7 @@ static void remmina_icon_on_launch_item(RemminaAppletMenu *menu, RemminaAppletMe
 
 static void remmina_icon_on_edit_item(RemminaAppletMenu *menu, RemminaAppletMenuItem *menuitem, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *s;
 
 	switch (menuitem->item_type) {
@@ -213,7 +213,7 @@ static void remmina_icon_on_edit_item(RemminaAppletMenu *menu, RemminaAppletMenu
 
 static void remmina_icon_populate_extra_menu_item(GtkWidget *menu)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menuitem;
 	gboolean new_ontop;
 	GHashTableIter iter;
@@ -259,7 +259,7 @@ static void remmina_icon_populate_extra_menu_item(GtkWidget *menu)
 void
 remmina_icon_populate_menu(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menu;
 	GtkWidget *menuitem;
 
@@ -281,12 +281,12 @@ remmina_icon_populate_menu(void)
 
 void remmina_icon_populate_menu(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_icon_popdown_menu(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gtk_get_current_event_time() - remmina_icon.popup_time <= 500) {
 		remmina_exec_command(REMMINA_COMMAND_MAIN, NULL);
 	}
@@ -294,7 +294,7 @@ static void remmina_icon_popdown_menu(GtkWidget *widget, gpointer data)
 
 static void remmina_icon_on_activate(GtkStatusIcon *icon, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menu;
 	gint button, event_time;
 
@@ -315,7 +315,7 @@ static void remmina_icon_on_activate(GtkStatusIcon *icon, gpointer user_data)
 
 static void remmina_icon_on_popup_menu(GtkStatusIcon *icon, guint button, guint activate_time, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *menu;
 
 	menu = gtk_menu_new();
@@ -329,7 +329,7 @@ static void remmina_icon_on_popup_menu(GtkStatusIcon *icon, guint button, guint 
 
 static void remmina_icon_save_autostart_file(GKeyFile *gkeyfile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *content;
 	gsize length;
 
@@ -340,7 +340,7 @@ static void remmina_icon_save_autostart_file(GKeyFile *gkeyfile)
 
 static void remmina_icon_create_autostart_file(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 
 	if (!g_file_test(remmina_icon.autostart_file, G_FILE_TEST_EXISTS)) {
@@ -365,7 +365,7 @@ gboolean remmina_icon_is_available(void)
 	 * available and shown to the user, so the user can continue
 	 * its work without the remmina main window */
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *gsversion;
 	unsigned int gsv_maj, gsv_min, gsv_seq;
 	gboolean gshell_has_legacyTray;
@@ -417,7 +417,7 @@ gboolean remmina_icon_is_available(void)
 
 void remmina_icon_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	gchar remmina_panel[23];
 	gboolean sni_supported;
@@ -499,7 +499,7 @@ void remmina_icon_init(void)
 
 gboolean remmina_icon_is_autostart(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gboolean b;
 
@@ -512,7 +512,7 @@ gboolean remmina_icon_is_autostart(void)
 
 void remmina_icon_set_autostart(gboolean autostart)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gboolean b;
 

--- a/remmina/src/remmina_init_dialog.c
+++ b/remmina/src/remmina_init_dialog.c
@@ -47,12 +47,12 @@ G_DEFINE_TYPE( RemminaInitDialog, remmina_init_dialog, GTK_TYPE_DIALOG)
 
 static void remmina_init_dialog_class_init(RemminaInitDialogClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_init_dialog_destroy(RemminaInitDialog *dialog, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_free(dialog->title);
 	g_free(dialog->status);
 	g_free(dialog->username);
@@ -66,7 +66,7 @@ static void remmina_init_dialog_destroy(RemminaInitDialog *dialog, gpointer data
 
 static void remmina_init_dialog_init(RemminaInitDialog *dialog)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *hbox = NULL;
 	GtkWidget *widget;
 
@@ -126,7 +126,7 @@ static void remmina_init_dialog_init(RemminaInitDialog *dialog)
 
 static void remmina_init_dialog_connecting(RemminaInitDialog *dialog)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_label_set_text(GTK_LABEL(dialog->status_label), (dialog->status ? dialog->status : dialog->title));
 	gtk_image_set_from_icon_name(GTK_IMAGE(dialog->image), "dialog-information", GTK_ICON_SIZE_DIALOG);
 	gtk_dialog_set_response_sensitive(GTK_DIALOG(dialog), GTK_RESPONSE_OK, FALSE);
@@ -136,7 +136,7 @@ static void remmina_init_dialog_connecting(RemminaInitDialog *dialog)
 
 GtkWidget* remmina_init_dialog_new(const gchar *title_format, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaInitDialog *dialog;
 	va_list args;
 
@@ -154,7 +154,7 @@ GtkWidget* remmina_init_dialog_new(const gchar *title_format, ...)
 
 void remmina_init_dialog_set_status(RemminaInitDialog *dialog, const gchar *status_format, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* This function can be called from a non main thread */
 
 	va_list args;
@@ -186,7 +186,7 @@ void remmina_init_dialog_set_status(RemminaInitDialog *dialog, const gchar *stat
 
 void remmina_init_dialog_set_status_temp(RemminaInitDialog *dialog, const gchar *status_format, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* This function can be called from a non main thread */
 
@@ -216,7 +216,7 @@ void remmina_init_dialog_set_status_temp(RemminaInitDialog *dialog, const gchar 
 
 gint remmina_init_dialog_authpwd(RemminaInitDialog *dialog, const gchar *label, gboolean allow_save)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget *grid;
 	GtkWidget *password_entry;
@@ -301,7 +301,7 @@ gint remmina_init_dialog_authpwd(RemminaInitDialog *dialog, const gchar *label, 
 gint remmina_init_dialog_authuserpwd(RemminaInitDialog *dialog, gboolean want_domain, const gchar *default_username,
 				     const gchar *default_domain, gboolean allow_save)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget *grid;
 	GtkWidget *username_entry;
@@ -429,7 +429,7 @@ gint remmina_init_dialog_authuserpwd(RemminaInitDialog *dialog, gboolean want_do
 
 gint remmina_init_dialog_certificate(RemminaInitDialog* dialog, const gchar* subject, const gchar* issuer, const gchar* fingerprint)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	gint status;
 	GtkWidget* grid;
@@ -530,7 +530,7 @@ gint remmina_init_dialog_certificate(RemminaInitDialog* dialog, const gchar* sub
 }
 gint remmina_init_dialog_certificate_changed(RemminaInitDialog* dialog, const gchar* subject, const gchar* issuer, const gchar* new_fingerprint, const gchar* old_fingerprint)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	gint status;
 	GtkWidget* grid;
@@ -647,7 +647,7 @@ gint remmina_init_dialog_certificate_changed(RemminaInitDialog* dialog, const gc
 /* NOT TESTED */
 static GtkWidget* remmina_init_dialog_create_file_button(GtkGrid *grid, const gchar *label, gint row, const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gchar *pkidir;
 
@@ -675,7 +675,7 @@ static GtkWidget* remmina_init_dialog_create_file_button(GtkGrid *grid, const gc
 gint remmina_init_dialog_authx509(RemminaInitDialog *dialog, const gchar *cacert, const gchar *cacrl, const gchar *clientcert,
 				  const gchar *clientkey)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget *grid;
 	GtkWidget *cacert_button;
@@ -744,7 +744,7 @@ gint remmina_init_dialog_authx509(RemminaInitDialog *dialog, const gchar *cacert
 
 gint remmina_init_dialog_serverkey_confirm(RemminaInitDialog *dialog, const gchar *serverkey, const gchar *prompt)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget *vbox = NULL;
 	GtkWidget *widget;
@@ -811,7 +811,7 @@ gint remmina_init_dialog_serverkey_confirm(RemminaInitDialog *dialog, const gcha
 
 gint remmina_init_dialog_serverkey_unknown(RemminaInitDialog *dialog, const gchar *serverkey)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* This function can be called from a non main thread */
 
 	return remmina_init_dialog_serverkey_confirm(dialog, serverkey,
@@ -820,7 +820,7 @@ gint remmina_init_dialog_serverkey_unknown(RemminaInitDialog *dialog, const gcha
 
 gint remmina_init_dialog_serverkey_changed(RemminaInitDialog *dialog, const gchar *serverkey)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* This function can be called from a non main thread */
 
 	return remmina_init_dialog_serverkey_confirm(dialog, serverkey,

--- a/remmina/src/remmina_key_chooser.c
+++ b/remmina/src/remmina_key_chooser.c
@@ -43,7 +43,7 @@
 /* Handle key-presses on the GtkEventBox */
 static gboolean remmina_key_chooser_dialog_on_key_press(GtkWidget *widget, GdkEventKey *event, RemminaKeyChooserArguments *arguments)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!arguments->use_modifiers || !event->is_modifier) {
 		arguments->state = event->state;
 		arguments->keyval = gdk_keyval_to_lower(event->keyval);
@@ -56,7 +56,7 @@ static gboolean remmina_key_chooser_dialog_on_key_press(GtkWidget *widget, GdkEv
 /* Show a key chooser dialog and return the keyval for the selected key */
 RemminaKeyChooserArguments* remmina_key_chooser_new(GtkWindow *parent_window, gboolean use_modifiers)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkBuilder *builder = remmina_public_gtk_builder_new_from_file("remmina_key_chooser.glade");
 	GtkDialog *dialog;
 	RemminaKeyChooserArguments *arguments;
@@ -82,7 +82,7 @@ RemminaKeyChooserArguments* remmina_key_chooser_new(GtkWindow *parent_window, gb
 /* Get the uppercase character value of a keyval */
 gchar* remmina_key_chooser_get_value(guint keyval, guint state)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	if (!keyval)
 		return g_strdup(KEY_CHOOSER_NONE);
@@ -100,7 +100,7 @@ gchar* remmina_key_chooser_get_value(guint keyval, guint state)
 /* Get the keyval of a (lowercase) character value */
 guint remmina_key_chooser_get_keyval(const gchar *value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *patterns[] =
 	{
 		KEY_MODIFIER_SHIFT,

--- a/remmina/src/remmina_log.c
+++ b/remmina/src/remmina_log.c
@@ -66,12 +66,12 @@ G_DEFINE_TYPE(RemminaLogWindow, remmina_log_window, GTK_TYPE_WINDOW)
 
 static void remmina_log_window_class_init(RemminaLogWindowClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 static void remmina_log_window_init(RemminaLogWindow *logwin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *scrolledwindow;
 	GtkWidget *widget;
 
@@ -94,7 +94,7 @@ static void remmina_log_window_init(RemminaLogWindow *logwin)
 static GtkWidget*
 remmina_log_window_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return GTK_WIDGET(g_object_new(REMMINA_TYPE_LOG_WINDOW, NULL));
 }
 
@@ -103,13 +103,13 @@ static GtkWidget *log_window = NULL;
 
 static void remmina_log_end(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	log_window = NULL;
 }
 
 void remmina_log_start(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (log_window) {
 		gtk_window_present(GTK_WINDOW(log_window));
 	}else  {
@@ -122,13 +122,13 @@ void remmina_log_start(void)
 
 gboolean remmina_log_running(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return (log_window != NULL);
 }
 
 static gboolean remmina_log_scroll_to_end(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextIter iter;
 
 	if (log_window) {
@@ -141,7 +141,7 @@ static gboolean remmina_log_scroll_to_end(gpointer data)
 
 static gboolean remmina_log_print_real(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTextIter iter;
 
 	if (log_window) {
@@ -155,7 +155,7 @@ static gboolean remmina_log_print_real(gpointer data)
 
 void remmina_log_print(const gchar *text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!log_window)
 		return;
 
@@ -164,7 +164,7 @@ void remmina_log_print(const gchar *text)
 
 void remmina_log_printf(const gchar *fmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 	gchar *text;
 

--- a/remmina/src/remmina_main.c
+++ b/remmina/src/remmina_main.c
@@ -83,7 +83,7 @@ static char *quick_connect_plugin_list[] =
 
 static void remmina_main_save_size(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if ((gdk_window_get_state(gtk_widget_get_window(GTK_WIDGET(remminamain->window))) & GDK_WINDOW_STATE_MAXIMIZED) == 0) {
 		gtk_window_get_size(remminamain->window, &remmina_pref.main_width, &remmina_pref.main_height);
 		remmina_pref.main_maximize = FALSE;
@@ -94,7 +94,7 @@ static void remmina_main_save_size(void)
 
 static void remmina_main_save_expanded_group_func(GtkTreeView *tree_view, GtkTreePath *path, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	gchar *group;
 
@@ -108,7 +108,7 @@ static void remmina_main_save_expanded_group_func(GtkTreeView *tree_view, GtkTre
 
 static void remmina_main_save_expanded_group(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (GTK_IS_TREE_STORE(remminamain->priv->file_model)) {
 		if (remminamain->priv->expanded_group) {
 			remmina_string_array_free(remminamain->priv->expanded_group);
@@ -131,14 +131,14 @@ void remmina_main_save_before_destroy()
 static gboolean remmina_main_dexit(gpointer data)
 {
 	/* Try to exit remmina after a delete window event */
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_application_condexit(REMMINA_CONDEXIT_ONMAINWINDELETE);
 	return FALSE;
 }
 
 gboolean remmina_main_on_delete_event(GtkWidget *widget, GdkEvent *event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_main_save_before_destroy();
 
 	// Forget the main window: it has been deleted
@@ -150,7 +150,7 @@ gboolean remmina_main_on_delete_event(GtkWidget *widget, GdkEvent *event, gpoint
 
 void remmina_main_destroy()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	/* Called when main window is destroyed via a call of gtk_widget_destroy() */
 	if (remminamain) {
@@ -176,7 +176,7 @@ void remmina_main_destroy()
 
 static void remmina_main_clear_selection_data(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_free(remminamain->priv->selected_filename);
 	g_free(remminamain->priv->selected_name);
 	remminamain->priv->selected_filename = NULL;
@@ -189,7 +189,7 @@ static void remmina_main_clear_selection_data(void)
 static gboolean remmina_main_selection_func(GtkTreeSelection *selection, GtkTreeModel *model, GtkTreePath *path,
 					    gboolean path_currently_selected, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint context_id;
 	GtkTreeIter iter;
 	gchar buf[1000];
@@ -224,7 +224,7 @@ static gboolean remmina_main_selection_func(GtkTreeSelection *selection, GtkTree
 
 static void remmina_main_load_file_list_callback(RemminaFile *remminafile, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	GtkListStore *store;
 	store = GTK_LIST_STORE(user_data);
@@ -245,7 +245,7 @@ static void remmina_main_load_file_list_callback(RemminaFile *remminafile, gpoin
 
 static gboolean remmina_main_load_file_tree_traverse(GNode *node, GtkTreeStore *store, GtkTreeIter *parent)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter *iter;
 	RemminaGroupData *data;
 	GNode *child;
@@ -272,7 +272,7 @@ static gboolean remmina_main_load_file_tree_traverse(GNode *node, GtkTreeStore *
 
 static void remmina_main_load_file_tree_group(GtkTreeStore *store)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GNode *root;
 
 	root = remmina_file_manager_get_group_tree();
@@ -282,7 +282,7 @@ static void remmina_main_load_file_tree_group(GtkTreeStore *store)
 
 static void remmina_main_expand_group_traverse(GtkTreeIter *iter)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeModel *tree;
 	gboolean ret;
 	gchar *group, *filename;
@@ -312,7 +312,7 @@ static void remmina_main_expand_group_traverse(GtkTreeIter *iter)
 
 static void remmina_main_expand_group(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 
 	if (gtk_tree_model_get_iter_first(remminamain->priv->file_model_sort, &iter)) {
@@ -322,7 +322,7 @@ static void remmina_main_expand_group(void)
 
 static gboolean remmina_main_load_file_tree_find(GtkTreeModel *tree, GtkTreeIter *iter, const gchar *match_group)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean ret, match;
 	gchar *group, *filename;
 	GtkTreeIter child;
@@ -350,7 +350,7 @@ static gboolean remmina_main_load_file_tree_find(GtkTreeModel *tree, GtkTreeIter
 
 static void remmina_main_load_file_tree_callback(RemminaFile *remminafile, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter, child;
 	GtkTreeStore *store;
 	gboolean found;
@@ -379,7 +379,7 @@ static void remmina_main_load_file_tree_callback(RemminaFile *remminafile, gpoin
 
 static void remmina_main_file_model_on_sort(GtkTreeSortable *sortable, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint columnid;
 	GtkSortType order;
 
@@ -391,7 +391,7 @@ static void remmina_main_file_model_on_sort(GtkTreeSortable *sortable, gpointer 
 
 static gboolean remmina_main_filter_visible_func(GtkTreeModel *model, GtkTreeIter *iter, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *text;
 	gchar *protocol, *name, *group, *server, *date, *s;
 	gboolean result = TRUE;
@@ -432,7 +432,7 @@ static gboolean remmina_main_filter_visible_func(GtkTreeModel *model, GtkTreeIte
 
 static void remmina_main_select_file(const gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	GtkTreePath *path;
 	gchar *item_filename;
@@ -460,7 +460,7 @@ static void remmina_main_select_file(const gchar *filename)
 
 static void remmina_main_load_files()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint items_count;
 	gchar buf[200];
 	guint context_id;
@@ -540,13 +540,13 @@ static void remmina_main_load_files()
 
 void remmina_main_load_files_cb()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_main_load_files();
 }
 
 void remmina_main_on_action_connection_connect(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaFile *remminafile;
 
@@ -566,7 +566,7 @@ void remmina_main_on_action_connection_connect(GtkAction *action, gpointer user_
 
 void remmina_main_on_action_connection_external_tools(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!remminamain->priv->selected_filename)
 		return;
 
@@ -575,13 +575,13 @@ void remmina_main_on_action_connection_external_tools(GtkAction *action, gpointe
 
 static void remmina_main_file_editor_destroy(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_main_load_files();
 }
 
 void remmina_main_on_action_application_mpchange(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	const gchar *username;
@@ -609,7 +609,7 @@ void remmina_main_on_action_application_mpchange(GtkAction *action, gpointer use
 
 void remmina_main_on_action_connections_new(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 
 	widget = remmina_file_editor_new();
@@ -621,7 +621,7 @@ void remmina_main_on_action_connections_new(GtkAction *action, gpointer user_dat
 
 void remmina_main_on_action_connection_copy(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 
 	if (!remminamain->priv->selected_filename)
@@ -641,7 +641,7 @@ void remmina_main_on_action_connection_copy(GtkAction *action, gpointer user_dat
 
 void remmina_main_on_action_connection_edit(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 
 	if (!remminamain->priv->selected_filename)
@@ -660,7 +660,7 @@ void remmina_main_on_action_connection_edit(GtkAction *action, gpointer user_dat
 
 void remmina_main_on_action_connection_delete(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 	gchar *delfilename;
 
@@ -682,7 +682,7 @@ void remmina_main_on_action_connection_delete(GtkAction *action, gpointer user_d
 
 void remmina_main_on_action_application_preferences(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkDialog *dialog = remmina_pref_dialog_new(0, remminamain->window);
 	gtk_dialog_run(dialog);
 	gtk_widget_destroy(GTK_WIDGET(dialog));
@@ -691,13 +691,13 @@ void remmina_main_on_action_application_preferences(GtkAction *action, gpointer 
 void remmina_main_on_action_application_quit(GtkAction *action, gpointer user_data)
 {
 	// Called by quit signal in remmina_main.glade
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_application_condexit(REMMINA_CONDEXIT_ONQUIT);
 }
 
 void remmina_main_on_action_view_statusbar(GtkToggleAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean toggled;
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
@@ -716,7 +716,7 @@ void remmina_main_on_action_view_statusbar(GtkToggleAction *action, gpointer use
 
 void remmina_main_on_action_view_file_mode(GtkRadioAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint v;
 
 	G_GNUC_BEGIN_IGNORE_DEPRECATIONS
@@ -748,7 +748,7 @@ void remmina_main_on_date_column_sort_clicked()
 
 static void remmina_main_import_file_list(GSList *files)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dlg;
 	GSList *element;
 	gchar *path;
@@ -791,7 +791,7 @@ static void remmina_main_import_file_list(GSList *files)
 
 static void remmina_main_action_tools_import_on_response(GtkDialog *dialog, gint response_id, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GSList *files;
 
 	if (response_id == GTK_RESPONSE_ACCEPT) {
@@ -803,7 +803,7 @@ static void remmina_main_action_tools_import_on_response(GtkDialog *dialog, gint
 
 void remmina_main_on_action_tools_import(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 
 	dialog = gtk_file_chooser_dialog_new(_("Import"), remminamain->window, GTK_FILE_CHOOSER_ACTION_OPEN, "Import",
@@ -815,7 +815,7 @@ void remmina_main_on_action_tools_import(GtkAction *action, gpointer user_data)
 
 void remmina_main_on_action_tools_export(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFilePlugin *plugin;
 	RemminaFile *remminafile;
 	GtkWidget *dialog;
@@ -845,49 +845,49 @@ void remmina_main_on_action_tools_export(GtkAction *action, gpointer user_data)
 
 void remmina_main_on_action_application_plugins(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_manager_show(remminamain->window);
 }
 
 void remmina_main_on_action_help_homepage(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_app_info_launch_default_for_uri("http://www.remmina.org", NULL, NULL);
 }
 
 void remmina_main_on_action_help_wiki(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_app_info_launch_default_for_uri("https://github.com/FreeRDP/Remmina/wiki", NULL, NULL);
 }
 
 void remmina_main_on_action_help_gplus(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_app_info_launch_default_for_uri("https://plus.google.com/communities/106276095923371962010", NULL, NULL);
 }
 
 void remmina_main_on_action_help_donations(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_app_info_launch_default_for_uri("http://www.remmina.org/wp/donations", NULL, NULL);
 }
 
 void remmina_main_on_action_help_debug(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_log_start();
 }
 
 void remmina_main_on_action_application_about(GtkAction *action, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_about_open(remminamain->window);
 };
 
 static gboolean remmina_main_quickconnect(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile;
 	gchar* server;
 
@@ -908,7 +908,7 @@ static gboolean remmina_main_quickconnect(void)
 
 gboolean remmina_main_quickconnect_on_click(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_main_quickconnect();
 }
 
@@ -922,7 +922,7 @@ void remmina_main_quick_search_enter(GtkWidget *widget, gpointer user_data)
 /* Handle double click on a row in the connections list */
 void remmina_main_file_list_on_row_activated(GtkTreeView *tree, GtkTreePath *path, GtkTreeViewColumn *column, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* If a connection was selected then execute the default action */
 	if (remminamain->priv->selected_filename) {
 		switch (remmina_pref.default_action) {
@@ -940,7 +940,7 @@ void remmina_main_file_list_on_row_activated(GtkTreeView *tree, GtkTreePath *pat
 /* Show the popup menu by the right button mouse click */
 gboolean remmina_main_file_list_on_button_press(GtkWidget *widget, GdkEventButton *event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (event->button == MOUSE_BUTTON_RIGHT) {
 #if GTK_CHECK_VERSION(3, 22, 0)
 		gtk_menu_popup_at_pointer(GTK_MENU(remminamain->menu_popup), (GdkEvent*)event);
@@ -956,7 +956,7 @@ gboolean remmina_main_file_list_on_button_press(GtkWidget *widget, GdkEventButto
 /* Show the popup menu by the menu key */
 gboolean remmina_main_file_list_on_key_press(GtkWidget *widget, GdkEventKey *event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (event->keyval == GDK_KEY_Menu) {
 #if GTK_CHECK_VERSION(3, 22, 0)
 		gtk_menu_popup_at_widget(GTK_MENU(remminamain->menu_popup), widget,
@@ -971,7 +971,7 @@ gboolean remmina_main_file_list_on_key_press(GtkWidget *widget, GdkEventKey *eve
 
 void remmina_main_quick_search_on_icon_press(GtkEntry *entry, GtkEntryIconPosition icon_pos, GdkEvent *event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (icon_pos == GTK_ENTRY_ICON_SECONDARY) {
 		gtk_entry_set_text(entry, "");
 	}
@@ -979,7 +979,7 @@ void remmina_main_quick_search_on_icon_press(GtkEntry *entry, GtkEntryIconPositi
 
 void remmina_main_quick_search_on_changed(GtkEditable *editable, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* If a search text was input then temporary set the file mode to list */
 	if (gtk_entry_get_text_length(remminamain->entry_quick_connect_server)) {
 		if (GTK_IS_TREE_STORE(remminamain->priv->file_model)) {
@@ -1000,7 +1000,7 @@ void remmina_main_quick_search_on_changed(GtkEditable *editable, gpointer user_d
 void remmina_main_on_drag_data_received(GtkWidget *widget, GdkDragContext *drag_context, gint x, gint y,
 					GtkSelectionData *data, guint info, guint time, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar **uris;
 	GSList *files = NULL;
 	gint i;
@@ -1018,7 +1018,7 @@ void remmina_main_on_drag_data_received(GtkWidget *widget, GdkDragContext *drag_
 /* Add a new menuitem to the Tools menu */
 static gboolean remmina_main_add_tool_plugin(gchar *name, RemminaPlugin *plugin, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaToolPlugin *tool_plugin = (RemminaToolPlugin*)plugin;
 	GtkWidget *menuitem = gtk_menu_item_new_with_label(plugin->description);
 
@@ -1030,14 +1030,14 @@ static gboolean remmina_main_add_tool_plugin(gchar *name, RemminaPlugin *plugin,
 
 gboolean remmina_main_on_window_state_event(GtkWidget *widget, GdkEventWindowState *event, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return FALSE;
 }
 
 /* Remmina main window initialization */
 static void remmina_main_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int i;
 	char *name;
 
@@ -1097,7 +1097,7 @@ static void remmina_main_init(void)
 /* RemminaMain instance */
 GtkWidget* remmina_main_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remminamain = g_new0(RemminaMain, 1);
 	remminamain->priv = g_new0(RemminaMainPriv, 1);
 	/* Assign UI widgets to the private members */

--- a/remmina/src/remmina_marshals.c
+++ b/remmina/src/remmina_marshals.c
@@ -91,7 +91,7 @@ remmina_marshal_BOOLEAN__INT(GClosure     *closure,
 			     gpointer invocation_hint G_GNUC_UNUSED,
 			     gpointer marshal_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	typedef gboolean (*GMarshalFunc_BOOLEAN__INT) (gpointer data1,
 						       gint arg_1,
 						       gpointer data2);
@@ -129,7 +129,7 @@ remmina_marshal_BOOLEAN__INT_STRING(GClosure *closure,
 				    gpointer invocation_hint G_GNUC_UNUSED,
 				    gpointer marshal_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	typedef gboolean (*GMarshalFunc_BOOLEAN__INT_STRING) (gpointer data1,
 							      gint arg_1,
 							      gpointer arg_2,

--- a/remmina/src/remmina_mpchange.c
+++ b/remmina/src/remmina_mpchange.c
@@ -80,7 +80,7 @@ enum {
 
 static gboolean remmina_mpchange_fieldcompare(const gchar *needle, const gchar *haystack, int *matchcount)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	if (needle[0] == 0) {
 		(*matchcount)++;
@@ -97,7 +97,7 @@ static gboolean remmina_mpchange_fieldcompare(const gchar *needle, const gchar *
 
 static void remmina_mpchange_file_list_callback(RemminaFile *remminafile, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkListStore* store;
 	GtkTreeIter iter;
 	int matchcount;
@@ -147,7 +147,7 @@ static void remmina_mpchange_file_list_callback(RemminaFile *remminafile, gpoint
 
 static void remmina_mpchange_checkbox_toggle(GtkCellRendererToggle *cell, gchar *path_string, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	struct mpchanger_params* mpcp = (struct mpchanger_params*)user_data;
 	GtkTreePath *path;
@@ -161,7 +161,7 @@ static void remmina_mpchange_checkbox_toggle(GtkCellRendererToggle *cell, gchar 
 
 static void remmina_mpchange_dochange(gchar* fname, struct mpchanger_params* mpcp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaFile* remminafile;
 
@@ -185,7 +185,7 @@ static void enable_inputs(struct mpchanger_params* mpcp, gboolean ena)
 
 static gboolean changenext(gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params* mpcp = (struct mpchanger_params*)user_data;
 	gchar* fname;
 	gboolean sel;
@@ -208,7 +208,7 @@ static gboolean changenext(gpointer user_data)
 
 static void remmina_mpchange_dochange_clicked(GtkButton *btn, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params* mpcp = (struct mpchanger_params*)user_data;
 	const gchar *passwd1, *passwd2;
 
@@ -248,7 +248,7 @@ static void remmina_mpchange_dochange_clicked(GtkButton *btn, gpointer user_data
 
 static gboolean remmina_mpchange_searchfield_changed_to(gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params *mpcp = (struct mpchanger_params *)user_data;
 	const gchar *s;
 
@@ -285,7 +285,7 @@ static gboolean remmina_mpchange_searchfield_changed_to(gpointer user_data)
 
 static void remmina_mpchange_searchfield_changed(GtkSearchEntry *se, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params *mpcp = (struct mpchanger_params *)user_data;
 
 	if (mpcp->searchentrychange_timeout_source_id) {
@@ -299,7 +299,7 @@ static void remmina_mpchange_searchfield_changed(GtkSearchEntry *se, gpointer us
 
 static void remmina_mpchange_stopsearch(GtkSearchEntry *entry, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* The stop-search signal is emitted when pressing ESC on a GtkSearchEntry. We end the dialog. */
 	struct mpchanger_params *mpcp = (struct mpchanger_params *)user_data;
 	gtk_dialog_response(mpcp->dialog, 1);
@@ -307,7 +307,7 @@ static void remmina_mpchange_stopsearch(GtkSearchEntry *entry, gpointer user_dat
 
 static gboolean remmina_file_multipasswd_changer_mt(gpointer d)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params *mpcp = d;
 	GtkBuilder* bu;
 	GtkDialog* dialog;
@@ -422,7 +422,7 @@ remmina_mpchange_schedule(gboolean has_domain, const gchar *group, const gchar *
 	// So we just schedule the multipassword changer to be executed on
 	// the main thread
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	struct mpchanger_params *mpcp;
 
 	mpcp = g_malloc0(sizeof(struct mpchanger_params));

--- a/remmina/src/remmina_plugin_cmdexec.c
+++ b/remmina/src/remmina_plugin_cmdexec.c
@@ -58,7 +58,7 @@ static void wait_for_child(GPid pid, gint script_retval, gpointer data)
 
 GtkDialog* remmina_plugin_cmdexec_new(RemminaFile* remminafile, const char *remmina_plugin_cmdexec_type)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkBuilder *builder;
 	PCon_Spinner *pcspinner;
 	GError *error = NULL;

--- a/remmina/src/remmina_plugin_manager.c
+++ b/remmina/src/remmina_plugin_manager.c
@@ -66,13 +66,13 @@ static const gchar *remmina_plugin_type_name[] =
 
 static gint remmina_plugin_manager_compare_func(RemminaPlugin **a, RemminaPlugin **b)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_strcmp0((*a)->name, (*b)->name);
 }
 
 static gboolean remmina_plugin_manager_register_plugin(RemminaPlugin *plugin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (plugin->type == REMMINA_PLUGIN_TYPE_SECRET) {
 		if (remmina_secret_plugin) {
 			g_print("Remmina plugin %s (type=%s) bypassed.\n", plugin->name,
@@ -190,7 +190,7 @@ RemminaPluginService remmina_plugin_manager_service =
 
 static void remmina_plugin_manager_load_plugin(const gchar *name)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GModule *module;
 	RemminaPluginEntryFunc entry;
 
@@ -217,7 +217,7 @@ static void remmina_plugin_manager_load_plugin(const gchar *name)
 
 void remmina_plugin_manager_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GDir *dir;
 	const gchar *name, *ptr;
 	gchar *fullpath;
@@ -247,7 +247,7 @@ void remmina_plugin_manager_init(void)
 
 RemminaPlugin* remmina_plugin_manager_get_plugin(RemminaPluginType type, const gchar *name)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPlugin *plugin;
 	gint i;
 
@@ -276,7 +276,7 @@ const gchar *remmina_plugin_manager_get_canonical_setting_name(const RemminaProt
 
 void remmina_plugin_manager_for_each_plugin(RemminaPluginType type, RemminaPluginFunc func, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPlugin *plugin;
 	gint i;
 
@@ -296,7 +296,7 @@ void remmina_plugin_manager_for_each_plugin(RemminaPluginType type, RemminaPlugi
  * WARNING: GListStore is supported only from GLib 2.44 */
 static gboolean remmina_plugin_manager_show_for_each_stdout(RemminaPlugin *plugin)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	g_print("%-20s%-16s%-64s%-10s\n", plugin->name,
 		_(remmina_plugin_type_name[plugin->type]),
@@ -307,14 +307,14 @@ static gboolean remmina_plugin_manager_show_for_each_stdout(RemminaPlugin *plugi
 
 void remmina_plugin_manager_show_stdout()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_print("%-20s%-16s%-64s%-10s\n", "NAME", "TYPE", "DESCRIPTION", "PLUGIN AND LIBRARY VERSION");
 	g_ptr_array_foreach(remmina_plugin_table, (GFunc)remmina_plugin_manager_show_for_each_stdout, NULL);
 }
 
 static gboolean remmina_plugin_manager_show_for_each(RemminaPlugin *plugin, GtkListStore *store)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 
 	gtk_list_store_append(store, &iter);
@@ -325,7 +325,7 @@ static gboolean remmina_plugin_manager_show_for_each(RemminaPlugin *plugin, GtkL
 
 void remmina_plugin_manager_show(GtkWindow *parent)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 	GtkWidget *scrolledwindow;
 	GtkWidget *tree;
@@ -379,7 +379,7 @@ void remmina_plugin_manager_show(GtkWindow *parent)
 
 RemminaFilePlugin* remmina_plugin_manager_get_import_file_handler(const gchar *file)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFilePlugin *plugin;
 	gint i;
 
@@ -398,7 +398,7 @@ RemminaFilePlugin* remmina_plugin_manager_get_import_file_handler(const gchar *f
 
 RemminaFilePlugin* remmina_plugin_manager_get_export_file_handler(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFilePlugin *plugin;
 	gint i;
 
@@ -415,7 +415,7 @@ RemminaFilePlugin* remmina_plugin_manager_get_export_file_handler(RemminaFile *r
 
 RemminaSecretPlugin* remmina_plugin_manager_get_secret_plugin(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_secret_plugin;
 }
 

--- a/remmina/src/remmina_pref.c
+++ b/remmina/src/remmina_pref.c
@@ -68,7 +68,7 @@ static const gchar *default_keymap_data = "# Please check gdk/gdkkeysyms.h for a
 
 static void remmina_pref_gen_secret(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guchar s[32];
 	gint i;
 	GTimeVal gtime;
@@ -96,7 +96,7 @@ static void remmina_pref_gen_secret(void)
 
 static guint remmina_pref_get_keyval_from_str(const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint k;
 
 	if (!str)
@@ -112,7 +112,7 @@ static guint remmina_pref_get_keyval_from_str(const gchar *str)
 
 static void remmina_pref_init_keymap(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar **groups;
 	gchar **gptr;
@@ -180,7 +180,7 @@ static gboolean remmina_pref_file_do_copy(const char *src_path, const char *dst_
 
 void remmina_pref_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar *remmina_dir;
 	const gchar *filename = g_strdup_printf("%s.pref", g_get_prgname());
@@ -691,7 +691,7 @@ void remmina_pref_init(void)
 
 void remmina_pref_save(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar *content;
 	gsize length;
@@ -781,7 +781,7 @@ void remmina_pref_save(void)
 
 void remmina_pref_add_recent(const gchar *protocol, const gchar *server)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaStringArray *array;
 	GKeyFile *gkeyfile;
 	gchar key[20];
@@ -822,7 +822,7 @@ void remmina_pref_add_recent(const gchar *protocol, const gchar *server)
 gchar*
 remmina_pref_get_recent(const gchar *protocol)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar key[20];
 	gchar *val;
@@ -841,7 +841,7 @@ remmina_pref_get_recent(const gchar *protocol)
 
 void remmina_pref_clear_recent(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar **keys;
 	gint i;
@@ -870,7 +870,7 @@ void remmina_pref_clear_recent(void)
 
 guint remmina_pref_keymap_get_keyval(const gchar *keymap, guint keyval)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	guint *table;
 	gint i;
 
@@ -890,7 +890,7 @@ guint remmina_pref_keymap_get_keyval(const gchar *keymap, guint keyval)
 gchar**
 remmina_pref_keymap_groups(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GList *list;
 	guint len;
 	gchar **keys;
@@ -913,7 +913,7 @@ remmina_pref_keymap_groups(void)
 
 gint remmina_pref_get_scale_quality(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* Paranoid programming */
 	if (remmina_pref.scale_quality < 0) {
 		remmina_pref.scale_quality = 0;
@@ -923,25 +923,25 @@ gint remmina_pref_get_scale_quality(void)
 
 gint remmina_pref_get_ssh_loglevel(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_pref.ssh_loglevel;
 }
 
 gboolean remmina_pref_get_ssh_parseconfig(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_pref.ssh_parseconfig;
 }
 
 gint remmina_pref_get_sshtunnel_port(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_pref.sshtunnel_port;
 }
 
 void remmina_pref_set_value(const gchar *key, const gchar *value)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar *content;
 	gsize length;
@@ -959,7 +959,7 @@ void remmina_pref_set_value(const gchar *key, const gchar *value)
 gchar*
 remmina_pref_get_value(const gchar *key)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GKeyFile *gkeyfile;
 	gchar *value;
 

--- a/remmina/src/remmina_pref_dialog.c
+++ b/remmina/src/remmina_pref_dialog.c
@@ -58,7 +58,7 @@ static RemminaPrefDialog *remmina_pref_dialog;
 /* Show a key chooser dialog */
 void remmina_pref_dialog_on_key_chooser(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaKeyChooserArguments *arguments;
 
 	g_return_if_fail(GTK_IS_BUTTON(widget));
@@ -75,7 +75,7 @@ void remmina_pref_dialog_on_key_chooser(GtkWidget *widget, gpointer user_data)
 /* Show the available resolutions list dialog */
 void remmina_pref_on_button_resolutions_clicked(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkDialog *dialog = remmina_string_list_new(FALSE, NULL);
 	remmina_string_list_set_validation_func(remmina_public_resolution_validation_func);
 	remmina_string_list_set_text(remmina_pref.resolutions, TRUE);
@@ -91,7 +91,7 @@ void remmina_pref_on_button_resolutions_clicked(GtkWidget *widget, gpointer user
  * file is selected*/
 void remmina_pref_on_color_scheme_selected(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *sourcepath;
 	gchar *remmina_dir;
 	gchar *destpath;
@@ -120,7 +120,7 @@ void remmina_pref_on_color_scheme_selected(GtkWidget *widget, gpointer user_data
 
 void remmina_pref_dialog_clear_recent(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkDialog *dialog;
 
 	remmina_pref_clear_recent();
@@ -134,7 +134,7 @@ void remmina_pref_dialog_clear_recent(GtkWidget *widget, gpointer user_data)
 /* Configure custom keystrokes to send to the plugins */
 void remmina_pref_on_button_keystrokes_clicked(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkDialog *dialog = remmina_string_list_new(TRUE, STRING_DELIMITOR2);
 	remmina_string_list_set_text(remmina_pref.keystrokes, TRUE);
 	remmina_string_list_set_titles(_("Keystrokes"), _("Configure the keystrokes"));
@@ -147,13 +147,13 @@ void remmina_pref_on_button_keystrokes_clicked(GtkWidget *widget, gpointer user_
 
 void remmina_pref_dialog_on_close_clicked(GtkWidget *widget, RemminaPrefDialog *dialog)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_destroy(GTK_WIDGET(remmina_pref_dialog->dialog));
 }
 
 void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean b;
 	GdkRGBA color;
 
@@ -274,7 +274,7 @@ void remmina_pref_on_dialog_destroy(GtkWidget *widget, gpointer user_data)
 
 static gboolean remmina_pref_dialog_add_pref_plugin(gchar *name, RemminaPlugin *plugin, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPrefPlugin *pref_plugin;
 	GtkWidget *vbox;
 	GtkWidget *widget;
@@ -296,13 +296,13 @@ static gboolean remmina_pref_dialog_add_pref_plugin(gchar *name, RemminaPlugin *
 
 void remmina_pref_dialog_vte_font_on_toggled(GtkWidget *widget, RemminaPrefDialog *dialog)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_set_sensitive(GTK_WIDGET(remmina_pref_dialog->fontbutton_terminal_font), !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget)));
 }
 
 void remmina_pref_dialog_disable_tray_icon_on_toggled(GtkWidget *widget, RemminaPrefDialog *dialog)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gboolean b;
 
 	b = !gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(widget));
@@ -323,7 +323,7 @@ static void remmina_pref_dialog_set_button_label(GtkButton *button, guint keyval
 /* Remmina preferences initialization */
 static void remmina_pref_dialog_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar buf[100];
 	GdkRGBA color;
 
@@ -482,7 +482,7 @@ static void remmina_pref_dialog_init(void)
 /* RemminaPrefDialog instance */
 GtkDialog* remmina_pref_dialog_new(gint default_tab, GtkWindow *parent)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	remmina_pref_dialog = g_new0(RemminaPrefDialog, 1);
 	remmina_pref_dialog->priv = g_new0(RemminaPrefDialogPriv, 1);

--- a/remmina/src/remmina_protocol_widget.c
+++ b/remmina/src/remmina_protocol_widget.c
@@ -105,7 +105,7 @@ static guint remmina_protocol_widget_signals[LAST_SIGNAL] =
 
 static void remmina_protocol_widget_class_init(RemminaProtocolWidgetClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_protocol_widget_signals[CONNECT_SIGNAL] = g_signal_new("connect", G_TYPE_FROM_CLASS(klass),
 		G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION, G_STRUCT_OFFSET(RemminaProtocolWidgetClass, connect), NULL, NULL,
 		g_cclosure_marshal_VOID__VOID, G_TYPE_NONE, 0);
@@ -125,7 +125,7 @@ static void remmina_protocol_widget_class_init(RemminaProtocolWidgetClass *klass
 
 static void remmina_protocol_widget_init_cancel(RemminaInitDialog *dialog, gint response_id, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if ((response_id == GTK_RESPONSE_CANCEL || response_id == GTK_RESPONSE_DELETE_EVENT)
 	    && dialog->mode == REMMINA_INIT_MODE_CONNECTING) {
 		remmina_protocol_widget_close_connection(gp);
@@ -134,7 +134,7 @@ static void remmina_protocol_widget_init_cancel(RemminaInitDialog *dialog, gint 
 
 static void remmina_protocol_widget_show_init_dialog(RemminaProtocolWidget* gp, const gchar *name)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->init_dialog) {
 		gtk_widget_destroy(gp->priv->init_dialog);
 	}
@@ -145,7 +145,7 @@ static void remmina_protocol_widget_show_init_dialog(RemminaProtocolWidget* gp, 
 
 static void remmina_protocol_widget_hide_init_dialog(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->init_dialog && GTK_IS_WIDGET(gp->priv->init_dialog))
 		gtk_widget_destroy(gp->priv->init_dialog);
 
@@ -154,7 +154,7 @@ static void remmina_protocol_widget_hide_init_dialog(RemminaProtocolWidget* gp)
 
 static void remmina_protocol_widget_destroy(RemminaProtocolWidget* gp, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_protocol_widget_hide_init_dialog(gp);
 	g_free(gp->priv->features);
 	gp->priv->features = NULL;
@@ -168,7 +168,7 @@ static void remmina_protocol_widget_destroy(RemminaProtocolWidget* gp, gpointer 
 
 static void remmina_protocol_widget_connect(RemminaProtocolWidget* gp, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	if (gp->priv->ssh_tunnel) {
 		remmina_ssh_tunnel_cancel_accept(gp->priv->ssh_tunnel);
@@ -179,13 +179,13 @@ static void remmina_protocol_widget_connect(RemminaProtocolWidget* gp, gpointer 
 
 static void remmina_protocol_widget_disconnect(RemminaProtocolWidget* gp, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_protocol_widget_hide_init_dialog(gp);
 }
 
 void remmina_protocol_widget_grab_focus(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget* child;
 
 	child = gtk_bin_get_child(GTK_BIN(gp));
@@ -198,7 +198,7 @@ void remmina_protocol_widget_grab_focus(RemminaProtocolWidget* gp)
 
 static void remmina_protocol_widget_init(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidgetPriv *priv;
 
 	priv = g_new0(RemminaProtocolWidgetPriv, 1);
@@ -211,7 +211,7 @@ static void remmina_protocol_widget_init(RemminaProtocolWidget* gp)
 
 void remmina_protocol_widget_open_connection_real(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget* gp = REMMINA_PROTOCOL_WIDGET(data);
 	RemminaProtocolPlugin* plugin;
 	RemminaFile* remminafile = gp->priv->remmina_file;
@@ -277,7 +277,7 @@ void remmina_protocol_widget_open_connection_real(gpointer data)
 
 void remmina_protocol_widget_open_connection(RemminaProtocolWidget* gp, RemminaFile* remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->remmina_file = remminafile;
 	gp->priv->scalemode = remmina_file_get_int(remminafile, "scale", FALSE);
 	gp->priv->scaler_expand = remmina_file_get_int(remminafile, "scaler_expand", FALSE);
@@ -289,7 +289,7 @@ void remmina_protocol_widget_open_connection(RemminaProtocolWidget* gp, RemminaF
 
 gboolean remmina_protocol_widget_close_connection(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkDisplay *display;
 #if GTK_CHECK_VERSION(3, 20, 0)
 	GdkSeat *seat;
@@ -353,7 +353,7 @@ gboolean remmina_protocol_widget_plugin_receives_keystrokes(RemminaProtocolWidge
 /* Send to the plugin some keystrokes */
 void remmina_protocol_widget_send_keystrokes(RemminaProtocolWidget* gp, GtkMenuItem *widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *keystrokes = g_object_get_data(G_OBJECT(widget), "keystrokes");
 	guint *keyvals;
 	gint i;
@@ -445,7 +445,7 @@ gboolean remmina_protocol_widget_plugin_screenshot(RemminaProtocolWidget* gp, Re
 
 void remmina_protocol_widget_emit_signal(RemminaProtocolWidget* gp, const gchar* signal_name)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	if ( !remmina_masterthread_exec_is_main_thread() ) {
 		/* Allow the execution of this function from a non main thread */
@@ -464,19 +464,19 @@ void remmina_protocol_widget_emit_signal(RemminaProtocolWidget* gp, const gchar*
 
 const RemminaProtocolFeature* remmina_protocol_widget_get_features(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->features;
 }
 
 const gchar* remmina_protocol_widget_get_domain(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->plugin->domain;
 }
 
 gboolean remmina_protocol_widget_query_feature_by_type(RemminaProtocolWidget* gp, RemminaProtocolFeatureType type)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const RemminaProtocolFeature *feature;
 
 #ifdef HAVE_LIBSSH
@@ -494,13 +494,13 @@ gboolean remmina_protocol_widget_query_feature_by_type(RemminaProtocolWidget* gp
 
 gboolean remmina_protocol_widget_query_feature_by_ref(RemminaProtocolWidget* gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->plugin->query_feature(gp, feature);
 }
 
 void remmina_protocol_widget_call_feature_by_type(RemminaProtocolWidget* gp, RemminaProtocolFeatureType type, gint id)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const RemminaProtocolFeature *feature;
 
 	for (feature = gp->priv->plugin->features; feature && feature->type; feature++) {
@@ -513,7 +513,7 @@ void remmina_protocol_widget_call_feature_by_type(RemminaProtocolWidget* gp, Rem
 
 void remmina_protocol_widget_call_feature_by_ref(RemminaProtocolWidget* gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	switch (feature->id) {
 #ifdef HAVE_LIBSSH
 	case REMMINA_PROTOCOL_FEATURE_TOOL_SSH:
@@ -540,7 +540,7 @@ void remmina_protocol_widget_call_feature_by_ref(RemminaProtocolWidget* gp, cons
 
 static gboolean remmina_protocol_widget_on_key_press(GtkWidget *widget, GdkEventKey *event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->hostkey_func) {
 		return gp->priv->hostkey_func(gp, event->keyval, FALSE, gp->priv->hostkey_func_data);
 	}
@@ -549,7 +549,7 @@ static gboolean remmina_protocol_widget_on_key_press(GtkWidget *widget, GdkEvent
 
 static gboolean remmina_protocol_widget_on_key_release(GtkWidget *widget, GdkEventKey *event, RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->hostkey_func) {
 		return gp->priv->hostkey_func(gp, event->keyval, TRUE, gp->priv->hostkey_func_data);
 	}
@@ -558,14 +558,14 @@ static gboolean remmina_protocol_widget_on_key_release(GtkWidget *widget, GdkEve
 
 void remmina_protocol_widget_register_hostkey(RemminaProtocolWidget* gp, GtkWidget *widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_signal_connect(G_OBJECT(widget), "key-press-event", G_CALLBACK(remmina_protocol_widget_on_key_press), gp);
 	g_signal_connect(G_OBJECT(widget), "key-release-event", G_CALLBACK(remmina_protocol_widget_on_key_release), gp);
 }
 
 void remmina_protocol_widget_set_hostkey_func(RemminaProtocolWidget* gp, RemminaHostkeyFunc func, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->hostkey_func = func;
 	gp->priv->hostkey_func_data = data;
 }
@@ -573,7 +573,7 @@ void remmina_protocol_widget_set_hostkey_func(RemminaProtocolWidget* gp, Remmina
 #ifdef HAVE_LIBSSH
 static gboolean remmina_protocol_widget_init_tunnel(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHTunnel *tunnel;
 	gint ret;
 
@@ -608,7 +608,7 @@ static gboolean remmina_protocol_widget_init_tunnel(RemminaProtocolWidget* gp)
 
 gchar* remmina_protocol_widget_start_direct_tunnel(RemminaProtocolWidget* gp, gint default_port, gboolean port_plus)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar *server;
 	gchar *host, *dest;
 	gint port;
@@ -672,7 +672,7 @@ gchar* remmina_protocol_widget_start_direct_tunnel(RemminaProtocolWidget* gp, gi
 
 gboolean remmina_protocol_widget_start_reverse_tunnel(RemminaProtocolWidget* gp, gint local_port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	if (!remmina_file_get_int(gp->priv->remmina_file, "ssh_enabled", FALSE)) {
 		return TRUE;
@@ -696,7 +696,7 @@ gboolean remmina_protocol_widget_start_reverse_tunnel(RemminaProtocolWidget* gp,
 
 gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wait, const gchar *fmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	RemminaSSHTunnel *tunnel = gp->priv->ssh_tunnel;
 	ssh_channel channel;
@@ -755,7 +755,7 @@ gboolean remmina_protocol_widget_ssh_exec(RemminaProtocolWidget* gp, gboolean wa
 #ifdef HAVE_LIBSSH
 static gboolean remmina_protocol_widget_tunnel_init_callback(RemminaSSHTunnel *tunnel, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget* gp = REMMINA_PROTOCOL_WIDGET(data);
 	gchar *server;
 	gint port;
@@ -771,13 +771,13 @@ static gboolean remmina_protocol_widget_tunnel_init_callback(RemminaSSHTunnel *t
 
 static gboolean remmina_protocol_widget_tunnel_connect_callback(RemminaSSHTunnel* tunnel, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static gboolean remmina_protocol_widget_tunnel_disconnect_callback(RemminaSSHTunnel* tunnel, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget* gp = REMMINA_PROTOCOL_WIDGET(data);
 
 	if (REMMINA_SSH(tunnel)->error) {
@@ -791,7 +791,7 @@ static gboolean remmina_protocol_widget_tunnel_disconnect_callback(RemminaSSHTun
 
 gboolean remmina_protocol_widget_start_xport_tunnel(RemminaProtocolWidget* gp, RemminaXPortTunnelInitFunc init_func)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	gboolean bindlocalhost;
 	gchar *server;
@@ -826,7 +826,7 @@ gboolean remmina_protocol_widget_start_xport_tunnel(RemminaProtocolWidget* gp, R
 
 void remmina_protocol_widget_set_display(RemminaProtocolWidget* gp, gint display)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef HAVE_LIBSSH
 	if (gp->priv->ssh_tunnel->localdisplay) g_free(gp->priv->ssh_tunnel->localdisplay);
 	gp->priv->ssh_tunnel->localdisplay = g_strdup_printf("unix:%i", display);
@@ -835,20 +835,20 @@ void remmina_protocol_widget_set_display(RemminaProtocolWidget* gp, gint display
 
 GtkWidget* remmina_protocol_widget_get_init_dialog(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->init_dialog;
 }
 
 gint remmina_protocol_widget_get_profile_remote_width(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("remmina_protocol_widget_get_profile_remote_width");
+	TRACE_CALL(__func__);
 	/* Returns the width of remote desktop as choosen by the user profile */
 	return gp->priv->profile_remote_width;
 }
 
 gint remmina_protocol_widget_get_profile_remote_height(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("remmina_protocol_widget_get_profile_remote_height");
+	TRACE_CALL(__func__);
 	/* Returns the height of remote desktop as choosen by the user profile */
 	return gp->priv->profile_remote_height;
 }
@@ -856,68 +856,68 @@ gint remmina_protocol_widget_get_profile_remote_height(RemminaProtocolWidget* gp
 
 gint remmina_protocol_widget_get_width(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->width;
 }
 
 void remmina_protocol_widget_set_width(RemminaProtocolWidget* gp, gint width)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->width = width;
 }
 
 gint remmina_protocol_widget_get_height(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->height;
 }
 
 void remmina_protocol_widget_set_height(RemminaProtocolWidget* gp, gint height)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->height = height;
 }
 
 RemminaScaleMode remmina_protocol_widget_get_current_scale_mode(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->scalemode;
 }
 
 void remmina_protocol_widget_set_current_scale_mode(RemminaProtocolWidget *gp, RemminaScaleMode scalemode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->scalemode = scalemode;
 }
 
 gboolean remmina_protocol_widget_get_expand(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->scaler_expand;
 }
 
 void remmina_protocol_widget_set_expand(RemminaProtocolWidget* gp, gboolean expand)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->scaler_expand = expand;
 	return;
 }
 
 gboolean remmina_protocol_widget_has_error(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->has_error;
 }
 
 gchar* remmina_protocol_widget_get_error_message(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->error_message;
 }
 
 void remmina_protocol_widget_set_error(RemminaProtocolWidget* gp, const gchar *fmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 
 	if (gp->priv->error_message) g_free(gp->priv->error_message);
@@ -937,19 +937,19 @@ void remmina_protocol_widget_set_error(RemminaProtocolWidget* gp, const gchar *f
 
 gboolean remmina_protocol_widget_is_closed(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->closed;
 }
 
 RemminaFile* remmina_protocol_widget_get_file(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return gp->priv->remmina_file;
 }
 
 gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget* gp, RemminaAuthpwdType authpwd_type, gboolean allow_password_saving)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile = gp->priv->remmina_file;
 	gchar* s;
 	gint ret;
@@ -981,7 +981,7 @@ gint remmina_protocol_widget_init_authpwd(RemminaProtocolWidget* gp, RemminaAuth
 
 gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolean want_domain, gboolean allow_password_saving)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile = gp->priv->remmina_file;
 
 	return remmina_init_dialog_authuserpwd(
@@ -995,42 +995,42 @@ gint remmina_protocol_widget_init_authuserpwd(RemminaProtocolWidget* gp, gboolea
 
 gint remmina_protocol_widget_init_certificate(RemminaProtocolWidget* gp, const gchar* subject, const gchar* issuer, const gchar* fingerprint)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_init_dialog_certificate(REMMINA_INIT_DIALOG(gp->priv->init_dialog), subject, issuer, fingerprint);
 }
 gint remmina_protocol_widget_changed_certificate(RemminaProtocolWidget *gp, const gchar* subject, const gchar* issuer, const gchar* new_fingerprint, const gchar* old_fingerprint)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_init_dialog_certificate_changed(REMMINA_INIT_DIALOG(gp->priv->init_dialog), subject, issuer, new_fingerprint, old_fingerprint);
 }
 
 gchar* remmina_protocol_widget_init_get_username(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_strdup(REMMINA_INIT_DIALOG(gp->priv->init_dialog)->username);
 }
 
 gchar* remmina_protocol_widget_init_get_password(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_strdup(REMMINA_INIT_DIALOG(gp->priv->init_dialog)->password);
 }
 
 gchar* remmina_protocol_widget_init_get_domain(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_strdup(REMMINA_INIT_DIALOG(gp->priv->init_dialog)->domain);
 }
 
 gboolean remmina_protocol_widget_init_get_savepassword(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return REMMINA_INIT_DIALOG(gp->priv->init_dialog)->save_password;
 }
 
 gint remmina_protocol_widget_init_authx509(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile* remminafile = gp->priv->remmina_file;
 
 	return remmina_init_dialog_authx509(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
@@ -1040,7 +1040,7 @@ gint remmina_protocol_widget_init_authx509(RemminaProtocolWidget* gp)
 
 gchar* remmina_protocol_widget_init_get_cacert(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->cacert;
@@ -1049,7 +1049,7 @@ gchar* remmina_protocol_widget_init_get_cacert(RemminaProtocolWidget* gp)
 
 gchar* remmina_protocol_widget_init_get_cacrl(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->cacrl;
@@ -1058,7 +1058,7 @@ gchar* remmina_protocol_widget_init_get_cacrl(RemminaProtocolWidget* gp)
 
 gchar* remmina_protocol_widget_init_get_clientcert(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->clientcert;
@@ -1067,7 +1067,7 @@ gchar* remmina_protocol_widget_init_get_clientcert(RemminaProtocolWidget* gp)
 
 gchar* remmina_protocol_widget_init_get_clientkey(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar* s;
 
 	s = REMMINA_INIT_DIALOG(gp->priv->init_dialog)->clientkey;
@@ -1076,7 +1076,7 @@ gchar* remmina_protocol_widget_init_get_clientkey(RemminaProtocolWidget* gp)
 
 void remmina_protocol_widget_init_save_cred(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaFile* remminafile = gp->priv->remmina_file;
 	gchar* s;
@@ -1131,7 +1131,7 @@ void remmina_protocol_widget_init_save_cred(RemminaProtocolWidget* gp)
 
 void remmina_protocol_widget_init_show_listen(RemminaProtocolWidget* gp, gint port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_init_dialog_set_status(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
 		_("Listening on port %i for an incoming %s connection..."), port,
 		remmina_file_get_string(gp->priv->remmina_file, "protocol"));
@@ -1139,33 +1139,33 @@ void remmina_protocol_widget_init_show_listen(RemminaProtocolWidget* gp, gint po
 
 void remmina_protocol_widget_init_show_retry(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_init_dialog_set_status_temp(REMMINA_INIT_DIALOG(gp->priv->init_dialog),
 		_("Authentication failed. Trying to reconnect..."));
 }
 
 void remmina_protocol_widget_init_show(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_show(gp->priv->init_dialog);
 }
 
 void remmina_protocol_widget_init_hide(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gtk_widget_hide(gp->priv->init_dialog);
 }
 
 static void remmina_protocol_widget_chat_on_destroy(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gp->priv->chat_window = NULL;
 }
 
 void remmina_protocol_widget_chat_open(RemminaProtocolWidget* gp, const gchar *name,
 				       void (*on_send)(RemminaProtocolWidget* gp, const gchar *text), void (*on_destroy)(RemminaProtocolWidget* gp))
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->chat_window) {
 		gtk_window_present(GTK_WINDOW(gp->priv->chat_window));
 	}else  {
@@ -1180,7 +1180,7 @@ void remmina_protocol_widget_chat_open(RemminaProtocolWidget* gp, const gchar *n
 
 void remmina_protocol_widget_chat_close(RemminaProtocolWidget* gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gp->priv->chat_window) {
 		gtk_widget_destroy(gp->priv->chat_window);
 	}
@@ -1188,7 +1188,7 @@ void remmina_protocol_widget_chat_close(RemminaProtocolWidget* gp)
 
 void remmina_protocol_widget_chat_receive(RemminaProtocolWidget* gp, const gchar* text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* This function can be called from a non main thread */
 
 	if (gp->priv->chat_window) {
@@ -1219,7 +1219,7 @@ GtkWidget* remmina_protocol_widget_new(void)
  * press the keys and release them in reversed order. */
 void remmina_protocol_widget_send_keys_signals(GtkWidget *widget, const guint *keyvals, int keyvals_length, GdkEventType action)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int i;
 	GdkEventKey event;
 	GdkKeymap *keymap = gdk_keymap_get_default();
@@ -1258,7 +1258,7 @@ void remmina_protocol_widget_send_keys_signals(GtkWidget *widget, const guint *k
 
 void remmina_protocol_widget_update_remote_resolution(RemminaProtocolWidget* gp, gint w, gint h)
 {
-	TRACE_CALL("remmina_file_update_screen_resolution");
+	TRACE_CALL(__func__);
 	GdkDisplay *display;
 #if GTK_CHECK_VERSION(3, 20, 0)
 	/* TODO: rename to "seat" */

--- a/remmina/src/remmina_public.c
+++ b/remmina/src/remmina_public.c
@@ -61,7 +61,7 @@
 GtkWidget*
 remmina_public_create_combo_entry(const gchar *text, const gchar *def, gboolean descending)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *combo;
 	gboolean found;
 	gchar *buf, *ptr1, *ptr2;
@@ -110,7 +110,7 @@ remmina_public_create_combo_entry(const gchar *text, const gchar *def, gboolean 
 GtkWidget*
 remmina_public_create_combo_text_d(const gchar *text, const gchar *def, const gchar *empty_choice)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *combo;
 	GtkListStore *store;
 	GtkCellRenderer *text_renderer;
@@ -129,7 +129,7 @@ remmina_public_create_combo_text_d(const gchar *text, const gchar *def, const gc
 
 void remmina_public_load_combo_text_d(GtkWidget *combo, const gchar *text, const gchar *def, const gchar *empty_choice)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkListStore *store;
 	GtkTreeIter iter;
 	gint i;
@@ -174,7 +174,7 @@ void remmina_public_load_combo_text_d(GtkWidget *combo, const gchar *text, const
 GtkWidget*
 remmina_public_create_combo(gboolean use_icon)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *combo;
 	GtkListStore *store;
 	GtkCellRenderer *renderer;
@@ -204,7 +204,7 @@ remmina_public_create_combo(gboolean use_icon)
 GtkWidget*
 remmina_public_create_combo_map(const gpointer *key_value_list, const gchar *def, gboolean use_icon, const gchar *domain)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	GtkWidget *combo;
 	GtkListStore *store;
@@ -236,7 +236,7 @@ remmina_public_create_combo_map(const gpointer *key_value_list, const gchar *def
 GtkWidget*
 remmina_public_create_combo_mapint(const gpointer *key_value_list, gint def, gboolean use_icon, const gchar *domain)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar buf[20];
 	g_snprintf(buf, sizeof(buf), "%i", def);
 	return remmina_public_create_combo_map(key_value_list, buf, use_icon, domain);
@@ -244,7 +244,7 @@ remmina_public_create_combo_mapint(const gpointer *key_value_list, gint def, gbo
 
 void remmina_public_create_group(GtkGrid *table, const gchar *group, gint row, gint rows, gint cols)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gchar *str;
 
@@ -265,7 +265,7 @@ void remmina_public_create_group(GtkGrid *table, const gchar *group, gint row, g
 gchar*
 remmina_public_combo_get_active_text(GtkComboBox *combo)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeModel *model;
 	GtkTreeIter iter;
 	gchar *s;
@@ -286,7 +286,7 @@ remmina_public_combo_get_active_text(GtkComboBox *combo)
 #if !GTK_CHECK_VERSION(3, 22, 0)
 void remmina_public_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *push_in, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gint tx, ty;
 	GtkAllocation allocation;
@@ -322,7 +322,7 @@ void remmina_public_popup_position(GtkMenu *menu, gint *x, gint *y, gboolean *pu
 gchar*
 remmina_public_combine_path(const gchar *path1, const gchar *path2)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (!path1 || path1[0] == '\0')
 		return g_strdup(path2);
 	if (path1[strlen(path1) - 1] == '/')
@@ -332,7 +332,7 @@ remmina_public_combine_path(const gchar *path1, const gchar *path2)
 
 void remmina_public_get_server_port(const gchar *server, gint defaultport, gchar **host, gint *port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *str, *ptr, *ptr2;
 
 	str = g_strdup(server);
@@ -378,7 +378,7 @@ void remmina_public_get_server_port(const gchar *server, gint defaultport, gchar
 
 gboolean remmina_public_get_xauth_cookie(const gchar *display, gchar **msg)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar buf[200];
 	gchar *out = NULL;
 	gchar *ptr;
@@ -409,7 +409,7 @@ gboolean remmina_public_get_xauth_cookie(const gchar *display, gchar **msg)
 
 gint remmina_public_open_xdisplay(const gchar *disp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *display;
 	gchar *ptr;
 	gint port;
@@ -443,7 +443,7 @@ gint remmina_public_open_xdisplay(const gchar *disp)
 /* This function was copied from GEdit (gedit-utils.c). */
 guint remmina_public_get_current_workspace(GdkScreen *screen)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef GDK_WINDOWING_X11
 #if GTK_CHECK_VERSION(3, 10, 0)
 	g_return_val_if_fail(GDK_IS_SCREEN(screen), 0);
@@ -494,7 +494,7 @@ guint remmina_public_get_current_workspace(GdkScreen *screen)
 /* This function was copied from GEdit (gedit-utils.c). */
 guint remmina_public_get_window_workspace(GtkWindow *gtkwindow)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 #ifdef GDK_WINDOWING_X11
 #if GTK_CHECK_VERSION(3, 10, 0)
 	GdkWindow *window;
@@ -548,7 +548,7 @@ guint remmina_public_get_window_workspace(GtkWindow *gtkwindow)
 /* Find hardware keycode for the requested keyval */
 guint16 remmina_public_get_keycode_for_keyval(GdkKeymap *keymap, guint keyval)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GdkKeymapKey *keys = NULL;
 	gint length = 0;
 	guint16 keycode = 0;
@@ -563,7 +563,7 @@ guint16 remmina_public_get_keycode_for_keyval(GdkKeymap *keymap, guint keyval)
 /* Check if the requested keycode is a key modifier */
 gboolean remmina_public_get_modifier_for_keycode(GdkKeymap *keymap, guint16 keycode)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_return_val_if_fail(keycode > 0, FALSE);
 #ifdef GDK_WINDOWING_X11
 	return gdk_x11_keymap_key_is_modifier(keymap, keycode);
@@ -575,7 +575,7 @@ gboolean remmina_public_get_modifier_for_keycode(GdkKeymap *keymap, guint16 keyc
 /* Load a GtkBuilder object from a filename */
 GtkBuilder* remmina_public_gtk_builder_new_from_file(gchar *filename)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *ui_path = g_strconcat(REMMINA_RUNTIME_UIDIR, G_DIR_SEPARATOR_S, filename, NULL);
 #if GTK_CHECK_VERSION(3, 10, 0)
 	GtkBuilder *builder = gtk_builder_new_from_file(ui_path);
@@ -591,7 +591,7 @@ GtkBuilder* remmina_public_gtk_builder_new_from_file(gchar *filename)
  * If possible use this function instead of the deprecated gtk_widget_reparent */
 void remmina_public_gtk_widget_reparent(GtkWidget *widget, GtkContainer *container)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_object_ref(widget);
 	gtk_container_remove(GTK_CONTAINER(gtk_widget_get_parent(widget)), widget);
 	gtk_container_add(container, widget);
@@ -601,7 +601,7 @@ void remmina_public_gtk_widget_reparent(GtkWidget *widget, GtkContainer *contain
 /* Validate the inserted value for a new resolution */
 gboolean remmina_public_resolution_validation_func(const gchar *new_str, gchar **error)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 	gint width, height;
 	gboolean splitted;
@@ -643,7 +643,7 @@ gboolean remmina_public_resolution_validation_func(const gchar *new_str, gchar *
 void remmina_public_send_notification(const gchar *notification_id,
 				      const gchar *notification_title, const gchar *notification_message)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GNotification *notification = g_notification_new(notification_title);
 	g_notification_set_body(notification, notification_message);
@@ -657,7 +657,7 @@ void remmina_public_send_notification(const gchar *notification_id,
 /* Replaces all occurences of search in a new copy of string by replacement. */
 gchar* remmina_public_str_replace(const gchar *string, const gchar *search, const gchar *replacement)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *str, **arr;
 
 	g_return_val_if_fail(string != NULL, NULL);
@@ -680,7 +680,7 @@ gchar* remmina_public_str_replace(const gchar *string, const gchar *search, cons
  * and overwrites the original string */
 gchar* remmina_public_str_replace_in_place(gchar *string, const gchar *search, const gchar *replacement)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *new_string = remmina_public_str_replace(string, search, replacement);
 	g_free(string);
 	string = g_strdup(new_string);

--- a/remmina/src/remmina_scrolled_viewport.c
+++ b/remmina/src/remmina_scrolled_viewport.c
@@ -44,7 +44,7 @@ G_DEFINE_TYPE( RemminaScrolledViewport, remmina_scrolled_viewport, GTK_TYPE_EVEN
 
 static void remmina_scrolled_viewport_get_preferred_width(GtkWidget* widget, gint* minimum_width, gint* natural_width)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* Just return a fake small size, so gtk_window_fullscreen() will not fail
 	 * because our content is too big*/
 	if (minimum_width != NULL) *minimum_width = 100;
@@ -53,7 +53,7 @@ static void remmina_scrolled_viewport_get_preferred_width(GtkWidget* widget, gin
 
 static void remmina_scrolled_viewport_get_preferred_height(GtkWidget* widget, gint* minimum_height, gint* natural_height)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* Just return a fake small size, so gtk_window_fullscreen() will not fail
 	 * because our content is too big*/
 	if (minimum_height != NULL) *minimum_height = 100;
@@ -63,7 +63,7 @@ static void remmina_scrolled_viewport_get_preferred_height(GtkWidget* widget, gi
 /* Event handler when mouse move on borders */
 static gboolean remmina_scrolled_viewport_motion_timeout(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaScrolledViewport *gsv;
 	GtkWidget *child;
 	GdkDisplay *display;
@@ -135,14 +135,14 @@ static gboolean remmina_scrolled_viewport_motion_timeout(gpointer data)
 
 static gboolean remmina_scrolled_viewport_enter(GtkWidget *widget, GdkEventCrossing *event, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_scrolled_viewport_remove_motion(REMMINA_SCROLLED_VIEWPORT(widget));
 	return FALSE;
 }
 
 static gboolean remmina_scrolled_viewport_leave(GtkWidget *widget, GdkEventCrossing *event, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaScrolledViewport *gsv = REMMINA_SCROLLED_VIEWPORT(widget);
 	gsv->viewport_motion = TRUE;
 	gsv->viewport_motion_handler = g_timeout_add(20, remmina_scrolled_viewport_motion_timeout, gsv);
@@ -151,13 +151,13 @@ static gboolean remmina_scrolled_viewport_leave(GtkWidget *widget, GdkEventCross
 
 static void remmina_scrolled_viewport_destroy(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_scrolled_viewport_remove_motion(REMMINA_SCROLLED_VIEWPORT(widget));
 }
 
 static void remmina_scrolled_viewport_class_init(RemminaScrolledViewportClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidgetClass *widget_class;
 	widget_class = (GtkWidgetClass*)klass;
 
@@ -168,12 +168,12 @@ static void remmina_scrolled_viewport_class_init(RemminaScrolledViewportClass *k
 
 static void remmina_scrolled_viewport_init(RemminaScrolledViewport *gsv)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 void remmina_scrolled_viewport_remove_motion(RemminaScrolledViewport *gsv)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (gsv->viewport_motion) {
 		gsv->viewport_motion = FALSE;
 		g_source_remove(gsv->viewport_motion_handler);
@@ -184,7 +184,7 @@ void remmina_scrolled_viewport_remove_motion(RemminaScrolledViewport *gsv)
 GtkWidget*
 remmina_scrolled_viewport_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaScrolledViewport *gsv;
 
 	gsv = REMMINA_SCROLLED_VIEWPORT(g_object_new(REMMINA_TYPE_SCROLLED_VIEWPORT, NULL));

--- a/remmina/src/remmina_sftp_client.c
+++ b/remmina/src/remmina_sftp_client.c
@@ -64,7 +64,7 @@ G_DEFINE_TYPE(RemminaSFTPClient, remmina_sftp_client, REMMINA_TYPE_FTP_CLIENT)
 static void
 remmina_sftp_client_class_init(RemminaSFTPClientClass *klass)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 #define GET_SFTPATTR_TYPE(a, type) \
@@ -89,7 +89,7 @@ static gboolean remmina_sftp_client_refresh(RemminaSFTPClient *client);
 static gboolean
 remmina_sftp_client_thread_update_task(RemminaSFTPClient *client, RemminaFTPTask *task)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (THREAD_CHECK_EXIT) return FALSE;
 
 	remmina_ftp_client_update_task(REMMINA_FTP_CLIENT(client), task);
@@ -100,7 +100,7 @@ remmina_sftp_client_thread_update_task(RemminaSFTPClient *client, RemminaFTPTask
 static void
 remmina_sftp_client_thread_set_error(RemminaSFTPClient *client, RemminaFTPTask *task, const gchar *error_format, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 
 	task->status = REMMINA_FTP_TASK_STATUS_ERROR;
@@ -119,7 +119,7 @@ remmina_sftp_client_thread_set_error(RemminaSFTPClient *client, RemminaFTPTask *
 static void
 remmina_sftp_client_thread_set_finish(RemminaSFTPClient *client, RemminaFTPTask *task)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	task->status = REMMINA_FTP_TASK_STATUS_FINISH;
 	g_free(task->tooltip);
 	task->tooltip = NULL;
@@ -130,7 +130,7 @@ remmina_sftp_client_thread_set_finish(RemminaSFTPClient *client, RemminaFTPTask 
 static RemminaFTPTask*
 remmina_sftp_client_thread_get_task(RemminaSFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFTPTask *task;
 
 	if (client->thread_abort) return NULL;
@@ -150,7 +150,7 @@ static gboolean
 remmina_sftp_client_thread_download_file(RemminaSFTPClient *client, RemminaSFTP *sftp, RemminaFTPTask *task,
 					 const gchar *remote_path, const gchar *local_path, guint64 *donesize)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_file remote_file;
 	FILE *local_file;
 	gchar *tmp;
@@ -252,7 +252,7 @@ static gboolean
 remmina_sftp_client_thread_recursive_dir(RemminaSFTPClient *client, RemminaSFTP *sftp, RemminaFTPTask *task,
 					 const gchar *rootdir_path, const gchar *subdir_path, GPtrArray *array)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_dir sftpdir;
 	sftp_attributes sftpattr;
 	gchar *tmp;
@@ -324,7 +324,7 @@ static gboolean
 remmina_sftp_client_thread_recursive_localdir(RemminaSFTPClient *client, RemminaFTPTask *task,
 					      const gchar *rootdir_path, const gchar *subdir_path, GPtrArray *array)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GDir *dir;
 	gchar *path;
 	const gchar *name;
@@ -368,7 +368,7 @@ remmina_sftp_client_thread_recursive_localdir(RemminaSFTPClient *client, Remmina
 static gboolean
 remmina_sftp_client_thread_mkdir(RemminaSFTPClient *client, RemminaSFTP *sftp, RemminaFTPTask *task, const gchar *path)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_attributes sftpattr;
 
 	sftpattr = sftp_stat(sftp->sftp_sess, path);
@@ -388,7 +388,7 @@ static gboolean
 remmina_sftp_client_thread_upload_file(RemminaSFTPClient *client, RemminaSFTP *sftp, RemminaFTPTask *task,
 				       const gchar *remote_path, const gchar *local_path, guint64 *donesize)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_file remote_file;
 	FILE *local_file;
 	gchar *tmp;
@@ -487,7 +487,7 @@ remmina_sftp_client_thread_upload_file(RemminaSFTPClient *client, RemminaSFTP *s
 static gpointer
 remmina_sftp_client_thread_main(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSFTPClient *client = REMMINA_SFTP_CLIENT(data);
 	RemminaSFTP *sftp = NULL;
 	RemminaFTPTask *task;
@@ -643,7 +643,7 @@ remmina_sftp_client_thread_main(gpointer data)
 static void
 remmina_sftp_client_destroy(RemminaSFTPClient *client, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (client->sftp) {
 		remmina_sftp_free(client->sftp);
 		client->sftp = NULL;
@@ -660,7 +660,7 @@ remmina_sftp_client_destroy(RemminaSFTPClient *client, gpointer data)
 static sftp_dir
 remmina_sftp_client_sftp_session_opendir(RemminaSFTPClient *client, const gchar *dir)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_dir sftpdir;
 	GtkWidget *dialog;
 
@@ -680,7 +680,7 @@ remmina_sftp_client_sftp_session_opendir(RemminaSFTPClient *client, const gchar 
 static gboolean
 remmina_sftp_client_sftp_session_closedir(RemminaSFTPClient *client, sftp_dir sftpdir)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 
 	if (!sftp_dir_eof(sftpdir)) {
@@ -698,7 +698,7 @@ remmina_sftp_client_sftp_session_closedir(RemminaSFTPClient *client, sftp_dir sf
 static void
 remmina_sftp_client_on_opendir(RemminaSFTPClient *client, gchar *dir, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp_dir sftpdir;
 	sftp_attributes sftpattr;
 	GtkWidget *dialog;
@@ -775,7 +775,7 @@ remmina_sftp_client_on_opendir(RemminaSFTPClient *client, gchar *dir, gpointer d
 static void
 remmina_sftp_client_on_newtask(RemminaSFTPClient *client, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (client->thread) return;
 
 	if (pthread_create(&client->thread, NULL, remmina_sftp_client_thread_main, client)) {
@@ -786,7 +786,7 @@ remmina_sftp_client_on_newtask(RemminaSFTPClient *client, gpointer data)
 static gboolean
 remmina_sftp_client_on_canceltask(RemminaSFTPClient *client, gint taskid, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 	gint ret;
 
@@ -808,7 +808,7 @@ remmina_sftp_client_on_canceltask(RemminaSFTPClient *client, gint taskid, gpoint
 static gboolean
 remmina_sftp_client_on_deletefile(RemminaSFTPClient *client, gint type, gchar *name, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *dialog;
 	gint ret = 0;
 	gchar *tmp;
@@ -840,7 +840,7 @@ remmina_sftp_client_on_deletefile(RemminaSFTPClient *client, gint type, gchar *n
 static void
 remmina_sftp_client_init(RemminaSFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	client->sftp = NULL;
 	client->thread = 0;
 	client->taskid = 0;
@@ -862,7 +862,7 @@ remmina_sftp_client_init(RemminaSFTPClient *client)
 static gboolean
 remmina_sftp_client_refresh(RemminaSFTPClient *client)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	SET_CURSOR(gdk_cursor_new_for_display(gdk_display_get_default(), GDK_WATCH));
 	gdk_flush();
 
@@ -876,7 +876,7 @@ remmina_sftp_client_refresh(RemminaSFTPClient *client)
 gint
 remmina_sftp_client_confirm_resume(RemminaSFTPClient *client, const gchar *path)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	GtkWidget *dialog;
 	gint response;
@@ -948,14 +948,14 @@ remmina_sftp_client_confirm_resume(RemminaSFTPClient *client, const gchar *path)
 GtkWidget*
 remmina_sftp_client_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return GTK_WIDGET(g_object_new(REMMINA_TYPE_SFTP_CLIENT, NULL));
 }
 
 void
 remmina_sftp_client_open(RemminaSFTPClient *client, RemminaSFTP *sftp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	client->sftp = sftp;
 
 	g_idle_add((GSourceFunc)remmina_sftp_client_refresh, client);
@@ -964,7 +964,7 @@ remmina_sftp_client_open(RemminaSFTPClient *client, RemminaSFTP *sftp)
 GtkWidget*
 remmina_sftp_client_new_init(RemminaSFTP *sftp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *client;
 	GtkWidget *dialog;
 

--- a/remmina/src/remmina_sftp_plugin.c
+++ b/remmina/src/remmina_sftp_plugin.c
@@ -66,7 +66,7 @@ static RemminaPluginService *remmina_plugin_service = NULL;
 static gpointer
 remmina_plugin_sftp_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = (RemminaProtocolWidget*)data;
 	RemminaPluginSftpData *gpdata;
 	RemminaFile *remminafile;
@@ -143,7 +143,7 @@ remmina_plugin_sftp_main_thread(gpointer data)
 static void
 remmina_plugin_sftp_client_on_realize(GtkWidget *widget, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaFile *remminafile;
 
 	remminafile = remmina_plugin_service->protocol_plugin_get_file(gp);
@@ -153,7 +153,7 @@ remmina_plugin_sftp_client_on_realize(GtkWidget *widget, RemminaProtocolWidget *
 static void
 remmina_plugin_sftp_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSftpData *gpdata;
 	RemminaFile *remminafile;
 
@@ -182,7 +182,7 @@ remmina_plugin_sftp_init(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_sftp_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSftpData *gpdata = GET_PLUGIN_DATA(gp);
 
 	remmina_plugin_service->protocol_plugin_set_expand(gp, TRUE);
@@ -203,7 +203,7 @@ remmina_plugin_sftp_open_connection(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_sftp_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSftpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -226,14 +226,14 @@ remmina_plugin_sftp_close_connection(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_sftp_query_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static void
 remmina_plugin_sftp_call_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSftpData *gpdata = GET_PLUGIN_DATA(gp);
 	RemminaFile *remminafile;
 
@@ -327,7 +327,7 @@ static RemminaProtocolPlugin remmina_plugin_sftp =
 void
 remmina_sftp_plugin_register(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_service = &remmina_plugin_manager_service;
 	remmina_plugin_service->register_plugin((RemminaPlugin*)&remmina_plugin_sftp);
 }
@@ -336,7 +336,7 @@ remmina_sftp_plugin_register(void)
 
 void remmina_sftp_plugin_register(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 #endif

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -116,7 +116,7 @@ static const gchar *common_identities[] =
 gchar*
 remmina_ssh_identity_path(const gchar *id)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (id == NULL) return NULL;
 	if (id[0] == '/') return g_strdup(id);
 	return g_strdup_printf("%s/%s", g_get_home_dir(), id);
@@ -125,7 +125,7 @@ remmina_ssh_identity_path(const gchar *id)
 gchar*
 remmina_ssh_find_identity(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *path;
 	gint i;
 
@@ -142,7 +142,7 @@ remmina_ssh_find_identity(void)
 void
 remmina_ssh_set_error(RemminaSSH *ssh, const gchar *fmt)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar *err;
 
 	err = ssh_get_error(ssh->session);
@@ -152,7 +152,7 @@ remmina_ssh_set_error(RemminaSSH *ssh, const gchar *fmt)
 void
 remmina_ssh_set_application_error(RemminaSSH *ssh, const gchar *fmt, ...)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	va_list args;
 
 	va_start(args, fmt);
@@ -163,7 +163,7 @@ remmina_ssh_set_application_error(RemminaSSH *ssh, const gchar *fmt, ...)
 static gint
 remmina_ssh_auth_password(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint ret;
 	gint authlist;
 	gint n;
@@ -197,7 +197,7 @@ remmina_ssh_auth_password(RemminaSSH *ssh)
 static gint
 remmina_ssh_auth_pubkey(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint ret;
 	ssh_key priv_key;
 
@@ -232,7 +232,7 @@ remmina_ssh_auth_pubkey(RemminaSSH *ssh)
 static gint
 remmina_ssh_auth_auto_pubkey(RemminaSSH* ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* ssh->password should be ssh->passphrase, TODO */
 	if (ssh->passphrase == NULL  || ssh->passphrase[0] == '\0') return -1;
 	gint ret = ssh_userauth_publickey_auto(ssh->session, ssh->user, ssh->passphrase);
@@ -249,7 +249,7 @@ remmina_ssh_auth_auto_pubkey(RemminaSSH* ssh)
 static gint
 remmina_ssh_auth_agent(RemminaSSH* ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint ret;
 	ret = ssh_userauth_agent(ssh->session, ssh->user);
 
@@ -265,7 +265,7 @@ remmina_ssh_auth_agent(RemminaSSH* ssh)
 static gint
 remmina_ssh_auth_gssapi(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint ret;
 
 	if (ssh->authenticated) return 1;
@@ -284,7 +284,7 @@ remmina_ssh_auth_gssapi(RemminaSSH *ssh)
 gint
 remmina_ssh_auth(RemminaSSH *ssh, const gchar *password)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	/* Check known host again to ensure it's still the original server when user forks
 	   a new session from existing one */
 	if (ssh_is_server_known(ssh->session) != SSH_SERVER_KNOWN_OK) {
@@ -324,7 +324,7 @@ remmina_ssh_auth(RemminaSSH *ssh, const gchar *password)
 gint
 remmina_ssh_auth_gui(RemminaSSH *ssh, RemminaInitDialog *dialog, RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *tips;
 	gchar *keyname;
 	gchar *pwdtype;
@@ -427,14 +427,14 @@ remmina_ssh_auth_gui(RemminaSSH *ssh, RemminaInitDialog *dialog, RemminaFile *re
 void
 remmina_ssh_log_callback(ssh_session session, int priority, const char *message, void *userdata)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_log_printf("[SSH] %s\n", message);
 }
 
 gboolean
 remmina_ssh_init_session(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint verbosity;
 #ifdef HAVE_NETINET_TCP_H
 	socket_t sshsock;
@@ -519,7 +519,7 @@ remmina_ssh_init_session(RemminaSSH *ssh)
 gboolean
 remmina_ssh_init_from_file(RemminaSSH *ssh, RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	const gchar *ssh_server;
 	const gchar *ssh_username;
 	const gchar *ssh_privatekey;
@@ -572,7 +572,7 @@ remmina_ssh_init_from_file(RemminaSSH *ssh, RemminaFile *remminafile)
 static gboolean
 remmina_ssh_init_from_ssh(RemminaSSH *ssh, const RemminaSSH *ssh_src)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	ssh->session = NULL;
 	ssh->authenticated = FALSE;
 	ssh->error = NULL;
@@ -592,7 +592,7 @@ remmina_ssh_init_from_ssh(RemminaSSH *ssh, const RemminaSSH *ssh_src)
 gchar*
 remmina_ssh_convert(RemminaSSH *ssh, const gchar *from)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *to = NULL;
 
 	if (ssh->charset && from) {
@@ -605,7 +605,7 @@ remmina_ssh_convert(RemminaSSH *ssh, const gchar *from)
 gchar*
 remmina_ssh_unconvert(RemminaSSH *ssh, const gchar *from)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *to = NULL;
 
 	if (ssh->charset && from) {
@@ -618,7 +618,7 @@ remmina_ssh_unconvert(RemminaSSH *ssh, const gchar *from)
 void
 remmina_ssh_free(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (ssh->session) {
 		ssh_disconnect(ssh->session);
 		ssh_free(ssh->session);
@@ -647,7 +647,7 @@ struct _RemminaSSHTunnelBuffer {
 static RemminaSSHTunnelBuffer*
 remmina_ssh_tunnel_buffer_new(ssize_t len)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHTunnelBuffer *buffer;
 
 	buffer = g_new(RemminaSSHTunnelBuffer, 1);
@@ -660,7 +660,7 @@ remmina_ssh_tunnel_buffer_new(ssize_t len)
 static void
 remmina_ssh_tunnel_buffer_free(RemminaSSHTunnelBuffer *buffer)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (buffer) {
 		g_free(buffer->data);
 		g_free(buffer);
@@ -670,7 +670,7 @@ remmina_ssh_tunnel_buffer_free(RemminaSSHTunnelBuffer *buffer)
 RemminaSSHTunnel*
 remmina_ssh_tunnel_new_from_file(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHTunnel *tunnel;
 
 	tunnel = g_new(RemminaSSHTunnel, 1);
@@ -705,7 +705,7 @@ remmina_ssh_tunnel_new_from_file(RemminaFile *remminafile)
 static void
 remmina_ssh_tunnel_close_all_channels(RemminaSSHTunnel *tunnel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	int i;
 
 	for (i = 0; i < tunnel->num_channels; i++) {
@@ -737,7 +737,7 @@ remmina_ssh_tunnel_close_all_channels(RemminaSSHTunnel *tunnel)
 static void
 remmina_ssh_tunnel_remove_channel(RemminaSSHTunnel *tunnel, gint n)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	ssh_channel_close(tunnel->channels[n]);
 	ssh_channel_send_eof(tunnel->channels[n]);
 	ssh_channel_free(tunnel->channels[n]);
@@ -754,7 +754,7 @@ remmina_ssh_tunnel_remove_channel(RemminaSSHTunnel *tunnel, gint n)
 static void
 remmina_ssh_tunnel_add_channel(RemminaSSHTunnel *tunnel, ssh_channel channel, gint sock)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint flags;
 	gint i;
 
@@ -784,7 +784,7 @@ remmina_ssh_tunnel_add_channel(RemminaSSHTunnel *tunnel, ssh_channel channel, gi
 static gpointer
 remmina_ssh_tunnel_main_thread_proc(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHTunnel *tunnel = (RemminaSSHTunnel*)data;
 	gchar *ptr;
 	ssize_t len = 0, lenw = 0;
@@ -1119,7 +1119,7 @@ remmina_ssh_tunnel_main_thread_proc(gpointer data)
 static gpointer
 remmina_ssh_tunnel_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHTunnel *tunnel = (RemminaSSHTunnel*)data;
 
 	pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, NULL);
@@ -1135,7 +1135,7 @@ remmina_ssh_tunnel_main_thread(gpointer data)
 void
 remmina_ssh_tunnel_cancel_accept(RemminaSSHTunnel *tunnel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (tunnel->server_sock >= 0) {
 		close(tunnel->server_sock);
 		tunnel->server_sock = -1;
@@ -1145,7 +1145,7 @@ remmina_ssh_tunnel_cancel_accept(RemminaSSHTunnel *tunnel)
 gboolean
 remmina_ssh_tunnel_open(RemminaSSHTunnel* tunnel, const gchar *host, gint port, gint local_port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint sock;
 	gint sockopt = 1;
 	struct sockaddr_in sin;
@@ -1196,7 +1196,7 @@ remmina_ssh_tunnel_open(RemminaSSHTunnel* tunnel, const gchar *host, gint port, 
 gboolean
 remmina_ssh_tunnel_x11(RemminaSSHTunnel *tunnel, const gchar *cmd)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	tunnel->tunnel_type = REMMINA_SSH_TUNNEL_X11;
 	tunnel->dest = g_strdup(cmd);
 	tunnel->running = TRUE;
@@ -1212,7 +1212,7 @@ remmina_ssh_tunnel_x11(RemminaSSHTunnel *tunnel, const gchar *cmd)
 gboolean
 remmina_ssh_tunnel_xport(RemminaSSHTunnel *tunnel, gboolean bindlocalhost)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	tunnel->tunnel_type = REMMINA_SSH_TUNNEL_XPORT;
 	tunnel->bindlocalhost = bindlocalhost;
 	tunnel->running = TRUE;
@@ -1228,7 +1228,7 @@ remmina_ssh_tunnel_xport(RemminaSSHTunnel *tunnel, gboolean bindlocalhost)
 gboolean
 remmina_ssh_tunnel_reverse(RemminaSSHTunnel *tunnel, gint port, gint local_port)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	tunnel->tunnel_type = REMMINA_SSH_TUNNEL_REVERSE;
 	tunnel->port = port;
 	tunnel->localport = local_port;
@@ -1245,14 +1245,14 @@ remmina_ssh_tunnel_reverse(RemminaSSHTunnel *tunnel, gint port, gint local_port)
 gboolean
 remmina_ssh_tunnel_terminated(RemminaSSHTunnel* tunnel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return (tunnel->thread == 0);
 }
 
 void
 remmina_ssh_tunnel_free(RemminaSSHTunnel* tunnel)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_t thread;
 
 	thread = tunnel->thread;
@@ -1289,7 +1289,7 @@ remmina_ssh_tunnel_free(RemminaSSHTunnel* tunnel)
 RemminaSFTP*
 remmina_sftp_new_from_file(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSFTP *sftp;
 
 	sftp = g_new(RemminaSFTP, 1);
@@ -1304,7 +1304,7 @@ remmina_sftp_new_from_file(RemminaFile *remminafile)
 RemminaSFTP*
 remmina_sftp_new_from_ssh(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSFTP *sftp;
 
 	sftp = g_new(RemminaSFTP, 1);
@@ -1319,7 +1319,7 @@ remmina_sftp_new_from_ssh(RemminaSSH *ssh)
 gboolean
 remmina_sftp_open(RemminaSFTP *sftp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	sftp->sftp_sess = sftp_new(sftp->ssh.session);
 	if (!sftp->sftp_sess) {
 		remmina_ssh_set_error(REMMINA_SSH(sftp), _("Failed to create sftp session: %s"));
@@ -1335,7 +1335,7 @@ remmina_sftp_open(RemminaSFTP *sftp)
 void
 remmina_sftp_free(RemminaSFTP *sftp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if (sftp->sftp_sess) {
 		sftp_free(sftp->sftp_sess);
 		sftp->sftp_sess = NULL;
@@ -1350,7 +1350,7 @@ remmina_sftp_free(RemminaSFTP *sftp)
 RemminaSSHShell*
 remmina_ssh_shell_new_from_file(RemminaFile *remminafile)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHShell *shell;
 
 	shell = g_new0(RemminaSSHShell, 1);
@@ -1367,7 +1367,7 @@ remmina_ssh_shell_new_from_file(RemminaFile *remminafile)
 RemminaSSHShell*
 remmina_ssh_shell_new_from_ssh(RemminaSSH *ssh)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHShell *shell;
 
 	shell = g_new0(RemminaSSHShell, 1);
@@ -1383,7 +1383,7 @@ remmina_ssh_shell_new_from_ssh(RemminaSSH *ssh)
 static gboolean
 remmina_ssh_call_exit_callback_on_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 
 	RemminaSSHShell *shell = (RemminaSSHShell*)data;
 	if ( shell->exit_callback )
@@ -1394,7 +1394,7 @@ remmina_ssh_call_exit_callback_on_main_thread(gpointer data)
 static gpointer
 remmina_ssh_shell_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaSSHShell *shell = (RemminaSSHShell*)data;
 	fd_set fds;
 	struct timeval timeout;
@@ -1508,7 +1508,7 @@ remmina_ssh_shell_thread(gpointer data)
 gboolean
 remmina_ssh_shell_open(RemminaSSHShell *shell, RemminaSSHExitFunc exit_callback, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *slavedevice;
 	struct termios stermios;
 
@@ -1543,7 +1543,7 @@ remmina_ssh_shell_open(RemminaSSHShell *shell, RemminaSSHExitFunc exit_callback,
 void
 remmina_ssh_shell_set_size(RemminaSSHShell *shell, gint columns, gint rows)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	LOCK_SSH(shell)
 	if (shell->channel) {
 		ssh_channel_change_pty_size(shell->channel, columns, rows);
@@ -1554,7 +1554,7 @@ remmina_ssh_shell_set_size(RemminaSSHShell *shell, gint columns, gint rows)
 void
 remmina_ssh_shell_free(RemminaSSHShell *shell)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	pthread_t thread = shell->thread;
 
 	shell->exit_callback = NULL;

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -207,7 +207,7 @@ static RemminaPluginService *remmina_plugin_service = NULL;
 static gpointer
 remmina_plugin_ssh_main_thread(gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaProtocolWidget *gp = (RemminaProtocolWidget*)data;
 	RemminaPluginSshData *gpdata;
 	RemminaFile *remminafile;
@@ -281,7 +281,7 @@ remmina_plugin_ssh_main_thread(gpointer data)
 
 void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal, const char *codeset, int master, int slave)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	if ( !remmina_masterthread_exec_is_main_thread() ) {
 		/* Allow the execution of this function from a non main thread */
 		RemminaMTExecData *d;
@@ -320,7 +320,7 @@ void remmina_plugin_ssh_vte_terminal_set_encoding_and_pty(VteTerminal *terminal,
 static gboolean
 remmina_plugin_ssh_on_focus_in(GtkWidget *widget, GdkEventFocus *event, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 
 	gtk_widget_grab_focus(gpdata->vte);
@@ -330,7 +330,7 @@ remmina_plugin_ssh_on_focus_in(GtkWidget *widget, GdkEventFocus *event, RemminaP
 static gboolean
 remmina_plugin_ssh_on_size_allocate(GtkWidget *widget, GtkAllocation *alloc, RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 	gint cols, rows;
 
@@ -347,7 +347,7 @@ remmina_plugin_ssh_on_size_allocate(GtkWidget *widget, GtkAllocation *alloc, Rem
 static void
 remmina_plugin_ssh_set_vte_pref(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 
 	if (remmina_pref.vte_font && remmina_pref.vte_font[0]) {
@@ -432,7 +432,7 @@ remmina_plugin_ssh_vte_save_session(GtkMenuItem *menuitem, RemminaProtocolWidget
 /* Send a keystroke to the plugin window */
 static void remmina_ssh_keystroke(RemminaProtocolWidget *gp, const guint keystrokes[], const gint keylen)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 	remmina_plugin_service->protocol_plugin_send_keys_signals(gpdata->vte,
 		keystrokes, keylen, GDK_KEY_PRESS | GDK_KEY_RELEASE);
@@ -459,7 +459,7 @@ remmina_ssh_plugin_popup_menu(GtkWidget *widget, GdkEvent *event, GtkWidget *men
 
 void remmina_plugin_ssh_popup_ui(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 	/* Context menu for slection and clipboard */
 	GtkWidget *menu = gtk_menu_new();
@@ -492,7 +492,7 @@ void remmina_plugin_ssh_popup_ui(RemminaProtocolWidget *gp)
 static void
 remmina_plugin_ssh_init(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata;
 	RemminaFile *remminafile;
 	GtkWidget *hbox;
@@ -666,7 +666,7 @@ remmina_plugin_ssh_init(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_ssh_open_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 
 	remmina_plugin_service->protocol_plugin_set_expand(gp, TRUE);
@@ -687,7 +687,7 @@ remmina_plugin_ssh_open_connection(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_ssh_close_connection(RemminaProtocolWidget *gp)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 
 	RemminaFile *remminafile;
@@ -713,14 +713,14 @@ remmina_plugin_ssh_close_connection(RemminaProtocolWidget *gp)
 static gboolean
 remmina_plugin_ssh_query_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return TRUE;
 }
 
 static void
 remmina_plugin_ssh_call_feature(RemminaProtocolWidget *gp, const RemminaProtocolFeature *feature)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaPluginSshData *gpdata = GET_PLUGIN_DATA(gp);
 
 	switch (feature->id) {
@@ -902,7 +902,7 @@ static RemminaProtocolPlugin remmina_plugin_ssh =
 void
 remmina_ssh_plugin_register(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_plugin_ssh_features[0].opt3 = GUINT_TO_POINTER(remmina_pref.vte_shortcutkey_copy);
 	remmina_plugin_ssh_features[1].opt3 = GUINT_TO_POINTER(remmina_pref.vte_shortcutkey_paste);
 	remmina_plugin_ssh_features[2].opt3 = GUINT_TO_POINTER(remmina_pref.vte_shortcutkey_select_all);
@@ -919,7 +919,7 @@ remmina_ssh_plugin_register(void)
 
 void remmina_ssh_plugin_register(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 }
 
 #endif

--- a/remmina/src/remmina_string_array.c
+++ b/remmina/src/remmina_string_array.c
@@ -42,14 +42,14 @@
 RemminaStringArray*
 remmina_string_array_new(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_ptr_array_new();
 }
 
 RemminaStringArray*
 remmina_string_array_new_from_string(const gchar *strs)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaStringArray *array;
 	gchar *buf, *ptr1, *ptr2;
 
@@ -75,7 +75,7 @@ remmina_string_array_new_from_string(const gchar *strs)
 RemminaStringArray*
 remmina_string_array_new_from_allocated_string(gchar *strs)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaStringArray *array;
 	array = remmina_string_array_new_from_string(strs);
 	g_free(strs);
@@ -84,13 +84,13 @@ remmina_string_array_new_from_allocated_string(gchar *strs)
 
 void remmina_string_array_add(RemminaStringArray* array, const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_add(array, g_strdup(str));
 }
 
 gint remmina_string_array_find(RemminaStringArray* array, const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 
 	for (i = 0; i < array->len; i++) {
@@ -102,13 +102,13 @@ gint remmina_string_array_find(RemminaStringArray* array, const gchar *str)
 
 void remmina_string_array_remove_index(RemminaStringArray* array, gint i)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_remove_index(array, i);
 }
 
 void remmina_string_array_remove(RemminaStringArray* array, const gchar *str)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gint i;
 
 	i = remmina_string_array_find(array, str);
@@ -119,7 +119,7 @@ void remmina_string_array_remove(RemminaStringArray* array, const gchar *str)
 
 void remmina_string_array_intersect(RemminaStringArray* array, const gchar *dest_strs)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	RemminaStringArray *dest_array;
 	gint i, j;
 
@@ -140,20 +140,20 @@ void remmina_string_array_intersect(RemminaStringArray* array, const gchar *dest
 
 static gint remmina_string_array_compare_func(const gchar **a, const gchar **b)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return g_strcmp0(*a, *b);
 }
 
 void remmina_string_array_sort(RemminaStringArray *array)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_sort(array, (GCompareFunc)remmina_string_array_compare_func);
 }
 
 gchar*
 remmina_string_array_to_string(RemminaStringArray* array)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GString *gstr;
 	gint i;
 
@@ -168,7 +168,7 @@ remmina_string_array_to_string(RemminaStringArray* array)
 
 void remmina_string_array_free(RemminaStringArray *array)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_foreach(array, (GFunc)g_free, NULL);
 	g_ptr_array_free(array, TRUE);
 }

--- a/remmina/src/remmina_string_list.c
+++ b/remmina/src/remmina_string_list.c
@@ -61,7 +61,7 @@ void remmina_string_list_update_buttons_state(void)
 /* Check the text inserted in the list */
 void remmina_string_list_on_cell_edited(GtkCellRendererText *cell, const gchar *path_string, const gchar *new_text)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	gchar *text;
 	gchar *error;
 	GtkTreePath *path = gtk_tree_path_new_from_string(path_string);
@@ -92,7 +92,7 @@ void remmina_string_list_on_cell_edited(GtkCellRendererText *cell, const gchar *
 /* Move a TreeIter position */
 static void remmina_string_list_move_iter(GtkTreeIter *from, GtkTreeIter *to)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreePath *path;
 
 	gtk_list_store_swap(string_list->liststore_items, from, to);
@@ -104,7 +104,7 @@ static void remmina_string_list_move_iter(GtkTreeIter *from, GtkTreeIter *to)
 /* Move down the selected TreeRow */
 void remmina_string_list_on_action_down(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	GtkTreeIter target_iter;
 
@@ -119,7 +119,7 @@ void remmina_string_list_on_action_down(GtkWidget *widget, gpointer user_data)
 /* Move up the selected TreeRow */
 void remmina_string_list_on_action_up(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	GtkTreeIter target_iter;
 	GtkTreePath *path;
@@ -139,7 +139,7 @@ void remmina_string_list_on_action_up(GtkWidget *widget, gpointer user_data)
 /* Add a new TreeRow to the list */
 void remmina_string_list_on_action_add(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	GtkTreePath *path;
 
@@ -158,7 +158,7 @@ void remmina_string_list_on_action_add(GtkWidget *widget, gpointer user_data)
 /* Remove the selected TreeRow from the list */
 void remmina_string_list_on_action_remove(GtkWidget *widget, gpointer user_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 
 	if (gtk_tree_selection_get_selected(string_list->treeview_selection, NULL, &iter)) {
@@ -171,7 +171,7 @@ void remmina_string_list_on_action_remove(GtkWidget *widget, gpointer user_data)
 /* Load a string list by splitting a string value */
 void remmina_string_list_set_text(const gchar *text, const gboolean clear_data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkTreeIter iter;
 	gchar **items;
 	gchar **values;
@@ -205,7 +205,7 @@ void remmina_string_list_set_text(const gchar *text, const gboolean clear_data)
 /* Get a string value representing the string list */
 gchar* remmina_string_list_get_text(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GString *str;
 	GtkTreeIter iter;
 	gboolean first;
@@ -247,7 +247,7 @@ gchar* remmina_string_list_get_text(void)
 /* Set a function that will be used to validate the new rows */
 void remmina_string_list_set_validation_func(RemminaStringListValidationFunc func)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	string_list->priv->validation_func = func;
 }
 
@@ -269,7 +269,7 @@ void remmina_string_list_set_titles(gchar *title1, gchar *title2)
 /* RemminaStringList initialization */
 static void remmina_string_list_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	string_list->priv->validation_func = NULL;
 	/* When two columns are requested, show also the first column */
 	if (string_list->priv->two_columns)
@@ -280,7 +280,7 @@ static void remmina_string_list_init(void)
 /* RemminaStringList instance */
 GtkDialog* remmina_string_list_new(gboolean two_columns, const gchar *fields_separator)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	string_list = g_new0(RemminaStringList, 1);
 	string_list->priv = g_new0(RemminaStringListPriv, 1);
 

--- a/remmina/src/remmina_sysinfo.c
+++ b/remmina/src/remmina_sysinfo.c
@@ -46,7 +46,7 @@ gboolean remmina_sysinfo_is_appindicator_available()
 	 * DBUS KDE StatusNotifier)
 	 */
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GDBusConnection *con;
 	GVariant *v;
 	GError *error;
@@ -82,7 +82,7 @@ gchar *remmina_sysinfo_get_gnome_shell_version()
 	 * if error or no gnome shell found.
 	 * The returned string must be freed with g_free */
 
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GDBusConnection *con;
 	GDBusProxy *p;
 	GVariant *v;

--- a/remmina/src/remmina_widget_pool.c
+++ b/remmina/src/remmina_widget_pool.c
@@ -43,19 +43,19 @@ static GPtrArray *remmina_widget_pool = NULL;
 
 void remmina_widget_pool_init(void)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	remmina_widget_pool = g_ptr_array_new();
 }
 
 static void remmina_widget_pool_on_widget_destroy(GtkWidget *widget, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_remove(remmina_widget_pool, widget);
 }
 
 void remmina_widget_pool_register(GtkWidget *widget)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	g_ptr_array_add(remmina_widget_pool, widget);
 	g_signal_connect(G_OBJECT(widget), "destroy", G_CALLBACK(remmina_widget_pool_on_widget_destroy), NULL);
 }
@@ -63,7 +63,7 @@ void remmina_widget_pool_register(GtkWidget *widget)
 GtkWidget*
 remmina_widget_pool_find(GType type, const gchar *tag)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gint i;
 
@@ -84,7 +84,7 @@ remmina_widget_pool_find(GType type, const gchar *tag)
 GtkWidget*
 remmina_widget_pool_find_by_window(GType type, GdkWindow *window)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gint i;
 	GdkWindow *parent;
@@ -107,7 +107,7 @@ remmina_widget_pool_find_by_window(GType type, GdkWindow *window)
 
 gint remmina_widget_pool_foreach(RemminaWidgetPoolForEachFunc callback, gpointer data)
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	GtkWidget *widget;
 	gint i;
 	gint n = 0;
@@ -138,7 +138,7 @@ gint remmina_widget_pool_foreach(RemminaWidgetPoolForEachFunc callback, gpointer
 
 gint remmina_widget_pool_count()
 {
-	TRACE_CALL("__func__");
+	TRACE_CALL(__func__);
 	return remmina_widget_pool->len;
 }
 


### PR DESCRIPTION
When `__func__` is quoted, it is not replaced by the preprocessor leading to the following output:

    28/10/2017 11:40:52 Trace calls: __func__

instead of the expected one:

    28/10/2017 11:45:08 Trace calls: remmina_on_startup