### PR TITLE
Fix null pointer dereference in remmina_main_quickconnect

### DIFF
--- a/src/remmina_main.c
+++ b/src/remmina_main.c
@@ -1050,7 +1050,7 @@ static gboolean remmina_main_quickconnect(void)
 
 	/* Save quick connect protocol if different from the previuous one */
 	qcp = gtk_combo_box_text_get_active_text(remminamain->combo_quick_connect_protocol);
-	if (strcmp(qcp, remmina_pref.last_quickconnect_protocol) != 0) {
+	if (qcp && strcmp(qcp, remmina_pref.last_quickconnect_protocol) != 0) {
 		g_free(remmina_pref.last_quickconnect_protocol);
 		remmina_pref.last_quickconnect_protocol = g_strdup(qcp);
 		remmina_pref_save();


### PR DESCRIPTION
gtk_combo_box_text_get_active_text() may returns NULL which then would
be handed as first argument to strcmp() causing a segmentation fault.

(gdb) bt
    at /usr/src/debug/net-misc/remmina-1.4.1/Remmina-v1.4.1/src/remmina_main.c:1053
    at
	/usr/src/debug/net-misc/remmina-1.4.1/Remmina-v1.4.1/src/remmina_main.c:1077

(gdb) f 1
    at /usr/src/debug/net-misc/remmina-1.4.1/Remmina-v1.4.1/src/remmina_main.c:1053
1053		if (strcmp(qcp, remmina_pref.last_quickconnect_protocol) != 0) {
(gdb) p qcp
$4 = (gchar *) 0x0

Signed-off-by: Florian Schmaus <flo@geekplace.eu>