### PR TITLE
Drop libfreerdp-plugins-standard from Debian deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ To install Remmina from Debian Backports, just copy and paste the following line
 ```
 echo 'deb http://ftp.debian.org/debian stretch-backports main' | sudo tee --append /etc/apt/sources.list.d/stretch-backports.list >> /dev/null
 sudo apt update
-sudo apt install -t stretch-backports remmina remmina-plugin-rdp remmina-plugin-secret libfreerdp-plugins-standard
+sudo apt install -t stretch-backports remmina remmina-plugin-rdp remmina-plugin-secret
 ```
 
 ### Ubuntu


### PR DESCRIPTION
libfreerdp-plugins-standard is a package that comes from freerdp, not freerdp2 (which remmina 1.2.x is built on).
Thus, dropping that misprint.