### PR TITLE
Add checkbox to advanced settings to scale window when using VNC

### DIFF
--- a/remmina-plugins/vnc/vnc_plugin.c
+++ b/remmina-plugins/vnc/vnc_plugin.c
@@ -1894,6 +1894,7 @@ static const RemminaProtocolSetting remmina_plugin_vnc_advanced_settings[] =
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableencryption",	 N_("Disable encryption"),	       FALSE,				      NULL,				     NULL			      },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableserverinput",	 N_("Disable server input"),	       TRUE,				      NULL,				     NULL			      },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disablepasswordstoring", N_("Disable password storing"),       FALSE,				      NULL,				     NULL			      },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "scale",	 N_("Scale"),	       TRUE,				      NULL,				     NULL			      },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_END,   NULL,			 NULL,				       FALSE,				      NULL,				     NULL			      }
 };
 


### PR DESCRIPTION
Partially fixes #937 (or fully fixes it, I'm not sure I actually see a use case for having adjustable "zoom" sliders, since I think you would always just want it to fit your window).