### PR TITLE
Removed compression option as not compatible with all SSH servers

### DIFF
--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -537,6 +537,12 @@ remmina_ssh_init_session(RemminaSSH *ssh)
 	}else {
 		remmina_log_printf("[SSH] SSH_OPTIONS_STRICTHOSTKEYCHECK does not have a valid value: %d\n", ssh->stricthostkeycheck);
 	}
+	rc = ssh_options_set(ssh->session, SSH_OPTIONS_COMPRESSION, ssh->compression);
+	if (rc == 0) {
+		remmina_log_printf("[SSH] SSH_OPTIONS_COMPRESSION has been set to: %s\n", ssh->compression);
+	}else {
+		remmina_log_printf("[SSH] SSH_OPTIONS_COMPRESSION does not have a valid value: %s\n", ssh->compression);
+	}
 
 	ssh_callbacks_init(ssh->callback);
 	if (remmina_log_running()) {
@@ -647,6 +653,8 @@ remmina_ssh_init_from_file(RemminaSSH *ssh, RemminaFile *remminafile)
 	ssh->hostkeytypes = g_strdup(remmina_file_get_string(remminafile, "ssh_hostkeytypes"));
 	ssh->proxycommand = g_strdup(remmina_file_get_string(remminafile, "ssh_proxycommand"));
 	ssh->stricthostkeycheck = remmina_file_get_int(remminafile, "ssh_stricthostkeycheck", 0);
+	gint c = remmina_file_get_int(remminafile, "ssh_compression", 0);
+	ssh->compression = (c == 1) ? "yes" : "no";
 
 	/* Public/Private keys */
 	s = (ssh_privatekey ? g_strdup(ssh_privatekey) : remmina_ssh_find_identity());
@@ -680,7 +688,7 @@ remmina_ssh_init_from_ssh(RemminaSSH *ssh, const RemminaSSH *ssh_src)
 	ssh->kex_algorithms = g_strdup(ssh_src->kex_algorithms);
 	ssh->ciphers = g_strdup(ssh_src->ciphers);
 	ssh->hostkeytypes = g_strdup(ssh_src->hostkeytypes);
-	ssh->stricthostkeycheck = ssh_src->stricthostkeycheck;
+	ssh->compression = ssh_src->compression;
 
 	return TRUE;
 }

--- a/remmina/src/remmina_ssh.c
+++ b/remmina/src/remmina_ssh.c
@@ -490,7 +490,8 @@ remmina_ssh_init_session(RemminaSSH *ssh)
 	ssh->session = ssh_new();
 	ssh_options_set(ssh->session, SSH_OPTIONS_HOST, ssh->server);
 	ssh_options_set(ssh->session, SSH_OPTIONS_PORT, &ssh->port);
-	ssh_options_set(ssh->session, SSH_OPTIONS_COMPRESSION, "yes");
+	/** @todo add an option to set the compression nad set it to no as the default option */
+	//ssh_options_set(ssh->session, SSH_OPTIONS_COMPRESSION, "yes");
 	/* When SSH_OPTIONS_USER is not set, the local user account is used */
 	if (*ssh->user != 0)
 		ssh_options_set(ssh->session, SSH_OPTIONS_USER, ssh->user);

--- a/remmina/src/remmina_ssh.h
+++ b/remmina/src/remmina_ssh.h
@@ -74,6 +74,7 @@ typedef struct _RemminaSSH {
         gchar *hostkeytypes;
         gchar *proxycommand;
         gint stricthostkeycheck;
+        const gchar *compression;
 
 	gchar *error;
 

--- a/remmina/src/remmina_ssh_plugin.c
+++ b/remmina/src/remmina_ssh_plugin.c
@@ -1004,6 +1004,7 @@ static const RemminaProtocolSetting remmina_ssh_advanced_settings[] =
 	{ REMMINA_PROTOCOL_SETTING_TYPE_FOLDER, "sshlogfolder",		  N_("SSH session log folder"),		    FALSE, NULL,		 NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	"sshlogname",		  N_("SSH session log file name"),	    FALSE, NULL,		 NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK,	"sshlogenabled",	  N_("Enable SSH session logging at exit"), FALSE, NULL,		 NULL },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK,	"ssh_compression",        N_("Enable SSH compression"),		    FALSE, NULL,		 NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK,	"disablepasswordstoring", N_("Disable password storing"),	    TRUE,  NULL,		 NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK,	"ssh_stricthostkeycheck", N_("Strict host key checking"),	    TRUE,  NULL,		 NULL },
 	{ REMMINA_PROTOCOL_SETTING_TYPE_END,	NULL,			  NULL,					    FALSE, NULL,		 NULL }


### PR DESCRIPTION
Some SSH servers do not supports compression that is enabled by default.

This PR set it to default value that is "no".

I'll implement later an option to enable it if required