### PR TITLE
Fix 'consistant' -> 'consistent' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Initially developed by [Vic Lee](https://github.com/llyzs)
 **Remmina** is a remote desktop client written in GTK+, aiming to be useful for
 system administrators and travellers, who need to work with lots of remote
 computers in front of either large monitors or tiny netbooks. Remmina supports
-multiple network protocols in an integrated and consistant user interface.
+multiple network protocols in an integrated and consistent user interface.
 Currently RDP, VNC, SPICE, NX, XDMCP and SSH are supported.
 
 Remmina is released in separated source packages:

--- a/remmina/src/remmina.1
+++ b/remmina/src/remmina.1
@@ -17,7 +17,7 @@
 Remmina is a remote desktop client written in GTK+, aiming to be useful for system
 administrators and travellers, who need to work with lots of remote computers
 in front of either large monitors or tiny netbooks. Remmina supports multiple
-network protocols in an integrated and consistant user interface.
+network protocols in an integrated and consistent user interface.
 Currently RDP, VNC, SPICE, NX, XDMCP and SSH are supported.
 
 Remmina is released in separated source packages:

--- a/snap/snapcraft.yaml.in
+++ b/snap/snapcraft.yaml.in
@@ -6,7 +6,7 @@ description: |
   Remmina is a remote desktop client written in GTK+, aiming to be useful for
   system administrators and travellers, who need to work with lots of remote
   computers in front of either large monitors or tiny netbooks. Remmina supports
-  multiple network protocols in an integrated and consistant user interface.
+  multiple network protocols in an integrated and consistent user interface.
   Currently RDP, VNC, SPICE, NX, XDMCP and SSH are supported.
 
   Remmina is free and open-source software, released under GNU GPL license.


### PR DESCRIPTION
Three files in the codebase present this typo.
This PR fixes it.