### PR TITLE
Support for "gatewayaccesstoken" (aka PAA) and "authentication level" RDP file properties

### DIFF
--- a/plugins/rdp/rdp_file.c
+++ b/plugins/rdp/rdp_file.c
@@ -98,11 +98,11 @@ static void remmina_rdp_file_import_field(RemminaFile* remminafile, const gchar*
 	}else if (g_strcmp0(key, "gatewayhostname") == 0) {
 		remmina_plugin_service->file_set_string(remminafile, "gateway_server", value);
 	}else if (g_strcmp0(key, "gatewayusagemethod") == 0) {
-		remmina_plugin_service->file_set_string(remminafile, "gatewayusagemethod", value);
-	}else if (g_strcmp0(key, "gatewaycredentialssource") == 0) {
-		remmina_plugin_service->file_set_string(remminafile, "gatewaycredentialssource", value);
-	}else if (g_strcmp0(key, "gatewayprofileusagemethod") == 0) {
-		remmina_plugin_service->file_set_string(remminafile, "gatewayprofileusagemethod", value);
+		remmina_plugin_service->file_set_int(remminafile, "gateway_usage", (atoi(value) == TSC_PROXY_MODE_DETECT));
+	} else if (g_strcmp0(key, "gatewayaccesstoken") == 0) {
+		remmina_plugin_service->file_set_string(remminafile, "gatewayaccesstoken", value);
+	} else if (g_strcmp0(key, "authentication level") == 0) {
+		remmina_plugin_service->file_set_int(remminafile, "authentication level", atoi(value));
 	}
 	/* tsclient fields, import only */
 	else if (g_strcmp0(key, "client hostname") == 0) {

--- a/plugins/rdp/rdp_plugin.c
+++ b/plugins/rdp/rdp_plugin.c
@@ -789,6 +789,13 @@ static gboolean remmina_rdp_main(RemminaProtocolWidget* gp)
 	if (rfi->settings->GatewayEnabled)
 		freerdp_set_gateway_usage_method(rfi->settings,
 			remmina_plugin_service->file_get_int(remminafile, "gateway_usage", FALSE) ? TSC_PROXY_MODE_DETECT : TSC_PROXY_MODE_DIRECT);
+
+	freerdp_set_param_string(rfi->settings, FreeRDP_GatewayAccessToken,
+		remmina_plugin_service->file_get_string(remminafile, "gatewayaccesstoken"));
+
+	rfi->settings->AuthenticationLevel = remmina_plugin_service->file_get_int(
+		remminafile, "authentication level", rfi->settings->AuthenticationLevel);
+
 	/* Certificate ignore */
 	rfi->settings->IgnoreCertificate = remmina_plugin_service->file_get_int(remminafile, "cert_ignore", 0);
 


### PR DESCRIPTION
With these properties supported, Remmina can be used to launch RDP files generated by F5 APM.
