### PR TITLE
ssh_userauth_publickey_auto: should accept empty passphrase

### DIFF
--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -234,12 +234,12 @@ remmina_ssh_auth_auto_pubkey(RemminaSSH* ssh)
 {
 	TRACE_CALL(__func__);
 	/* ssh->password should be ssh->passphrase, TODO */
-	if (ssh->passphrase == NULL  || ssh->passphrase[0] == '\0') return -1;
+	//if (ssh->passphrase == NULL  || ssh->passphrase[0] == '\0') return -1;
 	gint ret = ssh_userauth_publickey_auto(ssh->session, ssh->user, ssh->passphrase);
 
 	if (ret != SSH_AUTH_SUCCESS) {
 		remmina_ssh_set_error(ssh, _("SSH automatic public key authentication failed: %s"));
-		return 0;
+		return -1;
 	}
 
 	ssh->authenticated = TRUE;

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -234,7 +234,6 @@ remmina_ssh_auth_auto_pubkey(RemminaSSH* ssh)
 {
 	TRACE_CALL(__func__);
 	/* ssh->password should be ssh->passphrase, TODO */
-	//if (ssh->passphrase == NULL  || ssh->passphrase[0] == '\0') return -1;
 	gint ret = ssh_userauth_publickey_auto(ssh->session, ssh->user, ssh->passphrase);
 
 	if (ret != SSH_AUTH_SUCCESS) {


### PR DESCRIPTION
Empty passphrase should be a valid input for ssh_userauth_publickey_auto. Otherwise there is an extra passphrase dialog. It should appear only when ssh_userauth_publickey_auto really fails with empty passphrase.