### PR TITLE
flatpak: update manifest file

### DIFF
--- a/flatpak/org.remmina.Remmina.json
+++ b/flatpak/org.remmina.Remmina.json
@@ -195,8 +195,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://code.x2go.org/releases/source/nx-libs/nx-libs-3.5.0.32-lite.tar.gz",
-                    "sha256": "b5ab9f0ae35cdf6c3e26484d2a2ca55cd0225b6d8693f5544a096b19585bc50a"
+                    "url": "https://code.x2go.org/releases/source/nx-libs/nx-libs-3.5.0.33-lite.tar.gz",
+                    "sha256": "e43824f820f8d307207aa4686c68f9b0808909a6b6cd2c7d75b751b14dd3129f"
                 }
             ]
         },

--- a/flatpak/org.remmina.Remmina.json
+++ b/flatpak/org.remmina.Remmina.json
@@ -317,8 +317,8 @@
                     "cleanup": [
                         "/bin",
                         "/sbin",
-                        "/lib/systemd/",
-                        "/lib/udev/"
+                        "/lib/systemd",
+                        "/lib/udev"
                     ],
                     "config-opts": [
                         "--disable-gtk-doc"

--- a/flatpak/org.remmina.Remmina.json
+++ b/flatpak/org.remmina.Remmina.json
@@ -304,8 +304,8 @@
                     "sources": [
                         {
                             "type": "archive",
-                            "url": "https://github.com/lz4/lz4/archive/v1.8.0/lz4-1.8.0.tar.gz",
-                            "sha256": "2ca482ea7a9bb103603108b5a7510b7592b90158c151ff50a28f1ca8389fccf6"
+                            "url": "https://github.com/lz4/lz4/archive/v1.8.1.2/lz4-1.8.1.2.tar.gz",
+                            "sha256": "12f3a9e776a923275b2dc78ae138b4967ad6280863b77ff733028ce89b8123f9"
                         }
                     ]
                 },

--- a/flatpak/org.remmina.Remmina.json
+++ b/flatpak/org.remmina.Remmina.json
@@ -222,7 +222,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/FreeRDP/FreeRDP.git",
-                    "tag": "2.0.0-rc1"
+                    "tag": "2.0.0-rc1",
+                    "commit": "84f8161897534d9263ffebe43092827d40fc7ffb"
                 }
             ],
             "modules": [

--- a/remmina/desktop/appdata.xml
+++ b/remmina/desktop/appdata.xml
@@ -80,4 +80,5 @@
      <mimetype>application/x-remmina</mimetype>
   </mimetypes>
   <translation type="gettext">remmina</translation>
+  <update_contact>antenore@simbiosi.org</update_contact>
 </component>

--- a/remmina/desktop/appdata.xml
+++ b/remmina/desktop/appdata.xml
@@ -9,6 +9,8 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>Remmina</name>
+  <name xml:lang="it">Remmina</name>
+  <name xml:lang="fr">Remmina</name>
   <summary>Remote Desktop Client</summary>
   <summary xml:lang="it">Client di connessione a desktop remoti</summary>
   <summary xml:lang="fr">Client de contrôle de bureau à distance</summary>

--- a/remmina/desktop/appdata.xml
+++ b/remmina/desktop/appdata.xml
@@ -79,4 +79,5 @@
   <mimetypes>
      <mimetype>application/x-remmina</mimetype>
   </mimetypes>
+  <translation type="gettext">remmina</translation>
 </component>

--- a/remmina/desktop/appdata.xml
+++ b/remmina/desktop/appdata.xml
@@ -82,5 +82,5 @@
      <mimetype>application/x-remmina</mimetype>
   </mimetypes>
   <translation type="gettext">remmina</translation>
-  <update_contact>antenore@simbiosi.org</update_contact>
+  <update_contact>admin@remmina.org</update_contact>
 </component>

--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -124,4 +124,3 @@ Exec=@REMMINA_BINARY_PATH@ --icon
 [Desktop Action Quit]
 Name=Quit
 Exec=@REMMINA_BINARY_PATH@ --quit
-OnlyShowIn=Unity;


### PR DESCRIPTION
Update libraries to newer version.

Some improvements to adhere more to flathub guidelines.

(No specific modification for libsoup and json-glib as they are already present in gnome sdk)