### PR TITLE
Fix travis flatpak build

### DIFF
--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -1,5 +1,6 @@
 FROM fedora:latest
 RUN dnf install -yq flatpak flatpak-builder git xz
+RUN mkdir -m1777 -p /tmp
 RUN adduser -U -m user
 USER user
 WORKDIR /home/user

--- a/flatpak/flatpak.sh
+++ b/flatpak/flatpak.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-flatpak-builder --arch=$FLATPAK_ARCH --user --install-deps-from=flathub --sandbox --repo=repo build *.json
+flatpak-builder --arch=$FLATPAK_ARCH --user --disable-rofiles-fuse --install-deps-from=flathub --sandbox --repo=repo build *.json


### PR DESCRIPTION
Current build issue seems to be triggered by a non-existent `/tmp` directory when the container is run.

For now, as a workaround, mount `/tmp` as a `tmpfs`.

The root reason for the missing `/tmp` should be investigated later.