### PR TITLE
Fix fullscreen on wrong display

### DIFF
--- a/src/rcw.c
+++ b/src/rcw.c
@@ -3201,9 +3201,9 @@ static gboolean rcw_go_fullscreen(GtkWidget *widget, GdkEvent *event, gpointer d
 #if GTK_CHECK_VERSION(3, 18, 0)
 	if (remmina_pref.fullscreen_on_auto) {
 		gtk_window_fullscreen_on_monitor(GTK_WINDOW(widget),
-				gdk_screen_get_default(),
-				gdk_screen_get_monitor_at_window (
-					gdk_screen_get_default(),
+				gdk_display_get_default(),
+				gdk_display_get_monitor_at_window (
+					gdk_display_get_default(),
 					gtk_widget_get_window(widget)));
 	} else {
 		remmina_log_print("Fullscreen managed by WM or by the user, as per settings");


### PR DESCRIPTION
The "3. Submit a merge request" link in CONTRIBUTING.md yields a 404 so I do my best making this PR as reasonable as possible.

## The Problem
What I try to solve is the annoying issue that switching to fullscreen ended up on the wrong monitor all the time. It didn't matter on which monitor the window was before clicking the fullscreen button.

## My Solution
With a bit of googling I found out that the gdk_screen* functions where marked as deprected. So I substituded the one affecting the fullscreen functionality with the gdk_display* functions and it worked!

Cheers