### PR TITLE
Switch back to x11 GTK backend under Wayland

### DIFF
--- a/remmina/src/remmina.c
+++ b/remmina/src/remmina.c
@@ -253,7 +253,7 @@ int main(int argc, char* argv[])
 	const gchar *app_id;
 	int status;
 
-	gdk_set_allowed_backends("wayland,x11,broadway,quartz,mir");
+	gdk_set_allowed_backends("x11,wayland,broadway,quartz,mir");
 
 	remmina_masterthread_exec_save_main_thread_id();
 


### PR DESCRIPTION
It seems that GTK Clipboard handling under wayland backend is quite broken:
1) owner-change signal is emitted when the window take focus or is moved,
not when clipboard owner changes
2) The signal owner-change event data GdkEventOwnerChange has the "owner"
field set to NULL, even when the new owner is local to the application
3) the clipboard owner of a GtkClipboard object is only set
when we call gtk_clipboard_set_with_owner(), and is not set
when another process takes clipboard ownership.
4) Calling gtk_clipboard_set_with_owner() emits owner-change signal
two times.

All those problems disappear under XWayland.
Currently testing on Ubuntu 17.10 GTK 3.33.25.

Since there are no know workaround in GTK for Remmina to know:
1) When an external process has taken clipboard ownership
2) Know if the current clipboard owner is Remmia or not

we switch back to XWayland.