### PR TITLE
Fixing segmentation fault due to setting name NULL

### DIFF
--- a/plugins/vnc/vnc_plugin.c
+++ b/plugins/vnc/vnc_plugin.c
@@ -1847,14 +1847,14 @@ static gpointer quality_list[] =
  */
 static const RemminaProtocolSetting remmina_plugin_vnc_basic_settings[] =
 {
-	{ REMMINA_PROTOCOL_SETTING_TYPE_SERVER,	  "server",	  NULL,			   FALSE,		     "_rfb._tcp",		       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "proxy",	  N_("Repeater"),	   FALSE,		     NULL,			       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "username",	  N_("User name"),	   FALSE,		     NULL,			       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, "password",	  N_("User password"),	   FALSE,		     NULL,			       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "colordepth",	  N_("Color depth"),	   FALSE,		     colordepth_list,		       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "quality",	  N_("Quality"),	   FALSE,		     quality_list,		       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_KEYMAP,	  NULL,		  NULL,			   FALSE,		     NULL,			       NULL						    },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_END,	  NULL,		  NULL,			   FALSE,		     NULL,			       NULL						    }
+	{ REMMINA_PROTOCOL_SETTING_TYPE_SERVER,	  "server",	  NULL,			   FALSE,     "_rfb._tcp",	NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "proxy",	  N_("Repeater"),	   FALSE,     NULL,		NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "username",	  N_("User name"),	   FALSE,     NULL,		NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, "password",	  N_("User password"),	   FALSE,     NULL,		NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "colordepth",	  N_("Color depth"),	   FALSE,     colordepth_list,	NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "quality",	  N_("Quality"),	   FALSE,     quality_list,	NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_KEYMAP,	  "keymap",	  NULL,			   FALSE,     NULL,		NULL},
+	{ REMMINA_PROTOCOL_SETTING_TYPE_END,	  NULL,		  NULL,			   FALSE,     NULL,		NULL}
 };
 
 /* Array of RemminaProtocolSetting for basic settings.
@@ -1868,13 +1868,13 @@ static const RemminaProtocolSetting remmina_plugin_vnc_basic_settings[] =
  */
 static const RemminaProtocolSetting remmina_plugin_vnci_basic_settings[] =
 {
-	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "listenport",	    N_("Listen on port"),      FALSE,			   NULL,			     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "username",	    N_("User name"),	       FALSE,			   NULL,			     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, "password",	    N_("User password"),       FALSE,			   NULL,			     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "colordepth",	    N_("Color depth"),	       FALSE,			   colordepth_list,		     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "quality",	    N_("Quality"),	       FALSE,			   quality_list,		     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_KEYMAP,	  NULL,		    NULL,		       FALSE,			   NULL,			     NULL						   },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_END,	  NULL,		    NULL,		       FALSE,			   NULL,			     NULL						   }
+	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "listenport",	    N_("Listen on port"),      FALSE,   NULL,		     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_TEXT,	  "username",	    N_("User name"),	       FALSE,   NULL,		     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_PASSWORD, "password",	    N_("User password"),       FALSE,   NULL,		     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "colordepth",	    N_("Color depth"),	       FALSE,   colordepth_list,     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_SELECT,	  "quality",	    N_("Quality"),	       FALSE,   quality_list,	     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_KEYMAP,	  NULL,		    NULL,		       FALSE,   NULL,		     NULL   },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_END,	  NULL,		    NULL,		       FALSE,   NULL,		     NULL   }
 };
 
 /* Array of RemminaProtocolSetting for advanced settings.
@@ -1888,13 +1888,13 @@ static const RemminaProtocolSetting remmina_plugin_vnci_basic_settings[] =
  */
 static const RemminaProtocolSetting remmina_plugin_vnc_advanced_settings[] =
 {
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "showcursor",		 N_("Show remote cursor"),	       TRUE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "viewonly",		 N_("View only"),		       FALSE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableclipboard",	 N_("Disable clipboard sync"),	       TRUE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableencryption",	 N_("Disable encryption"),	       FALSE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableserverinput",	 N_("Disable server input"),	       TRUE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disablepasswordstoring", N_("Disable password storing"),       FALSE,				      NULL,				     NULL			      },
-	{ REMMINA_PROTOCOL_SETTING_TYPE_END,   NULL,			 NULL,				       FALSE,				      NULL,				     NULL			      }
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "showcursor",		 N_("Show remote cursor"),	       TRUE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "viewonly",		 N_("View only"),		       FALSE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableclipboard",	 N_("Disable clipboard sync"),	       TRUE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableencryption",	 N_("Disable encryption"),	       FALSE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disableserverinput",	 N_("Disable server input"),	       TRUE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_CHECK, "disablepasswordstoring", N_("Disable password storing"),       FALSE,	      NULL,	     NULL        },
+	{ REMMINA_PROTOCOL_SETTING_TYPE_END,   NULL,			 NULL,				       FALSE,	      NULL,	     NULL        }
 };
 
 /* Array for available features.

--- a/src/remmina_file.c
+++ b/src/remmina_file.c
@@ -547,6 +547,7 @@ void remmina_file_unsave_password(RemminaFile *remminafile)
 			setting_iter = protocol_plugin->basic_settings;
 			if (setting_iter) {
 				while (setting_iter->type != REMMINA_PROTOCOL_SETTING_TYPE_END) {
+					g_debug("setting name: %s", setting_iter->name);
 					if (remmina_plugin_manager_is_encrypted_setting(protocol_plugin, setting_iter->name)) {
 						remmina_file_set_string(remminafile, remmina_plugin_manager_get_canonical_setting_name(setting_iter), NULL);
 					}


### PR DESCRIPTION
Since ever REMMINA_PROTOCOL_SETTING_TYPE_KEYMAP setting name was not set.

It fixes #1642 
It should have the potential to solve other issues as the keymap value was not saved correctly.