### PR TITLE
travis: build flatpak using branch from PR instead of next

### DIFF
--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -1,9 +1,9 @@
 FROM fedora:latest
-RUN dnf install -yq flatpak flatpak-builder git xz
+RUN dnf install -yq flatpak flatpak-builder git
 RUN mkdir -m1777 -p /tmp
-RUN adduser -U -m user
-USER user
-WORKDIR /home/user
-ADD --chown=user:user . .
-RUN flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-CMD ["/bin/bash", "-xe", "flatpak.sh"]
+RUN useradd -U -m remmina
+USER remmina
+WORKDIR /home/remmina
+COPY --chown=remmina:remmina . .
+RUN flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+CMD ["/bin/sh", "-xe", "flatpak-build.sh"]

--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -1,5 +1,5 @@
 FROM fedora:latest
-RUN dnf install -yq flatpak flatpak-builder git
+RUN dnf install -yq flatpak flatpak-builder fuse git
 RUN mkdir -m1777 -p /tmp
 RUN useradd -U -m remmina
 USER remmina

--- a/flatpak/Dockerfile
+++ b/flatpak/Dockerfile
@@ -6,4 +6,4 @@ USER remmina
 WORKDIR /home/remmina
 COPY --chown=remmina:remmina . .
 RUN flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
-CMD ["/bin/sh", "-xe", "flatpak-build.sh"]
+CMD ["/bin/sh", "-xe", "./flatpak/flatpak-build.sh"]

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -13,7 +13,7 @@ Build instructions
 
 2. Enable the Flatpak repository maintained by Flathub:
 
-        flatpak remote-add --user --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
+        flatpak --user remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
 
 3. Build Remmina:
 

--- a/flatpak/flatpak-build.sh
+++ b/flatpak/flatpak-build.sh
@@ -1,9 +1,36 @@
 #!/bin/sh -e
 
-flatpak-builder \
-    --user \
-    --arch="${FLATPAK_ARCH}" \
+flatpak_builder()
+{
+    flatpak-builder \
+        --user \
+        --arch="${FLATPAK_ARCH}" \
+        --repo=repo \
+        --sandbox \
+        "$@"
+}
+
+# Build everything but Remmina module
+flatpak_builder \
     --install-deps-from=flathub \
-    --repo=repo \
-    --sandbox \
-    app/ org.remmina.Remmina.json
+    --stop-at=remmina \
+    app/ flatpak/org.remmina.Remmina.json
+
+# Build Remmina module from local checkout
+flatpak build app/ \
+    cmake -G Ninja \
+          -DCMAKE_INSTALL_PREFIX:PATH=/app \
+          -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+          -DWITH_MANPAGES:BOOL=OFF \
+          -DWITH_TELEPATHY:BOOL=OFF \
+          .
+
+flatpak build app/ \
+    ninja -v install
+
+# Finish Flatpak app
+flatpak_builder \
+    --disable-download \
+    --disable-updates \
+    --finish-only \
+    app/ flatpak/org.remmina.Remmina.json

--- a/flatpak/flatpak-build.sh
+++ b/flatpak/flatpak-build.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+flatpak-builder \
+    --user \
+    --arch="${FLATPAK_ARCH}" \
+    --disable-rofiles-fuse \
+    --install-deps-from=flathub \
+    --repo=repo \
+    --sandbox \
+    app/ org.remmina.Remmina.json

--- a/flatpak/flatpak-build.sh
+++ b/flatpak/flatpak-build.sh
@@ -3,7 +3,6 @@
 flatpak-builder \
     --user \
     --arch="${FLATPAK_ARCH}" \
-    --disable-rofiles-fuse \
     --install-deps-from=flathub \
     --repo=repo \
     --sandbox \

--- a/flatpak/flatpak.sh
+++ b/flatpak/flatpak.sh
@@ -1,2 +1,0 @@
-#!/bin/sh
-flatpak-builder --arch=$FLATPAK_ARCH --user --disable-rofiles-fuse --install-deps-from=flathub --sandbox --repo=repo build *.json

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -85,7 +85,7 @@ elif [ "$BUILD_TYPE" == "flatpak" ]; then
     if [ "$TRAVIS_BUILD_STEP" == "before_install" ]; then
         sudo service docker start || true
     elif [ "$TRAVIS_BUILD_STEP" == "install" ]; then
-        docker build -t flatpak ./flatpak
+        docker build -t flatpak -f ./flatpak/Dockerfile .
     elif [ "$TRAVIS_BUILD_STEP" == "script" ]; then
         docker run --privileged --env=FLATPAK_ARCH=$FLATPAK_ARCH flatpak
     fi

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -34,16 +34,11 @@
 set -xe
 
 TRAVIS_BUILD_STEP="$1"
-DOCKER_BUILDER_NAME='builder'
 
 if [ -z "$TRAVIS_BUILD_STEP" ]; then
     echo "No travis build step defined"
     exit 0
 fi
-
-function docker_exec() {
-    docker exec -i $DOCKER_BUILDER_NAME $*
-}
 
 if [ "$BUILD_TYPE" == "deb" ]; then
     if [ "$TRAVIS_BUILD_STEP" == "before_install" ]; then
@@ -95,6 +90,6 @@ elif [ "$BUILD_TYPE" == "flatpak" ]; then
         docker run --privileged --env=FLATPAK_ARCH=$FLATPAK_ARCH flatpak
     fi
 else
-    echo 'No $BUILD_TYPE defined'
+    echo 'No $BUILD_TYPE defined' >&2
     exit 1
 fi


### PR DESCRIPTION
Currently, travis flatpak build always uses the tip of next branch. This means builds triggered by a pull request does not test the changes introduced by the PR since the code is not merged in next branch yet.

This PR aims to fix this.