### PR TITLE
build: make appindicator include consistent with pkg-config flags

### DIFF
--- a/cmake/FindAPPINDICATOR.cmake
+++ b/cmake/FindAPPINDICATOR.cmake
@@ -41,9 +41,9 @@ else()
 	# Try with normal libappindicator
 	pkg_check_modules(PC_APPINDICATOR appindicator3-0.1)
 
-	find_path(APPINDICATOR_INCLUDE_DIR NAMES app-indicator.h
+	find_path(APPINDICATOR_INCLUDE_DIR NAMES libappindicator/app-indicator.h
 		HINTS ${PC_APPINDICATOR_INCLUDEDIR} ${PC_APPINDICATOR_INCLUDE_DIRS}
-		PATH_SUFFIXES libappindicator3-0.1/libappindicator)
+		PATH_SUFFIXES libappindicator3-0.1)
 
 	find_library(APPINDICATOR_LIBRARY NAMES appindicator3)
 

--- a/remmina/src/remmina_icon.c
+++ b/remmina/src/remmina_icon.c
@@ -49,7 +49,7 @@
 #include "remmina_sysinfo.h"
 
 #ifdef HAVE_LIBAPPINDICATOR
-#include <app-indicator.h>
+#include <libappindicator/app-indicator.h>
 #endif
 
 typedef struct _RemminaIcon {


### PR DESCRIPTION
Trailing libappindicator/ directory is not included in include path
returned by pkg-config (/usr/include/libappindicator3-0.1).