### PR TITLE
Fix typo in German translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2198,7 +2198,7 @@ msgstr "Wählen Sie dieses wenn Sie ein dunkles Thema verwenden."
 
 #: data/ui/remmina_preferences.glade:682
 msgid "Applet"
-msgstr "Aplpet"
+msgstr "Applet"
 
 #: data/ui/remmina_preferences.glade:709
 msgid "Host key"


### PR DESCRIPTION
Just a minor fix in the German translation that catched my eye. 

Btw. would you be so kind to change my entry in the AUTHORS file? Please change
`Philipp <der-eismann@users.noreply.github.com>`
to 
`Philipp Trulson <philipp@trulson.de>`
That would be great! 