### PR TITLE
telepathy: add dbus-glib-1 to link flags

### DIFF
--- a/plugins/telepathy/CMakeLists.txt
+++ b/plugins/telepathy/CMakeLists.txt
@@ -43,10 +43,11 @@ set_target_properties(remmina-plugin-telepathy PROPERTIES PREFIX "")
 set_target_properties(remmina-plugin-telepathy PROPERTIES NO_SONAME 1)
 
 find_required_package(GTK3)
+pkg_check_modules(PC_DBUS_GLIB dbus-glib-1)
 
 include_directories(${REMMINA_COMMON_INCLUDE_DIRS} ${TELEPATHY_INCLUDE_DIRS})
 target_link_libraries(remmina-plugin-telepathy ${REMMINA_COMMON_LIBRARIES}
-    ${TELEPATHY_LIBRARIES})
+    ${TELEPATHY_LIBRARIES} ${PC_DBUS_GLIB_LIBRARIES})
 
 install(TARGETS remmina-plugin-telepathy DESTINATION ${REMMINA_PLUGINDIR})
 


### PR DESCRIPTION
Fix compilation with -Wl,z,defs / -Wl,--no-undefined in CFLAGS.

Resolves #1432.