### PR TITLE
Fix ayatana libappindicator cmake search

### DIFF
--- a/cmake/FindAPPINDICATOR.cmake
+++ b/cmake/FindAPPINDICATOR.cmake
@@ -24,9 +24,9 @@ include(FindPackageHandleStandardArgs)
 # Try with ayatana-libappindicator
 pkg_check_modules(PC_AYATANA_APPINDICATOR ayatana-appindicator3-0.1)
 
-find_path(AYATANA_APPINDICATOR_INCLUDE_DIR NAMES app-indicator.h
+find_path(AYATANA_APPINDICATOR_INCLUDE_DIR NAMES libayatana-appindicator/app-indicator.h
 	HINTS ${PC_AYATANA_APPINDICATOR_INCLUDEDIR} ${PC_AYATANA_APPINDICATOR_INCLUDE_DIRS}
-	PATH_SUFFIXES libayatana-appindicator3-0.1/libayatana-appindicator)
+	PATH_SUFFIXES libayatana-appindicator3-0.1)
 
 find_library(AYATANA_APPINDICATOR_LIBRARY NAMES ayatana-appindicator3)
 
@@ -35,6 +35,7 @@ if (AYATANA_APPINDICATOR_INCLUDE_DIR AND AYATANA_APPINDICATOR_LIBRARY)
 endif()
 
 if (APPINDICATOR_FOUND)
+	add_definitions(-DHAVE_AYATANA_LIBAPPINDICATOR)
 	set(APPINDICATOR_LIBRARIES ${AYATANA_APPINDICATOR_LIBRARY})
 	set(APPINDICATOR_INCLUDE_DIRS ${AYATANA_APPINDICATOR_INCLUDE_DIR})
 else()

--- a/src/remmina_icon.c
+++ b/src/remmina_icon.c
@@ -49,7 +49,11 @@
 #include "remmina_sysinfo.h"
 
 #ifdef HAVE_LIBAPPINDICATOR
-#include <libappindicator/app-indicator.h>
+	#ifdef HAVE_AYATANA_LIBAPPINDICATOR
+		#include <libayatana-appindicator/app-indicator.h>
+	#else
+		#include <libappindicator/app-indicator.h>
+	#endif
 #endif
 
 typedef struct _RemminaIcon {


### PR DESCRIPTION
@mfvescovi @larchunix @antenore 
This should reenable compilation with libayatana-appindicator after commit https://github.com/FreeRDP/Remmina/commit/a41cb9e0e90a69d18c4f9697fa271d9a0102aa93 broke it.
Tested on debian sid and Ubuntu 18.04.

