### PR TITLE
Updated freerdp on flatpak definition file

### DIFF
--- a/flatpak/org.remmina.Remmina.json
+++ b/flatpak/org.remmina.Remmina.json
@@ -222,7 +222,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "2.0.0-rc0"
+                    "tag": "2.0.0-rc1"
                 }
             ],
             "modules": [


### PR DESCRIPTION
Remmina uses some error definitions introduced on rev 2.0.0-rc1 of freerdp.
See commit: https://github.com/FreeRDP/FreeRDP/commit/7a73a0eb1b85d2e58402c45481058de013f68c43