### PR TITLE
Add xdmcp protocol to Keywords

### DIFF
--- a/remmina/desktop/remmina.desktop.in
+++ b/remmina/desktop/remmina.desktop.in
@@ -72,7 +72,7 @@ Terminal=false
 Type=Application
 Categories=GTK;GNOME;X-GNOME-NetworkSettings;Network;
 Actions=Profile;Tray;Quit;
-Keywords=remote desktop;rdp;vnc;nx;ssh;spice;
+Keywords=remote desktop;rdp;vnc;nx;ssh;spice;xdmcp;
 StartupWMClass=remmina
 
 [Desktop Action Profile]


### PR DESCRIPTION
Even the xdmcp protocol is supported and this would avoid patching at distro-level (as Ubuntu is doing already).