### PR TITLE
Autodetect missing H264 on libfreerdp

### DIFF
--- a/plugins/rdp/CMakeLists.txt
+++ b/plugins/rdp/CMakeLists.txt
@@ -58,12 +58,6 @@ add_definitions(-DFREERDP_REQUIRED_MAJOR=${FREERDP_REQUIRED_MAJOR})
 add_definitions(-DFREERDP_REQUIRED_MINOR=${FREERDP_REQUIRED_MINOR})
 add_definitions(-DFREERDP_REQUIRED_REVISION=${FREERDP_REQUIRED_REVISION})
 
-option(WITH_GFX_H264 "Enable support for H264 modes in GFX" ON)
-if (WITH_GFX_H264)
-	add_definitions(-DWITH_GFX_H264)
-endif()
-
-
 add_library(remmina-plugin-rdp MODULE ${REMMINA_PLUGIN_RDP_SRCS})
 set_target_properties(remmina-plugin-rdp PROPERTIES PREFIX "")
 set_target_properties(remmina-plugin-rdp PROPERTIES NO_SONAME 1)

--- a/plugins/rdp/rdp_settings.c
+++ b/plugins/rdp/rdp_settings.c
@@ -34,6 +34,7 @@
  *
  */
 
+
 #include "rdp_plugin.h"
 #include "rdp_settings.h"
 #include <freerdp/locale/keyboard.h>


### PR DESCRIPTION
This patch autodetects when libfreerdp H264 support is missing (i.e. on OpenSuse or Ubuntu). This happens because these distributions cannot distribute libavcodec/libavutils/ffmpeg on the mian package archive area. When H264 support is not available from libfreerdp and a remmina user create a new profile which defaults to an GFX AVC mode, the user gets a warning asking him/her to use a different color Depth. But some user cannot understand that message, see issue #1584.
With this patch, when libfreerdp does not expose the libfreerdp cmake WITH_GFX_H264=ON build option, Remmina will automatically remove the two color depths "GFX AVC444" and "GFX AVC420" from the color depth dropdown in the profile editor, and fallback to "GFX RFX" mode when connecting if a profile is configured for one of the two removed color depths.
This patch also remove the remmina cmake option WITH_GFX_H264 which could be used to manually disable at compile time these two color depths.
Cc @weberhofer 